### PR TITLE
Fix link err in docs

### DIFF
--- a/docs/en_US/BuiltinAssessor.md
+++ b/docs/en_US/BuiltinAssessor.md
@@ -19,6 +19,7 @@ Note: Please follow the format when you write your `config.yml` file.
 
 <a name="MedianStop"></a>
 
+
 ![](https://placehold.it/15/1589F0/000000?text=+) `Median Stop Assessor`
 
 > Builtin Assessor Name: **Medianstop**

--- a/docs/en_US/BuiltinAssessor.md
+++ b/docs/en_US/BuiltinAssessor.md
@@ -19,7 +19,6 @@ Note: Please follow the format when you write your `config.yml` file.
 
 <a name="MedianStop"></a>
 
-
 ![](https://placehold.it/15/1589F0/000000?text=+) `Median Stop Assessor`
 
 > Builtin Assessor Name: **Medianstop**

--- a/docs/en_US/assessors.rst
+++ b/docs/en_US/assessors.rst
@@ -13,7 +13,7 @@ Here is an experimental result of MNIST after using 'Curvefitting' Assessor in '
 Like Tuners, users can either use built-in Assessors, or customize an Assessor on their own. Please refer to the following tutorials for detail:
 
 ..  toctree::
-    :maxdepth:2
+    :maxdepth: 2
 
     builtin_assessor
     Customized Assessors<CustomizeAssessor>

--- a/docs/en_US/assessors.rst
+++ b/docs/en_US/assessors.rst
@@ -13,7 +13,7 @@ Here is an experimental result of MNIST after using 'Curvefitting' Assessor in '
 Like Tuners, users can either use built-in Assessors, or customize an Assessor on their own. Please refer to the following tutorials for detail:
 
 ..  toctree::
-    :maxdepth: 2
+    :maxdepth:2
 
-    Builtin Assessors<BuiltinAssessor>
+    builtin_assessor
     Customized Assessors<CustomizeAssessor>

--- a/docs/en_US/builtin_assessor.rst
+++ b/docs/en_US/builtin_assessor.rst
@@ -4,6 +4,6 @@ Builtin-Assessors
 ..  toctree::
     :maxdepth: 1
 
-    Overview<BuiltinAssessors>
+    Overview<BuiltinAssessor>
     Medianstop<MedianstopAssessor>
     Curvefitting<CurvefittingAssessor>

--- a/docs/en_US/tuners.rst
+++ b/docs/en_US/tuners.rst
@@ -13,6 +13,6 @@ For details, please refer to the following tutorials:
 ..  toctree::
     :maxdepth: 2
 
-    Builtin Tuners<BuiltinTuner>
+    builtin_tuner
     Customized Tuners<CustomizeTuner>
     Customized Advisor<CustomizeAdvisor>


### PR DESCRIPTION
- many .md files in docs/en_US not shown in the html doc.  
- fix spelling error