### PR TITLE
Implement full graph version (for tensorflow) of NAS-Interface

### DIFF
--- a/tools/nni_annotation/code_generator.py
+++ b/tools/nni_annotation/code_generator.py
@@ -121,7 +121,7 @@ def parse_annotation_mutable_layers(code, lineno):
             target_call_args.append(ast.Dict(keys=[], values=[]))
             target_call_args.append(ast.Num(n=0))
         if mode == 'oneshot-tf':
-            target_call_args.append(ast.Name('tensorflow'))
+            target_call_args.append(ast.Name(id='tensorflow'))
         target_call = ast.Call(func=target_call_attr, args=target_call_args, keywords=[])
         node = ast.Assign(targets=[layer_output], value=target_call)
         nodes.append(node)
@@ -332,7 +332,7 @@ class Transformer(ast.NodeTransformer):
             call_node = parse_annotation(string[1:]).value
             if call_node.args:
                 call_attr = ast.Attribute(value=ast.Name(id='nni', ctx=ast.Load()), attr='reload_tensorflow_variables', ctx=ast.Load())
-                return ast.Call(func=call_attr, args=call_node.args, keywords=[])
+                return ast.Expr(value=ast.Call(func=call_attr, args=call_node.args, keywords=[]))
             else:
                 deprecated_message = "'@nni.get_next_parameter' is deprecated in annotation due to inconvenience. Please remove this line in the trial code."
                 print_warning(deprecated_message)

--- a/tools/nni_annotation/code_generator.py
+++ b/tools/nni_annotation/code_generator.py
@@ -21,7 +21,6 @@
 
 import ast
 import astor
-from nni_cmd.common_utils import print_warning
 
 # pylint: disable=unidiomatic-typecheck
 
@@ -333,9 +332,6 @@ class Transformer(ast.NodeTransformer):
             if call_node.args:
                 call_attr = ast.Attribute(value=ast.Name(id='nni', ctx=ast.Load()), attr='reload_tensorflow_variables', ctx=ast.Load())
                 return ast.Expr(value=ast.Call(func=call_attr, args=call_node.args, keywords=[]))
-            else:
-                deprecated_message = "'@nni.get_next_parameter' is deprecated in annotation due to inconvenience. Please remove this line in the trial code."
-                print_warning(deprecated_message)
 
         if string.startswith('@nni.report_intermediate_result')  \
                 or string.startswith('@nni.report_final_result') \

--- a/tools/nni_annotation/code_generator.py
+++ b/tools/nni_annotation/code_generator.py
@@ -38,7 +38,13 @@ def parse_annotation_mutable_layers(code, lineno):
     nodes = []
     mutable_id = 'mutable_block_' + str(lineno)
     mutable_layer_cnt = 0
-    mode = 'general'
+    if call.keywords:
+        mode = call.keywords[0].value
+        assert isinstance(mode, (ast.Str, ast.Name)), 'Mode must be a string or Name'
+        mode = mode.s if isinstance(mode, ast.Str) else mode.id
+        assert mode in ['general', 'oneshot-tf', 'oneshot-pytorch']
+    else:
+        mode = 'general'
     for arg in call.args:
         if type(arg) is ast.Str:
             assert arg.s in ['general', 'tensorflow'], 'Unsupported mode %s' % arg.s
@@ -114,7 +120,7 @@ def parse_annotation_mutable_layers(code, lineno):
         else:
             target_call_args.append(ast.Dict(keys=[], values=[]))
             target_call_args.append(ast.Num(n=0))
-        if mode == 'tensorflow':
+        if mode == 'oneshot-tf':
             target_call_args.append(ast.Name('tensorflow'))
         target_call = ast.Call(func=target_call_attr, args=target_call_args, keywords=[])
         node = ast.Assign(targets=[layer_output], value=target_call)
@@ -323,8 +329,13 @@ class Transformer(ast.NodeTransformer):
             return node  # not an annotation, ignore it
 
         if string.startswith('@nni.get_next_parameter'):
-            deprecated_message = "'@nni.get_next_parameter' is deprecated in annotation due to inconvenience. Please remove this line in the trial code."
-            print_warning(deprecated_message)
+            call_node = parse_annotation(string[1:]).value
+            if call_node.args:
+                call_attr = ast.Attribute(value=ast.Name(id='nni', ctx=ast.Load()), attr='reload_tensorflow_variables', ctx=ast.Load())
+                return ast.Call(func=call_attr, args=call_node.args, keywords=[])
+            else:
+                deprecated_message = "'@nni.get_next_parameter' is deprecated in annotation due to inconvenience. Please remove this line in the trial code."
+                print_warning(deprecated_message)
 
         if string.startswith('@nni.report_intermediate_result')  \
                 or string.startswith('@nni.report_final_result') \
@@ -377,7 +388,7 @@ def parse(code):
         if type(nodes[i]) is ast.ImportFrom and nodes[i].module == '__future__':
             last_future_import = i
     nodes.insert(last_future_import + 1, import_nni)
-    if transformer.mode == 'tensorflow':
+    if transformer.mode == 'oneshot-tf':
         import_tf = ast.Import(names=[ast.alias(name='tensorflow', asname=None)])
         nodes.insert(last_future_import + 1, import_tf)
 


### PR DESCRIPTION
Related issue #1159, used to run ENAS

## Overview

In tensorflow, users need to build graph first and then create a session to run that graph. In the previous version, the graph of a trial will be determined (to be a sub-graph) once it receives a parameter configuration from the tuner. That is to say, the graph of this trial will not change even if it receives other parameter configurations in the future.

So in this version we will create and use tensorflow variable as signals, and tensorflow conditional functions to control the search space (full-graph) to be more flexible, which means it can be changed into different sub-graphs (multiple times) depending on these signals.

## API Changed

> **Originally, users can insert annotation into their codes like this:**
```python
def conv(input, size=3, ch=64):
      ... ...
def pool(input):
      ... ...

out1 = conv(image, 3, 64)
out2 = conv(out1, 3, 64)
out3 = conv(out2, 3, 128)

#NNI Annotation
"""@nni.mutable_layers(
{
    layer_choice: [conv(ch=128), conv(ch=256), pool()],
    optional_inputs: [out3],
    optional_input_size: 1,
    layer_output: layer_out
}
)"""
Out = fc_1000(layer_out)
```
> **Now if their want to use tensorflow version, two changes should be made:**

1. They need to **specify the mode** as 'oneshot-tf' in the mutable_layers function like this:
```diff
#NNI Annotation
"""@nni.mutable_layers(
{
    layer_choice: [conv(ch=128), conv(ch=256), pool()],
    optional_inputs: [out3],
    optional_input_size: 1,
    layer_output: layer_out
},
+ mode=oneshot-tf
)"""
```

2. They need to add `nni.get_next_parameter(session)` before they invoke the session.run function:

Note that they need to **pass their tensorflow session as an arg** into this function. An example might be:
```python
for _ in range(num):
    """@nni.get_next_parameter(self.session)"""
    loss, _ = self.session.run([loss_op, train_op])
    """@nni.report_final_result(loss)"""
```
