### PR TITLE
Modify experiment config for CI test

### DIFF
--- a/test/naive/local.yml
+++ b/test/naive/local.yml
@@ -9,15 +9,15 @@ searchSpacePath: search_space.json
 #choice: true, false
 useAnnotation: false
 tuner:
-  tunerCommand: python3 naive_tuner.py
+  tunerCommand: /home/travis/virtualenv/python3.6.3/bin/python3 naive_tuner.py
   tunerCwd: .
   tunerGpuNum: 0
 assessor:
-  assessorCommand: python3 naive_assessor.py
+  assessorCommand: /home/travis/virtualenv/python3.6.3/bin/python3 naive_assessor.py
   assessorCwd: .
   assessorGpuNum: 0
 trial:
-  trialCommand: python3 naive_trial.py
+  trialCommand: /home/travis/virtualenv/python3.6.3/bin/python3 naive_trial.py
   trialCodeDir: .
   trialGpuNum: 0
 #machineList can be empty if the platform is local


### PR DESCRIPTION
- the python ran by exec in typescript is not the python in the venv of travis
- since our sdk is installed in venv
- this causes some import error