### PR TITLE
add NO_MORE_TRIAL state in experiment

### DIFF
--- a/src/nni_manager/common/manager.ts
+++ b/src/nni_manager/common/manager.ts
@@ -76,7 +76,7 @@ interface TrialJobStatistics {
 }
 
 interface NNIManagerStatus {
-    status: 'INITIALIZED' | 'EXPERIMENT_RUNNING' | 'ERROR' | 'STOPPING' | 'STOPPED' | 'DONE';
+    status: 'INITIALIZED' | 'EXPERIMENT_RUNNING' | 'ERROR' | 'STOPPING' | 'STOPPED' | 'DONE' | 'NO_MORE_TRIAL';
     errors: string[];
 }
 


### PR DESCRIPTION
tuners such as batchtuner, gridsearch have finite configurations, and will send NO_MORE_TRIAL to nnimanager after tried all the configurations. In this pr, nnimanager sets the experiment state to NO_MORE_TRIAL when received command NO_MORE_TRIAL from tuner.

fix catch error in resumeExperiment().

TODO: 1. update webui accordingly; 2. check tuners correctly uses NO_MORE_TRIAL.