### PR TITLE
refactor experiment stopping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,16 +81,10 @@ setup(
         'pyyaml',
         'requests',
         'scipy',
-        'schema'        
-    ],
-    dependency_links = [
-        'git+https://github.com/hyperopt/hyperopt.git'
+        'schema'
     ],
 
     cmdclass={
         'install': CustomInstallCommand
-    },
-    entry_points={
-        'console_scripts': ['nnictl = nnicmd.nnictl:parse_args']
     }
 )

--- a/src/nni_manager/core/nnimanager.ts
+++ b/src/nni_manager/core/nnimanager.ts
@@ -340,15 +340,16 @@ class NNIManager implements Manager {
     }
 
     private async periodicallyUpdateExecDuration(): Promise<void> {
-        const startTime: number = Date.now();
         const execDuration: number = this.experimentProfile.execDuration;
+        let execDurationThisRun: number = 0;
         if (!this.trialJobsMaintainer) {
             throw new Error('Error: trialJobsMaintainer has not been setup');
         }
         for (; ;) {
             await delay(1000 * 60 * 2); // 2 minutes
             if (this.trialJobsMaintainer.isTrialJobsRunning()) {
-                this.experimentProfile.execDuration = execDuration + (Date.now() - startTime) / 1000;
+                execDurationThisRun += 60 * 2;
+                this.experimentProfile.execDuration = execDuration + execDurationThisRun;
                 await this.storeExperimentProfile();
             }
         }
@@ -494,7 +495,6 @@ class NNIManager implements Manager {
                     };
                     const trialJobDetail: TrialJobDetail = await this.trainingService.submitTrialJob(trialJobAppForm);
                     this.trialJobsMaintainer.setTrialJob(trialJobDetail.id, Object.assign({}, trialJobDetail));
-                    // TO DO: to uncomment
                     assert(trialJobDetail.status === 'WAITING');
                     await this.dataStore.storeTrialJobEvent(trialJobDetail.status, trialJobDetail.id, content, trialJobDetail.url);
                     if (this.currSubmittedTrialNum === this.experimentProfile.params.maxTrialNum) {

--- a/src/nni_manager/core/trialJobs.ts
+++ b/src/nni_manager/core/trialJobs.ts
@@ -151,8 +151,10 @@ class TrialJobs {
                 }
                 await this.requestTrialJobsStatus();
             } else {
-                this.isRunning = false;
-                pastExecDurationThisRun += (Date.now() - startTime) / 1000;
+                if (this.isRunning) {
+                    pastExecDurationThisRun += (Date.now() - startTime) / 1000;
+                    this.isRunning = false;
+                }
             }
             await delay(5000);
         }

--- a/tools/nnicmd/launcher.py
+++ b/tools/nnicmd/launcher.py
@@ -48,6 +48,7 @@ def start_rest_server(port, platform, mode, experiment_id=None):
     print_normal('Starting restful server...')
     manager = os.environ.get('NNI_MANAGER', 'nnimanager')
     cmds = [manager, '--port', str(port), '--mode', platform, '--start_mode', mode]
+    print('zql: ', cmds)
     if mode == 'resume':
         cmds += ['--experiment_id', experiment_id]
     if not os.path.exists(LOG_DIR):


### PR DESCRIPTION
with this functionality, after the experiment reaches maxDuration or maxTrialNum, users still could extend maxDuration and maxTrialNum to run more trials, and submit customized trials. Restserver, tuner/assessor will not stop even reaches maxDuration or maxTrialNum. The experiment only stops when `nnictl stop` is issued. This functionality is appealing because users may want to submit/run more (customized) trials even after maxDuration or maxTrialNum is reached.