### PR TITLE
fix bug in smac search space convert

### DIFF
--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -192,7 +192,7 @@ class SMACTuner(Tuner):
         Returns
         -------
         dict
-            challenger dict
+            dict which stores copy of challengers
         """
         converted_dict = {}
         for key, value in challenger_dict.items():

--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -194,15 +194,18 @@ class SMACTuner(Tuner):
         dict
             challenger dict
         """
+        converted_dict = {}
         for key, value in challenger_dict.items():
             # convert to loguniform
             if key in self.loguniform_key:
-                challenger_dict[key] = np.exp(challenger_dict[key])
+                converted_dict[key] = np.exp(challenger_dict[key])
             # convert categorical back to original value
-            if key in self.categorical_dict:
+            elif key in self.categorical_dict:
                 idx = challenger_dict[key]
-                challenger_dict[key] = self.categorical_dict[key][idx]
-        return challenger_dict
+                converted_dict[key] = self.categorical_dict[key][idx]
+            else:
+                converted_dict[key] = value
+        return converted_dict
 
     def generate_parameters(self, parameter_id):
         """generate one instance of hyperparameters
@@ -220,13 +223,11 @@ class SMACTuner(Tuner):
         if self.first_one:
             init_challenger = self.smbo_solver.nni_smac_start()
             self.total_data[parameter_id] = init_challenger
-            json_tricks.dumps(init_challenger.get_dictionary())
             return self.convert_loguniform_categorical(init_challenger.get_dictionary())
         else:
             challengers = self.smbo_solver.nni_smac_request_challengers()
             for challenger in challengers:
                 self.total_data[parameter_id] = challenger
-                json_tricks.dumps(challenger.get_dictionary())
                 return self.convert_loguniform_categorical(challenger.get_dictionary())
 
     def generate_multiple_parameters(self, parameter_id_list):
@@ -247,7 +248,6 @@ class SMACTuner(Tuner):
             for one_id in parameter_id_list:
                 init_challenger = self.smbo_solver.nni_smac_start()
                 self.total_data[one_id] = init_challenger
-                json_tricks.dumps(init_challenger.get_dictionary())
                 params.append(self.convert_loguniform_categorical(init_challenger.get_dictionary()))
         else:
             challengers = self.smbo_solver.nni_smac_request_challengers()
@@ -257,7 +257,6 @@ class SMACTuner(Tuner):
                 if cnt >= len(parameter_id_list):
                     break
                 self.total_data[parameter_id_list[cnt]] = challenger
-                json_tricks.dumps(challenger.get_dictionary())
                 params.append(self.convert_loguniform_categorical(challenger.get_dictionary()))
                 cnt += 1
         return params


### PR DESCRIPTION
**fix the bug:** 
Traceback (most recent call last):
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/__main__.py", line 189, in main
    dispatcher.run()
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher_base.py", line 63, in run
    self.handle_request((command, data))
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher_base.py", line 105, in handle_request
    return command_handlers[command](data)
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/msg_dispatcher.py", line 101, in handle_request_trial_jobs
    params_list = self.tuner.generate_multiple_parameters(ids)
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/smac_tuner/smac_tuner.py", line 262, in generate_multiple_parameters
    params.append(self.convert_loguniform_categorical(challenger.get_dictionary()))
  File "/data/anaconda/envs/reco_base/lib/python3.6/site-packages/nni/smac_tuner/smac_tuner.py", line 205, in convert_loguniform_categorical
    challenger_dict[key] = self.categorical_dict[key][idx]
IndexError: list index out of range
[2019-03-27 13:55:14] PRINT ERROR:	list index out of range