### PR TITLE
Fix wrong example gdbt

### DIFF
--- a/examples/trials/auto-gbdt/main.py
+++ b/examples/trials/auto-gbdt/main.py
@@ -87,7 +87,7 @@ def run(lgb_train, lgb_eval, params, X_test, y_test):
     y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
 
     # eval 
-    rmse = mean_squared_error(y_test, y_pred) ** 0.5
+    rmse = mean_squared_error(y_test, y_pred) ** 0.5 * - 1
     print('The rmse of prediction is:', rmse)
 
     nni.report_final_result(rmse)

--- a/tools/nni_cmd/nnictl.py
+++ b/tools/nni_cmd/nnictl.py
@@ -74,6 +74,7 @@ def parse_args():
     #parse stop command
     parser_stop = subparsers.add_parser('stop', help='stop the experiment')
     parser_stop.add_argument('id', nargs='?', help='the id of experiment')
+    parser_stop.add_argument('all', nargs='?', default='all', help='stop all experiments')
     parser_stop.set_defaults(func=stop_experiment)
 
     #parse trial command

--- a/tools/nni_cmd/nnictl.py
+++ b/tools/nni_cmd/nnictl.py
@@ -73,8 +73,7 @@ def parse_args():
 
     #parse stop command
     parser_stop = subparsers.add_parser('stop', help='stop the experiment')
-    parser_stop.add_argument('id', nargs='?', help='the id of experiment')
-    parser_stop.add_argument('all', nargs='?', default='all', help='stop all experiments')
+    parser_stop.add_argument('id', nargs='?', help='the id of experiment, use "all" for all experiments')
     parser_stop.set_defaults(func=stop_experiment)
 
     #parse trial command


### PR DESCRIPTION
I find that the auto-gdbt example is wrong and some of the UI is misleading. It will show accuracy even though it is actually rmse. It is a problem because we want to minimize rmse and thus the optmization direction is completely the opposite.

Is there a way to set optimizing with a parameter similiar to larger_is_better = True?

![image](https://user-images.githubusercontent.com/18221871/48339237-b1fc6a00-e6a2-11e8-8e18-b32162963a41.png)
