### PR TITLE
Change hard-coded root directory to $PWD in PAI container

### DIFF
--- a/src/nni_manager/training_service/pai/hdfsClientUtility.ts
+++ b/src/nni_manager/training_service/pai/hdfsClientUtility.ts
@@ -133,10 +133,13 @@ export namespace HDFSClientUtility {
              deferred.resolve(exist);
         });
 
-        // Set timeout and reject the promise once reach timeout (5 seconds)
-        setTimeout(() => deferred.reject(`Check HDFS path ${hdfsPath} exists timeout`), 5000);
+        let timeoutId : NodeJS.Timer
+        const delayTimeout : Promise<boolean> = new Promise<boolean>((resolve : Function, reject : Function) : void => {
+            // Set timeout and reject the promise once reach timeout (5 seconds)        
+            setTimeout(() => deferred.reject(`Check HDFS path ${hdfsPath} exists timeout`), 5000);
+        });
 
-        return deferred.promise;
+        return Promise.race([deferred.promise, delayTimeout]).finally(() => clearTimeout(timeoutId));
     }
 
     /**


### PR DESCRIPTION
right now, we harded PAI container working folder to /root. However, that's not correct for Docker images whose working directory is not root. 

1. This PR is to change hard-coded root directory to $PWD in PAI container
2. Refactor time out logic for HDFSUtility and PAI token retrieval. 
