### PR TITLE
Fix bugs of dev-install caused by composition of the two packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,7 @@ dev-install:
 
 .PHONY: uninstall
 uninstall:
-	-$(PIP_UNINSTALL) -y nni
-	-$(PIP_UNINSTALL) -y nnictl
+	-cd build && $(PIP_UNINSTALL) -y nni
 	-rm -rf $(NNI_PKG_FOLDER)
 	-rm -f $(BIN_FOLDER)/node
 	-rm -f $(BIN_FOLDER)/nnictl

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,18 @@ install-python-modules:
 .PHONY: dev-install-python-modules
 dev-install-python-modules:
 	#$(_INFO) Installing Python SDK $(_END)
-	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' setup.py && $(PIP_INSTALL) $(PIP_MODE) -e .
+	mkdir -p build
+	ln -sf ../src/sdk/pynni/nni build/nni
+	ln -sf ../tools/nni_annotation build/nni_annotation
+	ln -sf ../tools/nni_cmd build/nni_cmd
+	ln -sf ../tools/nni_trial_tool build/nni_trial_tool
+	ln -sf ../tools/nni_gpu_tool build/nni_gpu_tool
+	cp setup.py build/
+	cp README.md build/
+	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' build/setup.py
+	sed -ie 's/src\/sdk\/pynni\/nni/nni/g' build/setup.py
+	sed -ie 's/tools\///g' build/setup.py
+	cd build && $(PIP_INSTALL) $(PIP_MODE) -e .
 
 
 .PHONY: install-node-modules

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ dev-install:
 .PHONY: uninstall
 uninstall:
 	-cd build && $(PIP_UNINSTALL) -y nni
+	-rm -rf build
 	-rm -rf $(NNI_PKG_FOLDER)
 	-rm -f $(BIN_FOLDER)/node
 	-rm -f $(BIN_FOLDER)/nnictl


### PR DESCRIPTION
PR for #709, which is related to an open [https://github.com/pypa/pip/issues/3160](issue) of pypi.
That is, editable install does not work with package_directory (or namespace or sub-package)

Currently we figure out a temporary remedy.
When users want to `dev-install`, we'll firstly create **soft links** to **all python package** and put them all in a newly built directory under the root directory. Then we modify `setup.py` and throw it into that directory and run `pip install` command. 