### PR TITLE
fix experiment state bug

### DIFF
--- a/src/nni_manager/core/nnimanager.ts
+++ b/src/nni_manager/core/nnimanager.ts
@@ -424,7 +424,7 @@ class NNIManager implements Manager {
         if (this.dispatcher === undefined) {
             throw new Error('Error: tuner has not been setup');
         }
-        let allFinishedTrialJobNum: number = 0;
+        let allFinishedTrialJobNum: number = this.currSubmittedTrialNum;
         let waitSubmittedToFinish: number;
         while (this.status.status !== 'STOPPING' && this.status.status !== 'STOPPED') {
             const finishedTrialJobNum: number = await this.requestTrialJobsStatus();


### PR DESCRIPTION
Fix the bug that when a finished experiment (state is DONE) is resumed, its state is always NO_MORE_TRIAL.