### PR TITLE
fix bug of table entries

### DIFF
--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -23,7 +23,8 @@ interface TrialDetailState {
     experimentStatus: string;
     experimentPlatform: string;
     experimentLogCollection: boolean;
-    entriesTable: number;
+    entriesTable: number; // table components val
+    entriesInSelect: string;
     searchSpace: string;
     isMultiPhase: boolean;
 }
@@ -68,6 +69,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
             experimentPlatform: '',
             experimentLogCollection: false,
             entriesTable: 20,
+            entriesInSelect: '20',
             isHasSearch: false,
             searchSpace: '',
             isMultiPhase: false
@@ -82,7 +84,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                 axios.get(`${MANAGER_IP}/metric-data`)
             ])
             .then(axios.spread((res, res1) => {
-                if (res.status === 200) {
+                if (res.status === 200 && res1.status === 200) {
                     const trialJobs = res.data;
                     const metricSource = res1.data;
                     const trialTable: Array<TableObj> = [];
@@ -149,7 +151,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                         });
                     });
                     // update search data result
-                    const { searchResultSource } = this.state;
+                    const { searchResultSource, entriesInSelect } = this.state;
                     if (searchResultSource.length !== 0) {
                         const temp: Array<number> = [];
                         Object.keys(searchResultSource).map(index => {
@@ -176,6 +178,11 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                             tableListSource: trialTable
                         }));
                     }
+                    if (entriesInSelect === 'all' && this._isMounted) {
+                        this.setState(() => ({
+                            entriesTable: trialTable.length
+                        }));
+                    }
                 }
             }));
     }
@@ -196,9 +203,10 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
             const searchResultList: Array<TableObj> = [];
             Object.keys(tableListSource).map(key => {
                 const item = tableListSource[key];
+                const upperVal = targetValue.toUpperCase();
                 if (item.sequenceId.toString() === targetValue
-                    || item.id.includes(targetValue)
-                    || item.status.includes(targetValue)
+                    || item.id.toUpperCase().includes(upperVal)
+                    || item.status.toUpperCase().includes(upperVal)
                 ) {
                     searchResultList.push(item);
                 }
@@ -244,7 +252,10 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                 break;
             case 'all':
                 const { tableListSource } = this.state;
-                this.setState(() => ({ entriesTable: tableListSource.length }));
+                this.setState(() => ({
+                    entriesInSelect: 'all',
+                    entriesTable: tableListSource.length
+                }));
                 break;
             default:
         }
@@ -270,7 +281,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                     const logCollection = res.data.params.logCollection;
                     let expLogCollection: boolean = false;
                     const isMultiy: boolean = res.data.params.multiPhase !== undefined
-                    ? res.data.params.multiPhase : false;
+                        ? res.data.params.multiPhase : false;
                     if (logCollection !== undefined && logCollection !== 'none') {
                         expLogCollection = true;
                     }

--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -203,10 +203,9 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
             const searchResultList: Array<TableObj> = [];
             Object.keys(tableListSource).map(key => {
                 const item = tableListSource[key];
-                const upperVal = targetValue.toUpperCase();
                 if (item.sequenceId.toString() === targetValue
-                    || item.id.toUpperCase().includes(upperVal)
-                    || item.status.toUpperCase().includes(upperVal)
+                    || item.id.includes(targetValue)
+                    || item.status.toUpperCase().includes(targetValue.toUpperCase())
                 ) {
                     searchResultList.push(item);
                 }
@@ -252,10 +251,12 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                 break;
             case 'all':
                 const { tableListSource } = this.state;
-                this.setState(() => ({
-                    entriesInSelect: 'all',
-                    entriesTable: tableListSource.length
-                }));
+                if (this._isMounted) {
+                    this.setState(() => ({
+                        entriesInSelect: 'all',
+                        entriesTable: tableListSource.length
+                    }));
+                }
                 break;
             default:
         }

--- a/src/webui/src/components/trial-detail/Para.tsx
+++ b/src/webui/src/components/trial-detail/Para.tsx
@@ -182,7 +182,8 @@ class Para extends React.Component<ParaProps, ParaState> {
             // need to cut down the data
             if (percent !== 0) {
                 const linesNum = paraData.data.length;
-                const len = Math.floor(linesNum * percent);
+                // Math.ceil rather than Math.floor to avoid lost lines
+                const len = Math.ceil(linesNum * percent);
                 paraData.data.length = len;
             }
             // need to swap the yAxis
@@ -236,6 +237,8 @@ class Para extends React.Component<ParaProps, ParaState> {
             visualMapObj = {
                 type: 'continuous',
                 precision: 3,
+                min: 0,
+                max: max,
                 color: ['#CA0000', '#FFC400', '#90EE90']
             };
         } else {


### PR DESCRIPTION
#1054 
1. fix bug of table entries. when select "all" and then table message update, table is paging again.
2. when only one succeed trial, {
        >. fix bug of color bar max value is 190
        >. hyper-parameter top select use Math.ceil() to avoid lost data
}
3. table search case-insensitive