### PR TITLE
Fix MetisTuner runtime bug.

### DIFF
--- a/src/sdk/pynni/nni/metis_tuner/metis_tuner.py
+++ b/src/sdk/pynni/nni/metis_tuner/metis_tuner.py
@@ -245,7 +245,7 @@ class MetisTuner(Tuner):
 
             # calculate y aggregation
             median = get_median(temp_y)
-            self.samples_y_aggregation[idx] = median
+            self.samples_y_aggregation[idx] = [median]
         else:
             self.samples_x.append(sample_x)
             self.samples_y.append([value])


### PR DESCRIPTION
MetisTuner will break down because the data type in `self.samples_y_aggregation` list is not always the same.