### PR TITLE
Add CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Neural Network Intelligence (NNI)
+
+Great!! We are always on the lookout for more contributors to our code base.
+
+Firstly, if you are unsure or afraid of anything, just ask or submit the issue or pull request anyways. You won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contributions and don't want a wall of rules to get in the way of that.
+
+However, for those individuals who want a bit more guidance on the best way to contribute to the project, read on. This document will cover all the points we're looking for in your contributions, raising your chances of quickly merging or addressing your contributions.
+
+There are a few simple guidelines that you need to follow before providing your hacks. 
+
+## Raising Issues
+
+When raising issues, please specify the following:
+- Setup details needs to be filled as specified in the issue template clearly for the reviewer to check.
+- A scenario where the issue occurred (with details on how to reproduce it).
+- Errors and log messages that are displayed by the software.
+- Any other details that might be useful.
+
+## Submit Proposals for New Features
+
+- There is always something more that is required, to make it easier to suit your use-cases. Feel free to join the discussion on new features or raise a PR with your proposed change. 
+
+## Contributing to Source Code and Bug Fixes
+
+Provide PRs with appropriate tags for bug fixes or enhancements to the source code. Do follow the correct naming conventions and code styles when you work on and do try to implement all code reviews along the way.
+
+## Solve Existing Issues
+Head over to [issues](https://github.com/Microsoft/nni/issues) to find issues where help is needed from contributors. You can find issues tagged with 'good-first-issue' or 'help-wanted' to contribute in. 
+
+A person looking to contribute can take up an issue by claiming it as a comment/assign their Github ID to it. In case there is no PR or update in progress for a week on the said issue, then the issue reopens for anyone to take up again. We need to consider high priority issues/regressions where response time must be a day or so. 
+
+## Code Styles & Naming Conventions  
+< Need Help Here >

--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ This project welcomes contributions and suggestions, please refer to our [contri
 
 We use [GitHub issues](https://github.com/Microsoft/nni/issues) for tracking requests and bugs.
 
+# License 
+The entire codebase is under [MIT license](https://github.com/Microsoft/nni/blob/master/LICENSE)
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To learn more about how this example was constructed and how to analyze the expe
 * [Tutorial of the command tool *nnictl*.](docs/NNICTLDOC.md)
 
 # Contributing
-This project welcomes contributions and suggestions, we are constructing the contribution guidelines, stay tuned =).
+This project welcomes contributions and suggestions, please refer to our [contributing](./docs/CONTRIBUTING.md) document for the same.
 
 We use [GitHub issues](https://github.com/Microsoft/nni/issues) for tracking requests and bugs.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Firstly, if you are unsure or afraid of anything, just ask or submit the issue o
 
 However, for those individuals who want a bit more guidance on the best way to contribute to the project, read on. This document will cover all the points we're looking for in your contributions, raising your chances of quickly merging or addressing your contributions.
 
-If you are looking for How to go about contributing and debugging the NNI source code, you can refer our [How to Contribute](./docs/HowToContribute.md) file in the `docs` folder.
+Looking for a quickstart, get acquainted with our [Get Started](./docs/GetStarted.md) guide.
 
 There are a few simple guidelines that you need to follow before providing your hacks. 
 
@@ -22,9 +22,15 @@ When raising issues, please specify the following:
 
 - There is always something more that is required, to make it easier to suit your use-cases. Feel free to join the discussion on new features or raise a PR with your proposed change. 
 
+- Fork the repository under your own github handle. After cloning the repository. Add, commit, push and sqaush (if necessary) the changes with detailed commit messages to your fork. From where you can proceed to making a pull request. 
+
 ## Contributing to Source Code and Bug Fixes
 
 Provide PRs with appropriate tags for bug fixes or enhancements to the source code. Do follow the correct naming conventions and code styles when you work on and do try to implement all code reviews along the way.
+
+If you are looking for How to go about contributing and debugging the NNI source code, you can refer our [How to Contribute](./docs/HowToContribute.md) file in the `docs` folder.
+
+Similarly for [writing trials](./docs/WriteYourTrial.md) or [starting experiments](StartExperiment.md). For everything else, refer [here](https://github.com/Microsoft/nni/tree/master/docs).
 
 ## Solve Existing Issues
 Head over to [issues](https://github.com/Microsoft/nni/issues) to find issues where help is needed from contributors. You can find issues tagged with 'good-first-issue' or 'help-wanted' to contribute in. 
@@ -32,4 +38,4 @@ Head over to [issues](https://github.com/Microsoft/nni/issues) to find issues wh
 A person looking to contribute can take up an issue by claiming it as a comment/assign their Github ID to it. In case there is no PR or update in progress for a week on the said issue, then the issue reopens for anyone to take up again. We need to consider high priority issues/regressions where response time must be a day or so. 
 
 ## Code Styles & Naming Conventions  
-< Need Help Here >
+We follow [PEP8](https://www.python.org/dev/peps/pep-0008/) for Python code and naming conventions, do try to adhere to the same when making a pull request or making a change. One can also take the help of linters such as `flake8` or `pylint`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Firstly, if you are unsure or afraid of anything, just ask or submit the issue o
 
 However, for those individuals who want a bit more guidance on the best way to contribute to the project, read on. This document will cover all the points we're looking for in your contributions, raising your chances of quickly merging or addressing your contributions.
 
+If you are looking for How to go about contributing and debugging the NNI source code, you can refer our [How to Contribute](./docs/HowToContribute.md) file in the `docs` folder.
+
 There are a few simple guidelines that you need to follow before providing your hacks. 
 
 ## Raising Issues

--- a/docs/HowToContribute.md
+++ b/docs/HowToContribute.md
@@ -51,3 +51,4 @@ After you change some code, just use **step 4** to rebuild your code, then the c
 
 ---
 At last, wish you have a wonderful day.
+For more contribution guidelines on making PR's or issues to NNI source code, you can refer to our [CONTRIBUTING](./docs/CONTRIBUTING.md) document. 


### PR DESCRIPTION
- Add a sample Contributing document for new contributors to read and refer from. 
- Linked docs folder with contributing 
- Add CONTRIBUTING and License header in README
- Please suggest any changes. 
- Solves #164 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>