### PR TITLE
fix: Fix typo successed, 'successed' is not a word

### DIFF
--- a/docs/ExperimentConfig.md
+++ b/docs/ExperimentConfig.md
@@ -136,7 +136,7 @@ machineList:
 * __maxTrialNum__
   *  Description
     
-	 __maxTrialNum__ specifies the max number of trial jobs created by nni, including successed and failed jobs.  
+	 __maxTrialNum__ specifies the max number of trial jobs created by nni, including succeeded and failed jobs.  
 	 
 * __trainingServicePlatform__
   * Description

--- a/src/webui/src/components/Sessionpro.tsx
+++ b/src/webui/src/components/Sessionpro.tsx
@@ -459,7 +459,7 @@ class Sessionpro extends React.Component<{}, SessionState> {
                     <div className="selectInline">
                         <Row>
                             <Col span={18}>
-                                <h2>The trials that successed</h2>
+                                <h2>The trials that succeeded</h2>
                             </Col>
                             <Col span={6}>
                                 <span className="tabuser1">top</span>


### PR DESCRIPTION
Typo, 'successed' is not a word.