### PR TITLE
Fix Windows available gpu

### DIFF
--- a/src/nni_manager/training_service/local/gpuScheduler.ts
+++ b/src/nni_manager/training_service/local/gpuScheduler.ts
@@ -73,8 +73,13 @@ class GPUScheduler {
 
     public getAvailableGPUIndices(): number[] {
         if (this.gpuSummary !== undefined) {
-            return this.gpuSummary.gpuInfos.filter((info: GPUInfo) => info.activeProcessNum === 0)
-                .map((info: GPUInfo) => info.index);
+            if(process.platform === 'win32') {
+                return this.gpuSummary.gpuInfos.map((info: GPUInfo) => info.index);
+            }
+            else{
+                return this.gpuSummary.gpuInfos.filter((info: GPUInfo) => info.activeProcessNum === 0)
+                    .map((info: GPUInfo) => info.index);
+            }
         }
 
         return [];


### PR DESCRIPTION
issue #1037 
For Windows, there may be inevitable processes occupying the gpu while gpu utilization is low. The change is to use all gpus in Windows rather than filtering out the gpus that no process running on. The risk is that OOM error may happen due to the gpu memory is not enough for the new job.