### PR TITLE
support travis CI and installing in python virtual environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ EXAMPLES_PATH ?= ${HOME}/nni/examples
 WHOAMI := $(shell whoami)
 YARN := $(INSTALL_PREFIX)/yarn/bin/yarn
 PIP_MODE ?= --user
-ifdef TRAVIS
-undefine PIP_MODE
-endif
 ifdef VIRTUAL_ENV
 undefine PIP_MODE
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 BIN_PATH ?= ${HOME}/.local/bin
 INSTALL_PREFIX ?= ${HOME}/.local
-PIP_MODE ?= --user
 EXAMPLES_PATH ?= ${HOME}/nni/examples
 WHOAMI := $(shell whoami)
-.PHONY: build install uninstall dev-install
 YARN := $(INSTALL_PREFIX)/yarn/bin/yarn
+ifndef TRAVIS
+PIP_MODE ?= --user
+endif
+.PHONY: build install uninstall dev-install
 
 build:
 	### Building NNI Manager ###
@@ -63,7 +65,7 @@ install:
 pip-install:
     ifneq ('$(HOME)', '/root')
         ifeq (${WHOAMI}, root)
-			### Sorry, sudo make install is not supported ###
+			### Sorry, sudo pip install is not supported ###
 			exit 1
         endif
     endif

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@ INSTALL_PREFIX ?= ${HOME}/.local
 EXAMPLES_PATH ?= ${HOME}/nni/examples
 WHOAMI := $(shell whoami)
 YARN := $(INSTALL_PREFIX)/yarn/bin/yarn
-ifndef TRAVIS
 PIP_MODE ?= --user
+ifdef TRAVIS
+undefine PIP_MODE
+endif
+ifdef VIRTUAL_ENV
+undefine PIP_MODE
 endif
 .PHONY: build install uninstall dev-install
 

--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -154,6 +154,10 @@ function parseArg(names: string[]): string {
 function getMsgDispatcherCommand(tuner: any, assessor: any): string {
     let command: string = `python3 -m nni --tuner_class_name ${tuner.className}`;
 
+    if (process.env.VIRTUAL_ENV) {
+        command = path.join(process.env.VIRTUAL_ENV, 'bin/') +command;
+    }
+
     if (tuner.classArgs !== undefined) {
         command += ` --tuner_args ${JSON.stringify(JSON.stringify(tuner.classArgs))}`;
     }

--- a/test/naive/run.py
+++ b/test/naive/run.py
@@ -76,10 +76,10 @@ if __name__ == '__main__':
         run()
         # TODO: check the output of rest server
         print(GREEN + 'PASS' + CLEAR)
-    except Exception as e:
+    except Exception as error:
         print(RED + 'FAIL' + CLEAR)
-        print('%r' % e)
+        print('%r' % error)
         traceback.print_exc()
-        raise e
+        raise error
 
     subprocess.run(['nnictl', 'stop'])

--- a/test/naive/run.py
+++ b/test/naive/run.py
@@ -80,5 +80,6 @@ if __name__ == '__main__':
         print(RED + 'FAIL' + CLEAR)
         print('%r' % e)
         traceback.print_exc()
+        raise e
 
     subprocess.run(['nnictl', 'stop'])


### PR DESCRIPTION
- undefine PIP_MODE(--user) in Makefile when make in a python virtual environment
- specify the exact python from venv in common/utils
- raise exception if run.py failed so travis CI will not pass