### PR TITLE
Fix bug of nnictl about stopping experiment and update statsmodels version

### DIFF
--- a/src/sdk/pynni/nni/bohb_advisor/requirements.txt
+++ b/src/sdk/pynni/nni/bohb_advisor/requirements.txt
@@ -1,2 +1,2 @@
 ConfigSpace==0.4.7
-statsmodels==0.9.0
+statsmodels==0.10.0

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -151,7 +151,7 @@ def parse_ids(args):
             exit(1)
         else:
             result_list = running_experiment_list
-    elif args.all:
+    elif args.all != 'all':
         result_list = running_experiment_list
     elif args.id.endswith('*'):
         for id in running_experiment_list:
@@ -166,7 +166,7 @@ def parse_ids(args):
         if len(result_list) > 1:
             print_error(args.id + ' is ambiguous, please choose ' + ' '.join(result_list) )
             return None
-    if not result_list and args.id:
+    if not result_list and args.id and args.id != 'all':
         print_error('There are no experiments matched, please set correct experiment id...')
     elif not result_list:
         print_error('There is no experiment running...')

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -151,7 +151,7 @@ def parse_ids(args):
             exit(1)
         else:
             result_list = running_experiment_list
-    elif args.all == 'all':
+    elif args.id == 'all':
         result_list = running_experiment_list
     elif args.id.endswith('*'):
         for id in running_experiment_list:

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -151,7 +151,7 @@ def parse_ids(args):
             exit(1)
         else:
             result_list = running_experiment_list
-    elif args.all != 'all':
+    elif args.all == 'all':
         result_list = running_experiment_list
     elif args.id.endswith('*'):
         for id in running_experiment_list:


### PR DESCRIPTION
## 1
issue #1098
incompatability between scipy and statsmodel --> refer to [this issue](https://github.com/statsmodels/statsmodels/issues/5759)
since statsmodel has been updated from 0.9.0 to 0.10.0　

## 2 
issue #1292
there's a bug about nnictl stop experiment in this PR #1216 .  `all` remains an option in args in `nnictl.py` but is used as a boolean value in `nnictl_utils.py`