### PR TITLE
remove Buffer warning

### DIFF
--- a/src/nni_manager/common/log.ts
+++ b/src/nni_manager/common/log.ts
@@ -40,7 +40,7 @@ class BufferSerialEmitter {
     private writable: Writable;
 
     constructor(writable: Writable) {
-        this.buffer = new Buffer(0);
+        this.buffer = Buffer.alloc(0);
         this.emitting = false;
         this.writable = writable;
     }
@@ -61,7 +61,7 @@ class BufferSerialEmitter {
                 this.emit();
             }
         });
-        this.buffer = new Buffer(0);
+        this.buffer = Buffer.alloc(0);
     }
 }
 


### PR DESCRIPTION
- Remove DeprecationWarning:
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

related to issue: #99 