### PR TITLE
Fix wrong example gdbt, minimize rmse instead

### DIFF
--- a/examples/trials/auto-gbdt/main.py
+++ b/examples/trials/auto-gbdt/main.py
@@ -87,7 +87,7 @@ def run(lgb_train, lgb_eval, params, X_test, y_test):
     y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
 
     # eval 
-    rmse = mean_squared_error(y_test, y_pred) ** 0.5
+    rmse = mean_squared_error(y_test, y_pred) ** 0.5 * -1
     print('The rmse of prediction is:', rmse)
 
     nni.report_final_result(rmse)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18221871/48340487-b24a3480-e6a5-11e8-8955-8420f2280440.png)
I find that the auto-gdbt example is wrong and some of the UI is misleading. It will show accuracy even though it is actually rmse. It is a problem because we want to minimize rmse and thus the optmization direction is completely the opposite.

Is there an easy way to choose to minimize or maximize a metric?