### PR TITLE
fix bug of randint in hyper-parameter graph

### DIFF
--- a/src/webui/src/components/trial-detail/Para.tsx
+++ b/src/webui/src/components/trial-detail/Para.tsx
@@ -162,8 +162,8 @@ class Para extends React.Component<ParaProps, ParaState> {
                     parallelAxis.push({
                         dim: i,
                         name: dimName[i],
-                        max: searchKey._value[0] - 1,
-                        min: 0
+                        min: searchKey._value[0] + 1,
+                        max: searchKey._value[1] - 1,
                     });
                     break;
 


### PR DESCRIPTION
randint(high) -> randint(low, high)
fix issue #1144 