### PR TITLE
Fix remote TrainingService bug, change forEach to "for of"

### DIFF
--- a/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
@@ -93,7 +93,7 @@ abstract class KubernetesTrainingService {
         return Promise.resolve(jobs);
     }
 
-    public getTrialJob(trialJobId: string): Promise<TrialJobDetail> {
+    public async getTrialJob(trialJobId: string): Promise<TrialJobDetail> {
 
         const kubernetesTrialJob: TrialJobDetail | undefined = this.trialJobsMap.get(trialJobId);
 

--- a/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
@@ -81,14 +81,14 @@ abstract class KubernetesTrainingService {
         }
     }
 
-    public listTrialJobs(): Promise<TrialJobDetail[]> {
+    public async listTrialJobs(): Promise<TrialJobDetail[]> {
         const jobs: TrialJobDetail[] = [];
         
-        this.trialJobsMap.forEach(async (value: KubernetesTrialJobDetail, key: string) => {
+        for (const [key, value] of this.trialJobsMap) { 
             if (value.form.jobType === 'TRIAL') {
                 jobs.push(await this.getTrialJob(key));
             }
-        });
+        };
 
         return Promise.resolve(jobs);
     }

--- a/src/nni_manager/training_service/pai/paiTrainingService.ts
+++ b/src/nni_manager/training_service/pai/paiTrainingService.ts
@@ -113,7 +113,7 @@ class PAITrainingService implements TrainingService {
         return Promise.resolve(jobs);
     }
 
-    public getTrialJob(trialJobId: string): Promise<TrialJobDetail> {
+    public async getTrialJob(trialJobId: string): Promise<TrialJobDetail> {
         if(!this.paiClusterConfig) {
             throw new Error('PAI Cluster config is not initialized');
         }

--- a/src/nni_manager/training_service/pai/paiTrainingService.ts
+++ b/src/nni_manager/training_service/pai/paiTrainingService.ts
@@ -104,11 +104,11 @@ class PAITrainingService implements TrainingService {
     public async listTrialJobs(): Promise<TrialJobDetail[]> {
         const jobs: TrialJobDetail[] = [];
         
-        this.trialJobsMap.forEach(async (value: PAITrialJobDetail, key: string) => {
+        for (const [key, value] of this.trialJobsMap) { 
             if (value.form.jobType === 'TRIAL') {
                 jobs.push(await this.getTrialJob(key));
             }
-        });
+        };
 
         return Promise.resolve(jobs);
     }

--- a/src/nni_manager/training_service/remote_machine/remoteMachineTrainingService.ts
+++ b/src/nni_manager/training_service/remote_machine/remoteMachineTrainingService.ts
@@ -110,15 +110,15 @@ class RemoteMachineTrainingService implements TrainingService {
     /**
      * List submitted trial jobs
      */
-    public listTrialJobs(): Promise<TrialJobDetail[]> {
+    public async listTrialJobs(): Promise<TrialJobDetail[]> {
         const jobs: TrialJobDetail[] = [];
         const deferred: Deferred<TrialJobDetail[]> = new Deferred<TrialJobDetail[]>();
 
-        this.trialJobsMap.forEach(async (value: RemoteMachineTrialJobDetail, key: string) => {
+        for (const [key, value] of this.trialJobsMap) { 
             if (value.form.jobType === 'TRIAL') {
                 jobs.push(await this.getTrialJob(key));
             }
-        });
+        };
         deferred.resolve(jobs);
 
         return deferred.promise;


### PR DESCRIPTION
trial job could not be stopped in remote machine when experiment is stopped, because awit/async does not work normally in forEach, refer https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404.
fix issue: https://github.com/Microsoft/nni/issues/558