### PR TITLE
Add dependent package installation for tuners before start restful server

### DIFF
--- a/tools/nni_cmd/constants.py
+++ b/tools/nni_cmd/constants.py
@@ -82,3 +82,16 @@ COLOR_RED_FORMAT = '\033[1;31;31m%s\033[0m'
 COLOR_GREEN_FORMAT = '\033[1;32;32m%s\033[0m'
 
 COLOR_YELLOW_FORMAT = '\033[1;33;33m%s\033[0m'
+
+ModuleName = {
+    'TPE': 'nni.hyperopt_tuner.hyperopt_tuner',
+    'Random': 'nni.hyperopt_tuner.hyperopt_tuner',
+    'Anneal': 'nni.hyperopt_tuner.hyperopt_tuner',
+    'Evolution': 'nni.evolution_tuner.evolution_tuner',
+    'SMAC': 'nni.smac_tuner.smac_tuner',
+    'BatchTuner': 'nni.batch_tuner.batch_tuner',
+    'Medianstop': 'nni.medianstop_assessor.medianstop_assessor',
+    'GridSearch': 'nni.gridsearch_tuner.gridsearch_tuner',
+    'NetworkMorphism': 'nni.networkmorphism_tuner.networkmorphism_tuner',
+    'Curvefitting': 'nni.curvefitting_assessor.curvefitting_assessor'
+}

--- a/tools/nni_cmd/launcher.py
+++ b/tools/nni_cmd/launcher.py
@@ -21,9 +21,10 @@
 
 import json
 import os
+import sys
 import shutil
 import string
-from subprocess import Popen, PIPE, call, check_output
+from subprocess import Popen, PIPE, call, check_output, check_call
 import tempfile
 from nni_annotation import *
 from .launcher_utils import validate_all_content
@@ -272,6 +273,17 @@ def set_experiment(experiment_config, mode, port, config_file_name):
 def launch_experiment(args, experiment_config, mode, config_file_name, experiment_id=None):
     '''follow steps to start rest server and start experiment'''
     nni_config = Config(config_file_name)
+
+    # check packages for tuner
+    if experiment_config.get('tuner'):
+        tuner_name = experiment_config['tuner']['builtinTunerName']
+        module_name = ModuleName[tuner_name]
+        try:
+            check_call([sys.executable, '-c', 'import %s'%(module_name)])
+        except:
+            print_error('The tuner %s should be installed through nnictl'%(tuner_name))
+            exit(1)
+
     # start rest server
     rest_process, start_time = start_rest_server(args.port, experiment_config['trainingServicePlatform'], mode, config_file_name, experiment_id)
     nni_config.set_config('restServerPid', rest_process.pid)


### PR DESCRIPTION
I tried SMAC tuner on mnist trial. And it seems everything works fine until I failed to open WebUI. After figuring out that SMAC has 2 packages to install, I think the launcher should deal with this and show the error rather than pretend to working fine.

So I add this check in `launcher.py` . And to keep the maintain convenient, I copied the map from tuners' name to their module in `nni` to `constatnts.py`.