### PR TITLE
Fix for master -- Node's API changes

### DIFF
--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -65,7 +65,7 @@ function mkDirP(dirPath: string): Promise<void> {
         } else {
             const parent: string = path.dirname(dirPath);
             mkDirP(parent).then(() => {
-                fs.mkdir(dirPath, (err: Error) => {
+                fs.mkdir(dirPath, (err: Error | null) => {
                     if (err) {
                         deferred.reject(err);
                     } else {

--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -65,7 +65,7 @@ function mkDirP(dirPath: string): Promise<void> {
         } else {
             const parent: string = path.dirname(dirPath);
             mkDirP(parent).then(() => {
-                fs.mkdir(dirPath, (err: Error | null) => {
+                fs.mkdir(dirPath, (err: Error) => {
                     if (err) {
                         deferred.reject(err);
                     } else {

--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -68,7 +68,7 @@ function mkDirP(dirPath: string): Promise<void> {
         } else {
             const parent: string = path.dirname(dirPath);
             mkDirP(parent).then(() => {
-                fs.mkdir(dirPath, (err: Error | null) => {
+                fs.mkdir(dirPath, (err: Error) => {
                     if (err) {
                         deferred.reject(err);
                     } else {

--- a/src/nni_manager/package.json
+++ b/src/nni_manager/package.json
@@ -35,7 +35,7 @@
     "@types/express": "^4.16.0",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.18",
+    "@types/node": "10.12.18",
     "@types/request": "^2.47.1",
     "@types/rx": "^4.1.1",
     "@types/sqlite3": "^3.1.3",


### PR DESCRIPTION
According to [this commit](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/92ee9c22b5740595bc0475008e8ac5952954aa76) (more specifically, this [file](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/92ee9c22b5740595bc0475008e8ac5952954aa76/types/node/v10/fs.d.ts#L728)), node's API for mkdir has changed, which causes NNI cannot be compile correctly.

This is because the prototype of fs.mkdir's callback function has changed.

We should further discuss how to fix the previous version of NNI. Maybe it will be better to fix the version of node.

