### PR TITLE
Fix bugs in Make pip-install action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ pip-install:
 	cp -rT yarn-v1.9.4 $(INSTALL_PREFIX)/yarn
 
 	### Export PATH for node and yarn
-	export PATH=${INSTALL_PREFIX}/node/bin:${INSTALL_PREFIX}/yarn/bin:$PATH
+	export PATH=$(INSTALL_PREFIX)/node/bin:$(INSTALL_PREFIX)/yarn/bin:$(PATH)
 
 	### Building NNI Manager ###
 	cd src/nni_manager && $(YARN) && $(YARN) build

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ pip-install:
 	tar xf yarn-v1.9.4.tar.gz
 	cp -rT yarn-v1.9.4 $(INSTALL_PREFIX)/yarn
 
+	### Export PATH for node and yarn
+	export PATH=${INSTALL_PREFIX}/node/bin:${INSTALL_PREFIX}/yarn/bin:$PATH
+
 	### Building NNI Manager ###
 	cd src/nni_manager && $(YARN) && $(YARN) build
 	

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ pip-install:
 	
 	mkdir -p $(BIN_PATH)
 	mkdir -p $(INSTALL_PREFIX)/nni
+	mkdir -p $(EXAMPLES_PATH)
 	
 	### Installing NNI Manager ###
 	cp -rT src/nni_manager/dist $(INSTALL_PREFIX)/nni/nni_manager

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,9 @@ pip-install:
 	tar xf yarn-v1.9.4.tar.gz
 	cp -rT yarn-v1.9.4 $(INSTALL_PREFIX)/yarn
 
-	### Export PATH for node and yarn
-	export PATH=$(INSTALL_PREFIX)/node/bin:$(INSTALL_PREFIX)/yarn/bin:$(PATH)
+	### Export PATH for node and yarn, and build NNI Manager ###
+	export PATH=$(INSTALL_PREFIX)/node/bin:$(INSTALL_PREFIX)/yarn/bin:$(PATH) && cd src/nni_manager && $(YARN) && $(YARN) build
 
-	### Building NNI Manager ###
-	cd src/nni_manager && $(YARN) && $(YARN) build
-	
 	### Building Web UI ###
 	cd src/webui && $(YARN) && $(YARN) build
 	

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ pip-install:
 	export PATH=$(INSTALL_PREFIX)/node/bin:$(INSTALL_PREFIX)/yarn/bin:$(PATH) && cd src/nni_manager && $(YARN) && $(YARN) build
 
 	### Building Web UI ###
-	cd src/webui && $(YARN) && $(YARN) build
+	export PATH=$(INSTALL_PREFIX)/node/bin:$(INSTALL_PREFIX)/yarn/bin:$(PATH) && cd src/webui && $(YARN) && $(YARN) build
 	
 	mkdir -p $(BIN_PATH)
 	mkdir -p $(INSTALL_PREFIX)/nni


### PR DESCRIPTION
Issue:
1. If use already installed an older node(<10.8), pip install will failed because yarn build will pick the older version node. 
2. pip-install action doesn't create examples folder under $HOME. 