### PR TITLE
Upgrade tensorflow version in the ga_squad and network_morphism examples.

### DIFF
--- a/examples/trials/ga_squad/requirements.txt
+++ b/examples/trials/ga_squad/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==1.4.0
+tensorflow==1.13.1

--- a/examples/trials/network_morphism/requirements.txt
+++ b/examples/trials/network_morphism/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14.2
-tensorflow==1.12.0
+tensorflow==1.13.1
 torchvision==0.2.1
 Keras==2.2.2
 torch==0.4.1


### PR DESCRIPTION
Tensorflow version before 1.12.2 has security issue which is extracted from here by github:
https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=tensorflow
I upgrade Tensorflow version to 1.13.1 and test it successfully in local environment.
