### PR TITLE
fix annotation permission deny

### DIFF
--- a/tools/nni_cmd/launcher.py
+++ b/tools/nni_cmd/launcher.py
@@ -277,7 +277,7 @@ def launch_experiment(args, experiment_config, mode, config_file_name, experimen
     nni_config.set_config('restServerPid', rest_process.pid)
     # Deal with annotation
     if experiment_config.get('useAnnotation'):
-        path = os.path.join(tempfile.gettempdir(), 'nni', 'annotation')
+        path = os.path.join(tempfile.gettempdir(), os.environ['USER'], 'nni', 'annotation')
         if not os.path.isdir(path):
             os.makedirs(path)
         path = tempfile.mkdtemp(dir=path)


### PR DESCRIPTION
- Similar to resolving permissions issues during installation, here we create a folder for every user under.
- So it guarantees that the user has write access to the folder