### PR TITLE
Fix smac convert bug

### DIFF
--- a/docs/en_US/Builtin_Tuner.md
+++ b/docs/en_US/Builtin_Tuner.md
@@ -73,8 +73,6 @@ Random search is suggested when each trial does not take too long (e.g., each tr
 # config.yml
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 ```
 
 <br>
@@ -114,10 +112,6 @@ tuner:
 **Suggested scenario**
 
 Its requirement of computation resource is relatively high. Specifically, it requires large initial population to avoid falling into local optimum. If your trial is short or leverages assessor, this tuner is a good choice. And, it is more suggested when your trial code supports weight transfer, that is, the trial could inherit the converged weights from its parent(s). This can greatly speed up the training progress.
-
-**Requirement of classArg**
-
-* **optimize_mode** (*maximize or minimize, optional, default = maximize*) - If 'maximize', tuners will return the hyperparameter set with larger expectation. If 'minimize', tuner will return the hyperparameter set with smaller expectation.
 
 **Usage example**
 

--- a/docs/en_US/PAIMode.md
+++ b/docs/en_US/PAIMode.md
@@ -55,7 +55,7 @@ Compared with LocalMode and [RemoteMachineMode](RemoteMachineMode.md), trial con
     * Optional key. It specifies the HDFS data direcotry for trial to download data. The format should be something like hdfs://{your HDFS host}:9000/{your data directory}
 * outputDir 
     * Optional key. It specifies the HDFS output directory for trial. Once the trial is completed (either succeed or fail), trial's stdout, stderr will be copied to this directory by NNI sdk automatically. The format should be something like hdfs://{your HDFS host}:9000/{your output directory}
-* virturlCluster
+* virtualCluster
     * Optional key. Set the virtualCluster of OpenPAI. If omitted, the job will run on default virtual cluster.
 * shmMB
     * Optional key. Set the shmMB configuration of OpenPAI, it set the shared memory for one task in the task role.

--- a/docs/en_US/SQuAD_evolution_examples.md
+++ b/docs/en_US/SQuAD_evolution_examples.md
@@ -2,8 +2,7 @@
 This example shows us how to use Genetic Algorithm to find good model architectures for Reading Comprehension.
 
 ## 1. Search Space
-Since attention and recurrent neural network (RNN) have been proven effective in Reading Comprehension.
-We conclude the search space as follow:
+Since attention and RNN have been proven effective in Reading Comprehension, we conclude the search space as follow:
 
 1. IDENTITY (Effectively means keep training).
 2. INSERT-RNN-LAYER (Inserts a LSTM. Comparing the performance of GRU and LSTM in our experiment, we decided to use LSTM here.)

--- a/src/sdk/pynni/nni/hyperopt_tuner/hyperopt_tuner.py
+++ b/src/sdk/pynni/nni/hyperopt_tuner/hyperopt_tuner.py
@@ -158,7 +158,7 @@ class HyperoptTuner(Tuner):
     HyperoptTuner is a tuner which using hyperopt algorithm.
     """
 
-    def __init__(self, algorithm_name, optimize_mode):
+    def __init__(self, algorithm_name, optimize_mode = 'minimize'):
         """
         Parameters
         ----------

--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -194,15 +194,18 @@ class SMACTuner(Tuner):
         dict
             challenger dict
         """
+        converted_dict = {}
         for key, value in challenger_dict.items():
             # convert to loguniform
             if key in self.loguniform_key:
-                challenger_dict[key] = np.exp(challenger_dict[key])
+                converted_dict[key] = np.exp(challenger_dict[key])
             # convert categorical back to original value
-            if key in self.categorical_dict:
+            elif key in self.categorical_dict:
                 idx = challenger_dict[key]
-                challenger_dict[key] = self.categorical_dict[key][idx]
-        return challenger_dict
+                converted_dict[key] = self.categorical_dict[key][idx]
+            else:
+                converted_dict[key] = value
+        return converted_dict
 
     def generate_parameters(self, parameter_id):
         """generate one instance of hyperparameters
@@ -220,13 +223,11 @@ class SMACTuner(Tuner):
         if self.first_one:
             init_challenger = self.smbo_solver.nni_smac_start()
             self.total_data[parameter_id] = init_challenger
-            json_tricks.dumps(init_challenger.get_dictionary())
             return self.convert_loguniform_categorical(init_challenger.get_dictionary())
         else:
             challengers = self.smbo_solver.nni_smac_request_challengers()
             for challenger in challengers:
                 self.total_data[parameter_id] = challenger
-                json_tricks.dumps(challenger.get_dictionary())
                 return self.convert_loguniform_categorical(challenger.get_dictionary())
 
     def generate_multiple_parameters(self, parameter_id_list):
@@ -247,7 +248,6 @@ class SMACTuner(Tuner):
             for one_id in parameter_id_list:
                 init_challenger = self.smbo_solver.nni_smac_start()
                 self.total_data[one_id] = init_challenger
-                json_tricks.dumps(init_challenger.get_dictionary())
                 params.append(self.convert_loguniform_categorical(init_challenger.get_dictionary()))
         else:
             challengers = self.smbo_solver.nni_smac_request_challengers()
@@ -257,7 +257,6 @@ class SMACTuner(Tuner):
                 if cnt >= len(parameter_id_list):
                     break
                 self.total_data[parameter_id_list[cnt]] = challenger
-                json_tricks.dumps(challenger.get_dictionary())
                 params.append(self.convert_loguniform_categorical(challenger.get_dictionary()))
                 cnt += 1
         return params

--- a/test/config_test/examples/cifar10-pytorch.test.yml
+++ b/test/config_test/examples/cifar10-pytorch.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ./cifar10_search_space.json
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/examples/mnist-annotation.test.yml
+++ b/test/config_test/examples/mnist-annotation.test.yml
@@ -6,8 +6,6 @@ trialConcurrency: 2
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/examples/mnist-keras.test.yml
+++ b/test/config_test/examples/mnist-keras.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ../../../examples/trials/mnist-keras/search_space.json
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/examples/mnist.test.yml
+++ b/test/config_test/examples/mnist.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ./mnist_search_space.json
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/examples/sklearn-classification.test.yml
+++ b/test/config_test/examples/sklearn-classification.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ../../../examples/trials/sklearn/classification/search_space.js
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/examples/sklearn-regression.test.yml
+++ b/test/config_test/examples/sklearn-regression.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ../../../examples/trials/sklearn/regression/search_space.json
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/config_test/tuners/mnist-annotation-random.test.yml
+++ b/test/config_test/tuners/mnist-annotation-random.test.yml
@@ -6,8 +6,6 @@ trialConcurrency: 1
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 assessor:
   builtinAssessorName: Medianstop
   classArgs:

--- a/test/metrics_test/metrics.test.yml
+++ b/test/metrics_test/metrics.test.yml
@@ -7,8 +7,6 @@ searchSpacePath: ./search_space.json
 
 tuner:
   builtinTunerName: Random
-  classArgs:
-    optimize_mode: maximize
 
 trial:
   codeDir: .

--- a/test/tuner_test.py
+++ b/test/tuner_test.py
@@ -38,7 +38,7 @@ def switch(dispatch_type, dispatch_name):
     '''Change dispatch in config.yml'''
     config_path = 'tuner_test/local.yml'
     experiment_config = get_yml_content(config_path)
-    if dispatch_name in ['GridSearch', 'BatchTuner']:
+    if dispatch_name in ['GridSearch', 'BatchTuner', 'Random']:
         experiment_config[dispatch_type.lower()] = {
             'builtin' + dispatch_type + 'Name': dispatch_name
         }

--- a/test/tuner_test/naive_trial.py
+++ b/test/tuner_test/naive_trial.py
@@ -1,6 +1,6 @@
 import nni
 
-params = nni.get_parameters()
+params = nni.get_next_parameter()
 print('params:', params)
 x = params['x']
 

--- a/tools/nni_cmd/config_schema.py
+++ b/tools/nni_cmd/config_schema.py
@@ -54,14 +54,14 @@ Optional('advisor'): Or({
     Optional('gpuNum'): And(int, lambda x: 0 <= x <= 99999),
 }),
 Optional('tuner'): Or({
-    'builtinTunerName': Or('TPE', 'Random', 'Anneal', 'SMAC', 'Evolution'),
+    'builtinTunerName': Or('TPE', 'Anneal', 'SMAC', 'Evolution'),
     Optional('classArgs'): {
         'optimize_mode': Or('maximize', 'minimize')
     },
     Optional('includeIntermediateResults'): bool,
     Optional('gpuNum'): And(int, lambda x: 0 <= x <= 99999),
 },{
-    'builtinTunerName': Or('BatchTuner', 'GridSearch'),
+    'builtinTunerName': Or('BatchTuner', 'GridSearch', 'Random'),
     Optional('gpuNum'): And(int, lambda x: 0 <= x <= 99999),
 },{
     'builtinTunerName': 'NetworkMorphism',


### PR DESCRIPTION
fix the bug below: 
Traceback (most recent call last):
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/__main__.py", line 189, in main
    dispatcher.run()
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher_base.py", line 63, in run
    self.handle_request((command, data))
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher_base.py", line 105, in handle_request
    return command_handlers[command](data)
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher.py", line 101, in handle_request_trial_jobs
    params_list = self.tuner.generate_multiple_parameters(ids)
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/smac_tuner/smac_tuner.py", line 262, in generate_multiple_parameters
    params.append(self.convert_loguniform_categorical(challenger.get_dictionary()))
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/smac_tuner/smac_tuner.py", line 205, in convert_loguniform_categorical
    challenger_dict[key] = self.categorical_dict[key][idx]
IndexError: list index out of range
