### PR TITLE
[Proposal] Implement resubmitting by refactoring sequenceId

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,9 @@ jobs:
     displayName: 'Naive test'
   - script: |
       cd test
+      PATH=$HOME/.local/bin:$PATH python3 resubmit_test.py
+  - script: |
+      cd test
       PATH=$HOME/.local/bin:$PATH python3 tuner_test.py
     displayName: 'Built-in tuners / assessors tests'
   - script: |

--- a/src/nni_manager/common/datastore.ts
+++ b/src/nni_manager/common/datastore.ts
@@ -22,6 +22,7 @@
 import { ExperimentProfile, TrialJobStatistics } from './manager';
 import { TrialJobDetail, TrialJobStatus } from './trainingService';
 
+// TODO: add a RESUBMIT event?
 type TrialJobEvent = TrialJobStatus | 'USER_TO_CANCEL' | 'ADD_CUSTOMIZED' | 'ADD_HYPERPARAMETER' | 'IMPORT_DATA';
 type MetricType = 'PERIODICAL' | 'FINAL' | 'CUSTOM' | 'REQUEST_PARAMETER';
 

--- a/src/nni_manager/common/experimentStartupInfo.ts
+++ b/src/nni_manager/common/experimentStartupInfo.ts
@@ -30,7 +30,6 @@ class ExperimentStartupInfo {
     private newExperiment: boolean = true;
     private basePort: number = -1;
     private initialized: boolean = false;
-    private initTrialSequenceID: number = 0;
     private logDir: string = '';
     private logLevel: string = '';
 
@@ -83,17 +82,6 @@ class ExperimentStartupInfo {
 
         return this.logLevel;
     }
-
-    public setInitTrialSequenceId(initSequenceId: number): void {
-        assert(this.initialized);
-        this.initTrialSequenceID = initSequenceId;
-    }
-
-    public getInitTrialSequenceId(): number {
-        assert(this.initialized);
-
-        return this.initTrialSequenceID;
-    }
 }
 
 function getExperimentId(): string {
@@ -108,14 +96,6 @@ function isNewExperiment(): boolean {
     return component.get<ExperimentStartupInfo>(ExperimentStartupInfo).isNewExperiment();
 }
 
-function setInitTrialSequenceId(initSequenceId: number): void {
-    component.get<ExperimentStartupInfo>(ExperimentStartupInfo).setInitTrialSequenceId(initSequenceId);
-}
-
-function getInitTrialSequenceId(): number {
-    return component.get<ExperimentStartupInfo>(ExperimentStartupInfo).getInitTrialSequenceId();
-}
-
 function getExperimentStartupInfo(): ExperimentStartupInfo {
     return component.get<ExperimentStartupInfo>(ExperimentStartupInfo);
 }
@@ -127,4 +107,4 @@ function setExperimentStartupInfo(
 }
 
 export { ExperimentStartupInfo, getBasePort, getExperimentId, isNewExperiment, getExperimentStartupInfo,
-    setExperimentStartupInfo, setInitTrialSequenceId, getInitTrialSequenceId };
+    setExperimentStartupInfo };

--- a/src/nni_manager/common/log.ts
+++ b/src/nni_manager/common/log.ts
@@ -141,7 +141,7 @@ class Logger {
         buffer.write(format(param));
         buffer.write('\n');
         buffer.end();
-        this.bufferSerialEmitter.feed(buffer.getContents());
+        this.bufferSerialEmitter.feed(buffer.getContents() as Buffer);
     }
 }
 

--- a/src/nni_manager/common/manager.ts
+++ b/src/nni_manager/common/manager.ts
@@ -102,6 +102,7 @@ abstract class Manager {
     public abstract importData(data: string): Promise<void>;
     public abstract exportData(): Promise<string>;
 
+    public abstract resubmitTrialJob(sequenceId: number): Promise<void>;
     public abstract addCustomizedTrialJob(hyperParams: string): Promise<void>;
     public abstract cancelTrialJobByUser(trialJobId: string): Promise<void>;
 

--- a/src/nni_manager/common/manager.ts
+++ b/src/nni_manager/common/manager.ts
@@ -79,7 +79,7 @@ interface ExperimentProfile {
     logDir?: string;
     startTime?: number;
     endTime?: number;
-    maxSequenceId: number;
+    nextSequenceId: number;
     revision: number;
 }
 

--- a/src/nni_manager/common/trainingService.ts
+++ b/src/nni_manager/common/trainingService.ts
@@ -23,18 +23,10 @@
  * define TrialJobStatus
  */
 type TrialJobStatus = 'UNKNOWN' | 'WAITING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'USER_CANCELED' | 'SYS_CANCELED' | 'EARLY_STOPPED';
-type JobType = 'TRIAL' | 'HOST';
 
 interface TrainingServiceMetadata {
     readonly key: string;
     readonly value: string;
-}
-
-/**
- * define JobApplicationForm
- */
-interface JobApplicationForm {
-    readonly jobType: JobType;
 }
 
 interface HyperParameters {
@@ -45,16 +37,9 @@ interface HyperParameters {
 /**
  * define TrialJobApplicationForm
  */
-interface TrialJobApplicationForm extends JobApplicationForm {
+interface TrialJobApplicationForm {
+    readonly sequenceId: number;
     readonly hyperParameters: HyperParameters;
-}
-
-/**
- * define HostJobApplicationForm
- */
-interface HostJobApplicationForm extends JobApplicationForm {
-    readonly host: string;
-    readonly cmd: string;
 }
 
 /**
@@ -69,8 +54,7 @@ interface TrialJobDetail {
     readonly tags?: string[];
     readonly url?: string;
     readonly workingDirectory: string;
-    readonly form: JobApplicationForm;
-    readonly sequenceId: number;
+    readonly form: TrialJobApplicationForm;
     isEarlyStopped?: boolean;
 }
 
@@ -112,8 +96,8 @@ abstract class TrainingService {
     public abstract getTrialJob(trialJobId: string): Promise<TrialJobDetail>;
     public abstract addTrialJobMetricListener(listener: (metric: TrialJobMetric) => void): void;
     public abstract removeTrialJobMetricListener(listener: (metric: TrialJobMetric) => void): void;
-    public abstract submitTrialJob(form: JobApplicationForm): Promise<TrialJobDetail>;
-    public abstract updateTrialJob(trialJobId: string, form: JobApplicationForm): Promise<TrialJobDetail>;
+    public abstract submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail>;
+    public abstract updateTrialJob(trialJobId: string, form: TrialJobApplicationForm): Promise<TrialJobDetail>;
     public abstract get isMultiPhaseJobSupported(): boolean;
     public abstract cancelTrialJob(trialJobId: string, isEarlyStopped?: boolean): Promise<void>;
     public abstract setClusterMetadata(key: string, value: string): Promise<void>;
@@ -133,7 +117,7 @@ class NNIManagerIpConfig {
 }
 
 export {
-    TrainingService, TrainingServiceError, TrialJobStatus, TrialJobApplicationForm,
+    TrainingService, TrainingServiceError, TrialJobApplicationForm, TrialJobStatus,
     TrainingServiceMetadata, TrialJobDetail, TrialJobMetric, HyperParameters,
-    HostJobApplicationForm, JobApplicationForm, JobType, NNIManagerIpConfig
+    NNIManagerIpConfig
 };

--- a/src/nni_manager/core/nnimanager.ts
+++ b/src/nni_manager/core/nnimanager.ts
@@ -725,7 +725,7 @@ class NNIManager implements Manager {
             revision: 0,
             execDuration: 0,
             logDir: getExperimentRootDir(),
-            nextSequenceId: 1,  // FIXME: maybe zero?
+            nextSequenceId: 0,
             params: {
                 authorName: '',
                 experimentName: '',

--- a/src/nni_manager/core/sqlDatabase.ts
+++ b/src/nni_manager/core/sqlDatabase.ts
@@ -54,7 +54,7 @@ create table ExperimentProfile (
     startTime integer,
     endTime integer,
     logDir text,
-    maxSequenceId integer,
+    nextSequenceId integer,
     revision integer);
 create index ExperimentProfile_id on ExperimentProfile(id);
 `;
@@ -67,7 +67,7 @@ function loadExperimentProfile(row: any): ExperimentProfile {
         startTime: row.startTime === null ? undefined : row.startTime,
         endTime: row.endTime === null ? undefined : row.endTime,
         logDir: row.logDir === null ? undefined : row.logDir,
-        maxSequenceId: row.maxSequenceId,
+        nextSequenceId: row.nextSequenceId,
         revision: row.revision
     };
 }
@@ -144,7 +144,7 @@ class SqlDB implements Database {
             exp.startTime === undefined ? null : exp.startTime,
             exp.endTime === undefined ? null : exp.endTime,
             exp.logDir === undefined ? null : exp.logDir,
-            exp.maxSequenceId,
+            exp.nextSequenceId,
             exp.revision
         ];
         this.log.trace(`storeExperimentProfile: SQL: ${sql}, args: ${JSON.stringify(args)}`);
@@ -183,7 +183,7 @@ class SqlDB implements Database {
         event: TrialJobEvent, trialJobId: string, timestamp: number, hyperParameter?: string, jobDetail?: TrialJobDetail): Promise<void> {
         const sql: string = 'insert into TrialJobEvent values (?,?,?,?,?,?)';
         const logPath: string | undefined = jobDetail === undefined ? undefined : jobDetail.url;
-        const sequenceId: number | undefined = jobDetail === undefined ? undefined : jobDetail.sequenceId;
+        const sequenceId: number | undefined = jobDetail === undefined ? undefined : jobDetail.form.sequenceId;
         const args: any[] = [timestamp, trialJobId, event, hyperParameter, logPath, sequenceId];
 
         this.log.trace(`storeTrialJobEvent: SQL: ${sql}, args: ${JSON.stringify(args)}`);

--- a/src/nni_manager/core/test/dataStore.test.ts
+++ b/src/nni_manager/core/test/dataStore.test.ts
@@ -80,7 +80,7 @@ describe('Unit test for dataStore', () => {
             execDuration: 0,
             startTime: Date.now(),
             endTime: Date.now(),
-            maxSequenceId: 0,
+            nextSequenceId: 0,
             revision: 0
         }
         const id: string = profile.id;

--- a/src/nni_manager/core/test/mockedTrainingService.ts
+++ b/src/nni_manager/core/test/mockedTrainingService.ts
@@ -40,7 +40,7 @@ class MockedTrainingService extends TrainingService {
         tags: ['test'],
         url: 'http://test',
         workingDirectory: '/tmp/mocked',
-        form: { // FIXME
+        form: {
             sequenceId: 0,
             hyperParameters: {
                 value: '',
@@ -58,7 +58,7 @@ class MockedTrainingService extends TrainingService {
         url: 'http://test',
         workingDirectory: '/tmp/mocked',
         form: {
-            sequenceId: 0,
+            sequenceId: 1,
             hyperParameters: {
                 value: '',
                 index: 0,

--- a/src/nni_manager/core/test/mockedTrainingService.ts
+++ b/src/nni_manager/core/test/mockedTrainingService.ts
@@ -40,10 +40,13 @@ class MockedTrainingService extends TrainingService {
         tags: ['test'],
         url: 'http://test',
         workingDirectory: '/tmp/mocked',
-        form: {
-            jobType: 'TRIAL'
+        form: { // FIXME
+            sequenceId: 0,
+            hyperParameters: {
+                value: '',
+                index: 0,
+            },
         },
-        sequenceId: 0
     };
     public jobDetail2: TrialJobDetail = {
         id: '3456',
@@ -55,9 +58,12 @@ class MockedTrainingService extends TrainingService {
         url: 'http://test',
         workingDirectory: '/tmp/mocked',
         form: {
-            jobType: 'TRIAL'
+            sequenceId: 0,
+            hyperParameters: {
+                value: '',
+                index: 0,
+            },
         },
-        sequenceId: 0
     };
 
     public listTrialJobs(): Promise<TrialJobDetail[]> {

--- a/src/nni_manager/core/test/nnimanager.test.ts
+++ b/src/nni_manager/core/test/nnimanager.test.ts
@@ -119,6 +119,9 @@ describe('Unit test for nnimanager', function () {
     })
 
 
+    // FIXME: unit test for resubmitTrialJob
+    //it('test resubmitTrialJob', () => {
+    //}
 
     it('test addCustomizedTrialJob', () => {
         return nniManager.addCustomizedTrialJob('hyperParams').then(() => {

--- a/src/nni_manager/core/test/nnimanager.test.ts
+++ b/src/nni_manager/core/test/nnimanager.test.ts
@@ -101,7 +101,7 @@ describe('Unit test for nnimanager', function () {
         params: updateExperimentParams,
         id: 'test',
         execDuration: 0,
-        maxSequenceId: 0,
+        nextSequenceId: 0,
         revision: 0
     }
 

--- a/src/nni_manager/core/test/sqlDatabase.test.ts
+++ b/src/nni_manager/core/test/sqlDatabase.test.ts
@@ -64,10 +64,10 @@ const expParams2: ExperimentParams = {
 };
 
 const profiles: ExperimentProfile[] = [
-    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: undefined, maxSequenceId: 0, revision: 1,},
-    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), maxSequenceId: 0, revision: 2 },
-    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), maxSequenceId: 0, revision: 2 },
-    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), maxSequenceId: 0, revision: 3 }
+    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: undefined, nextSequenceId: 0, revision: 1,},
+    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 2 },
+    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 2 },
+    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 3 }
 ];
 
 const events: TrialJobEventRecord[] = [

--- a/src/nni_manager/core/test/sqlDatabase.test.ts
+++ b/src/nni_manager/core/test/sqlDatabase.test.ts
@@ -65,9 +65,9 @@ const expParams2: ExperimentParams = {
 
 const profiles: ExperimentProfile[] = [
     { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: undefined, nextSequenceId: 0, revision: 1,},
-    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 2 },
+    { params: expParams1, id: '#1', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 1, revision: 2 },
     { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 2 },
-    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 0, revision: 3 }
+    { params: expParams2, id: '#2', execDuration: 0, logDir: '/log', startTime: Date.now(), endTime: Date.now(), nextSequenceId: 2, revision: 3 }
 ];
 
 const events: TrialJobEventRecord[] = [

--- a/src/nni_manager/rest_server/restHandler.ts
+++ b/src/nni_manager/rest_server/restHandler.ts
@@ -69,6 +69,7 @@ class NNIRestHandler {
         this.setClusterMetaData(router);
         this.listTrialJobs(router);
         this.getTrialJob(router);
+        this.resubmitTrialJob(router);
         this.addTrialJob(router);
         this.cancelTrialJob(router);
         this.getMetricData(router);
@@ -226,6 +227,16 @@ class NNIRestHandler {
             this.nniManager.getTrialJob(req.params.id).then((jobDetail: TrialJobInfo) => {
                 const jobInfo: TrialJobInfo = this.setErrorPathForFailedJob(jobDetail);
                 res.send(jobInfo);
+            }).catch((err: Error) => {
+                this.handle_error(err, res);
+            });
+        });
+    }
+
+    private resubmitTrialJob(router: Router): void {
+        router.get('/resubmit/:seqId', async (req: Request, res: Response) => {
+            this.nniManager.resubmitTrialJob(Number(req.params.seqId)).then(() => {
+                res.send();
             }).catch((err: Error) => {
                 this.handle_error(err, res);
             });

--- a/src/nni_manager/rest_server/restValidationSchemas.ts
+++ b/src/nni_manager/rest_server/restValidationSchemas.ts
@@ -198,7 +198,7 @@ export namespace ValidationSchemas {
             startTime: joi.number(),
             endTime: joi.number(),
             logDir: joi.string(),
-            maxSequenceId: joi.number()
+            nextSequenceId: joi.number()
         }
     };
 }

--- a/src/nni_manager/rest_server/test/mockedNNIManager.ts
+++ b/src/nni_manager/rest_server/test/mockedNNIManager.ts
@@ -85,10 +85,13 @@ export class MockedNNIManager extends Manager {
             // tslint:disable-next-line:no-http-string
             url: 'http://test',
             workingDirectory: '/tmp/mocked',
-            sequenceId: 0,
             form: {
-                jobType: 'TRIAL'
-            }
+                sequenceId: 0,
+                hyperParameters: {
+                    value: '',
+                    index: 0,
+                },
+            },
         };
         deferred.resolve(jobDetail);
 
@@ -148,7 +151,7 @@ export class MockedNNIManager extends Manager {
             execDuration: 0,
             startTime: Date.now(),
             endTime: Date.now(),
-            maxSequenceId: 0,
+            nextSequenceId: 0,
             revision: 0
         };
 

--- a/src/nni_manager/rest_server/test/mockedNNIManager.ts
+++ b/src/nni_manager/rest_server/test/mockedNNIManager.ts
@@ -65,6 +65,9 @@ export class MockedNNIManager extends Manager {
 
         return deferred.promise;
     }
+    public resubmitTrialJob(sequenceId: number): Promise<void> {
+        return Promise.resolve();
+    }
     public addCustomizedTrialJob(hyperParams: string): Promise<void> {
         return Promise.resolve();
     }

--- a/src/nni_manager/rest_server/test/restserver.test.ts
+++ b/src/nni_manager/rest_server/test/restserver.test.ts
@@ -180,4 +180,15 @@ describe('Unit test for rest server', () => {
             done();
         });
     });
+
+    it('Test GET resubmit/:reqId', (done: Mocha.Done) => {
+        request.get(`${ROOT_URL}/resubmit/1`, (err: Error, res: request.Response, body: any) => {
+            if (err) {
+                assert.fail(err.message);
+            } else {
+                expect(res.statusCode).to.equal(200);
+            }
+            done();
+        });
+    });
 });

--- a/src/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
@@ -25,7 +25,7 @@ import * as path from 'path';
 import * as component from '../../../common/component';
 import { getExperimentId } from '../../../common/experimentStartupInfo';
 import {
-    JobApplicationForm, NNIManagerIpConfig, TrialJobApplicationForm, TrialJobDetail
+    NNIManagerIpConfig, TrialJobApplicationForm, TrialJobDetail
 } from '../../../common/trainingService';
 import { delay, generateParamFileName, getExperimentRootDir, uniqueString } from '../../../common/utils';
 import { CONTAINER_INSTALL_NNI_SHELL_FORMAT } from '../../common/containerJobData';
@@ -77,7 +77,7 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
         }
     }
 
-    public async submitTrialJob(form: JobApplicationForm): Promise<TrialJobDetail> {
+    public async submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
         if (this.fcClusterConfig === undefined) {
             throw new Error('frameworkcontrollerClusterConfig is not initialized');
         }
@@ -260,7 +260,7 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
     }
 
     private async prepareRunScript(trialLocalTempFolder: string, curTrialSequenceId: number, trialJobId: string,
-                                   trialWorkingFolder: string, form: JobApplicationForm): Promise<void> {
+                                   trialWorkingFolder: string, form: TrialJobApplicationForm): Promise<void> {
         if (this.fcTrialConfig === undefined) {
             throw new Error('frameworkcontroller trial config is not initialized');
         }

--- a/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
@@ -27,7 +27,7 @@ import * as component from '../../../common/component';
 
 import { getExperimentId } from '../../../common/experimentStartupInfo';
 import {
-    JobApplicationForm, NNIManagerIpConfig, TrialJobApplicationForm, TrialJobDetail
+    NNIManagerIpConfig, TrialJobApplicationForm, TrialJobDetail
 } from '../../../common/trainingService';
 import { delay, generateParamFileName, getExperimentRootDir, uniqueString } from '../../../common/utils';
 import { CONTAINER_INSTALL_NNI_SHELL_FORMAT } from '../../common/containerJobData';
@@ -84,7 +84,7 @@ class KubeflowTrainingService extends KubernetesTrainingService implements Kuber
         this.log.info('Kubeflow training service exit.');
     }
 
-    public async submitTrialJob(form: JobApplicationForm): Promise<TrialJobDetail> {
+    public async submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
         if (this.kubernetesCRDClient === undefined) {
             throw new Error('Kubeflow job operator client is undefined');
         }
@@ -248,7 +248,7 @@ class KubeflowTrainingService extends KubernetesTrainingService implements Kuber
     }
 
     private async prepareRunScript(trialLocalTempFolder: string, trialJobId: string, trialWorkingFolder: string, curTrialSequenceId: number,
-                                   form: JobApplicationForm): Promise<void> {
+                                   form: TrialJobApplicationForm): Promise<void> {
         if (this.kubeflowClusterConfig === undefined) {
             throw new Error('Kubeflow Cluster config is not initialized');
         }

--- a/src/nni_manager/training_service/kubernetes/kubernetesData.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesData.ts
@@ -35,19 +35,17 @@ export class KubernetesTrialJobDetail implements TrialJobDetail {
     public workingDirectory: string;
     public form: TrialJobApplicationForm;
     public kubernetesJobName: string;
-    public sequenceId: number;
     public queryJobFailedCount: number;
 
     constructor(id: string, status: TrialJobStatus, submitTime: number,
                 workingDirectory: string, form: TrialJobApplicationForm,
-                kubernetesJobName: string, sequenceId: number, url: string) {
+                kubernetesJobName: string, url: string) {
         this.id = id;
         this.status = status;
         this.submitTime = submitTime;
         this.workingDirectory = workingDirectory;
         this.form = form;
         this.kubernetesJobName = kubernetesJobName;
-        this.sequenceId = sequenceId;
         this.tags = [];
         this.queryJobFailedCount = 0;
         this.url = url;

--- a/src/nni_manager/training_service/kubernetes/kubernetesData.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesData.ts
@@ -19,7 +19,7 @@
 
 'use strict';
 
-import { JobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
+import { TrialJobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
 
 /**
  * KubeflowTrialJobDetail
@@ -33,13 +33,13 @@ export class KubernetesTrialJobDetail implements TrialJobDetail {
     public tags?: string[];
     public url?: string;
     public workingDirectory: string;
-    public form: JobApplicationForm;
+    public form: TrialJobApplicationForm;
     public kubernetesJobName: string;
     public sequenceId: number;
     public queryJobFailedCount: number;
 
     constructor(id: string, status: TrialJobStatus, submitTime: number,
-                workingDirectory: string, form: JobApplicationForm,
+                workingDirectory: string, form: TrialJobApplicationForm,
                 kubernetesJobName: string, sequenceId: number, url: string) {
         this.id = id;
         this.status = status;

--- a/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
@@ -26,7 +26,7 @@ import * as azureStorage from 'azure-storage';
 import { EventEmitter } from 'events';
 import { Base64 } from 'js-base64';
 import { String } from 'typescript-string-operations';
-import { getExperimentId, getInitTrialSequenceId } from '../../common/experimentStartupInfo';
+import { getExperimentId } from '../../common/experimentStartupInfo';
 import { getLogger, Logger } from '../../common/log';
 import {
     NNIManagerIpConfig, TrialJobDetail, TrialJobMetric
@@ -90,9 +90,7 @@ abstract class KubernetesTrainingService {
         const jobs: TrialJobDetail[] = [];
 
         for (const [key, value] of this.trialJobsMap) {
-            if (value.form.jobType === 'TRIAL') {
-                jobs.push(await this.getTrialJob(key));
-            }
+            jobs.push(await this.getTrialJob(key));
         }
 
         return Promise.resolve(jobs);
@@ -221,7 +219,7 @@ abstract class KubernetesTrainingService {
 
     protected generateSequenceId(): number {
         if (this.nextTrialSequenceId === -1) {
-            this.nextTrialSequenceId = getInitTrialSequenceId();
+            this.nextTrialSequenceId = 1;  // FIXME: 0?
         }
 
         return this.nextTrialSequenceId++;

--- a/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
+++ b/src/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
@@ -50,7 +50,6 @@ abstract class KubernetesTrainingService {
     protected readonly trialLocalNFSTempFolder: string;
     protected stopping: boolean = false;
     protected experimentId! : string;
-    protected nextTrialSequenceId: number;
     protected kubernetesRestServerPort?: number;
     protected readonly CONTAINER_MOUNT_PATH: string;
     protected azureStorageClient?: azureStorage.FileService;
@@ -71,7 +70,6 @@ abstract class KubernetesTrainingService {
         this.trialJobsMap = new Map<string, KubernetesTrialJobDetail>();
         this.trialLocalNFSTempFolder = path.join(getExperimentRootDir(), 'trials-nfs-tmp');
         this.experimentId = getExperimentId();
-        this.nextTrialSequenceId = -1;
         this.CONTAINER_MOUNT_PATH = '/tmp/mount';
         this.genericK8sClient = new GeneralK8sClient();
         this.logCollection = 'none';
@@ -215,14 +213,6 @@ abstract class KubernetesTrainingService {
         }
 
         return Promise.resolve();
-    }
-
-    protected generateSequenceId(): number {
-        if (this.nextTrialSequenceId === -1) {
-            this.nextTrialSequenceId = 1;  // FIXME: 0?
-        }
-
-        return this.nextTrialSequenceId++;
     }
 
     // tslint:disable: no-unsafe-any no-any

--- a/src/nni_manager/training_service/local/localTrainingService.ts
+++ b/src/nni_manager/training_service/local/localTrainingService.ts
@@ -165,8 +165,8 @@ class LocalTrainingService implements TrainingService {
         const jobs: TrialJobDetail[] = [];
         for (const key of this.jobMap.keys()) {
             const trialJob: TrialJobDetail = await this.getTrialJob(key);
+            jobs.push(trialJob);
         }
-
         return jobs;
     }
 

--- a/src/nni_manager/training_service/local/localTrainingService.ts
+++ b/src/nni_manager/training_service/local/localTrainingService.ts
@@ -26,10 +26,10 @@ import * as path from 'path';
 import * as ts from 'tail-stream';
 import * as tkill from 'tree-kill';
 import { NNIError, NNIErrorNames } from '../../common/errors';
-import { getExperimentId, getInitTrialSequenceId } from '../../common/experimentStartupInfo';
+import { getExperimentId } from '../../common/experimentStartupInfo';
 import { getLogger, Logger } from '../../common/log';
 import {
-    HostJobApplicationForm, HyperParameters, JobApplicationForm, TrainingService, TrialJobApplicationForm,
+    HyperParameters, TrainingService, TrialJobApplicationForm,
     TrialJobDetail, TrialJobMetric, TrialJobStatus
 } from '../../common/trainingService';
 import {
@@ -76,21 +76,19 @@ class LocalTrialJobDetail implements TrialJobDetail {
     public tags?: string[];
     public url?: string;
     public workingDirectory: string;
-    public form: JobApplicationForm;
-    public sequenceId: number;
+    public form: TrialJobApplicationForm;
     public pid?: number;
     public gpuIndices?: number[];
 
     constructor(
         id: string, status: TrialJobStatus, submitTime: number,
-        workingDirectory: string, form: JobApplicationForm, sequenceId: number) {
+        workingDirectory: string, form: TrialJobApplicationForm) {
         this.id = id;
         this.status = status;
         this.submitTime = submitTime;
         this.workingDirectory = workingDirectory;
         this.form = form;
         this.url = `file://localhost:${workingDirectory}`;
-        this.sequenceId = sequenceId;
         this.gpuIndices = [];
     }
 }
@@ -125,7 +123,6 @@ class LocalTrainingService implements TrainingService {
     private initialized: boolean;
     private stopping: boolean;
     private rootDir!: string;
-    private trialSequenceId: number;
     private readonly experimentId! : string;
     private gpuScheduler!: GPUScheduler;
     private readonly occupiedGpuIndexNumMap: Map<number, number>;
@@ -145,7 +142,6 @@ class LocalTrainingService implements TrainingService {
         this.initialized = false;
         this.stopping = false;
         this.log = getLogger();
-        this.trialSequenceId = -1;
         this.experimentId = getExperimentId();
         this.jobStreamMap = new Map<string, ts.Stream>();
         this.log.info('Construct local machine training service.');
@@ -169,9 +165,6 @@ class LocalTrainingService implements TrainingService {
         const jobs: TrialJobDetail[] = [];
         for (const key of this.jobMap.keys()) {
             const trialJob: TrialJobDetail = await this.getTrialJob(key);
-            if (trialJob.form.jobType === 'TRIAL') {
-                jobs.push(trialJob);
-            }
         }
 
         return jobs;
@@ -181,9 +174,6 @@ class LocalTrainingService implements TrainingService {
         const trialJob: LocalTrialJobDetail | undefined = this.jobMap.get(trialJobId);
         if (trialJob === undefined) {
             throw new NNIError(NNIErrorNames.NOT_FOUND, 'Trial job not found');
-        }
-        if (trialJob.form.jobType === 'HOST') {
-            return this.getHostJob(trialJobId);
         }
         if (trialJob.status === 'RUNNING') {
             const alive: boolean = await isAlive(trialJob.pid);
@@ -219,28 +209,21 @@ class LocalTrainingService implements TrainingService {
         this.eventEmitter.off('metric', listener);
     }
 
-    public submitTrialJob(form: JobApplicationForm): Promise<TrialJobDetail> {
-        if (form.jobType === 'HOST') {
-            return this.runHostJob(<HostJobApplicationForm>form);
-        } else if (form.jobType === 'TRIAL') {
-            const trialJobId: string = uniqueString(5);
-            const trialJobDetail: LocalTrialJobDetail = new LocalTrialJobDetail(
-                trialJobId,
-                'WAITING',
-                Date.now(),
-                path.join(this.rootDir, 'trials', trialJobId),
-                form,
-                this.generateSequenceId()
-            );
-            this.jobQueue.push(trialJobId);
-            this.jobMap.set(trialJobId, trialJobDetail);
+    public submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
+        const trialJobId: string = uniqueString(5);
+        const trialJobDetail: LocalTrialJobDetail = new LocalTrialJobDetail(
+            trialJobId,
+            'WAITING',
+            Date.now(),
+            path.join(this.rootDir, 'trials', trialJobId),
+            form,
+        );
+        this.jobQueue.push(trialJobId);
+        this.jobMap.set(trialJobId, trialJobDetail);
 
-            this.log.debug(`submitTrialJob: return: ${JSON.stringify(trialJobDetail)} `);
+        this.log.debug(`submitTrialJob: return: ${JSON.stringify(trialJobDetail)} `);
 
-            return Promise.resolve(trialJobDetail);
-        } else {
-            return Promise.reject(new Error(`Job form not supported: ${JSON.stringify(form)}`));
-        }
+        return Promise.resolve(trialJobDetail);
     }
 
     /**
@@ -248,16 +231,12 @@ class LocalTrainingService implements TrainingService {
      * @param trialJobId trial job id
      * @param form job application form
      */
-    public async updateTrialJob(trialJobId: string, form: JobApplicationForm): Promise<TrialJobDetail> {
+    public async updateTrialJob(trialJobId: string, form: TrialJobApplicationForm): Promise<TrialJobDetail> {
         const trialJobDetail: undefined | TrialJobDetail = this.jobMap.get(trialJobId);
         if (trialJobDetail === undefined) {
             throw new Error(`updateTrialJob failed: ${trialJobId} not found`);
         }
-        if (form.jobType === 'TRIAL') {
-            await this.writeParameterFile(trialJobDetail.workingDirectory, (<TrialJobApplicationForm>form).hyperParameters);
-        } else {
-            throw new Error(`updateTrialJob failed: jobType ${form.jobType} not supported.`);
-        }
+        await this.writeParameterFile(trialJobDetail.workingDirectory, form.hyperParameters);
 
         return trialJobDetail;
     }
@@ -279,13 +258,7 @@ class LocalTrainingService implements TrainingService {
 
             return Promise.resolve();
         }
-        if (trialJob.form.jobType === 'TRIAL') {
-            tkill(trialJob.pid, 'SIGKILL');
-        } else if (trialJob.form.jobType === 'HOST') {
-            await cpp.exec(`pkill -9 -P ${trialJob.pid}`);
-        } else {
-            throw new Error(`Job type not supported: ${trialJob.form.jobType}`);
-        }
+        tkill(trialJob.pid, 'SIGKILL');
         this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
 
         return Promise.resolve();
@@ -406,7 +379,7 @@ class LocalTrainingService implements TrainingService {
             { key: 'NNI_SYS_DIR', value: trialJobDetail.workingDirectory },
             { key: 'NNI_TRIAL_JOB_ID', value: trialJobDetail.id },
             { key: 'NNI_OUTPUT_DIR', value: trialJobDetail.workingDirectory },
-            { key: 'NNI_TRIAL_SEQ_ID', value: trialJobDetail.sequenceId.toString() },
+            { key: 'NNI_TRIAL_SEQ_ID', value: trialJobDetail.form.sequenceId.toString() },
             { key: 'MULTI_PHASE', value: this.isMultiPhase.toString() }
         ];
 
@@ -549,7 +522,7 @@ class LocalTrainingService implements TrainingService {
         const scriptName: string = getScriptName('run');
         await fs.promises.writeFile(path.join(trialJobDetail.workingDirectory, scriptName),
                                     runScriptContent.join(getNewLine()), { encoding: 'utf8', mode: 0o777 });
-        await this.writeParameterFile(trialJobDetail.workingDirectory, (<TrialJobApplicationForm>trialJobDetail.form).hyperParameters);
+        await this.writeParameterFile(trialJobDetail.workingDirectory, trialJobDetail.form.hyperParameters);
         const trialJobProcess: cp.ChildProcess = runScript(path.join(trialJobDetail.workingDirectory, scriptName));
         this.setTrialJobStatus(trialJobDetail, 'RUNNING');
         trialJobDetail.startTime = Date.now();
@@ -576,59 +549,9 @@ class LocalTrainingService implements TrainingService {
         this.jobStreamMap.set(trialJobDetail.id, stream);
     }
 
-    private async runHostJob(form: HostJobApplicationForm): Promise<TrialJobDetail> {
-        const jobId: string = uniqueString(5);
-        const workDir: string = path.join(this.rootDir, 'hostjobs', jobId);
-        await cpp.exec(`mkdir -p ${workDir}`);
-        const wrappedCmd: string = `cd ${workDir} && ${form.cmd}>stdout 2>stderr`;
-        this.log.debug(`runHostJob: command: ${wrappedCmd}`);
-        const process: cp.ChildProcess = cp.exec(wrappedCmd);
-        const jobDetail: LocalTrialJobDetail = {
-            id: jobId,
-            status: 'RUNNING',
-            submitTime: Date.now(),
-            workingDirectory: workDir,
-            form: form,
-            sequenceId: this.generateSequenceId(),
-            pid: process.pid
-        };
-        this.jobMap.set(jobId, jobDetail);
-        this.log.debug(`runHostJob: return: ${JSON.stringify(jobDetail)} `);
-
-        return jobDetail;
-    }
-
-    private async getHostJob(jobId: string): Promise<TrialJobDetail> {
-        const jobDetail: LocalTrialJobDetail | undefined = this.jobMap.get(jobId);
-        if (jobDetail === undefined) {
-            throw new NNIError(NNIErrorNames.NOT_FOUND, `Host Job not found: ${jobId}`);
-        }
-        try {
-            await cpp.exec(`kill -0 ${jobDetail.pid}`);
-
-            return jobDetail;
-        } catch (error) {
-            if (error instanceof Error) {
-                this.log.debug(`getHostJob: error: ${error.message}`);
-                this.jobMap.delete(jobId);
-                throw new NNIError(NNIErrorNames.NOT_FOUND, `Host Job not found: ${error.message}`);
-            } else {
-                throw error;
-            }
-        }
-    }
-
     private async writeParameterFile(directory: string, hyperParameters: HyperParameters): Promise<void> {
         const filepath: string = path.join(directory, generateParamFileName(hyperParameters));
         await fs.promises.writeFile(filepath, hyperParameters.value, { encoding: 'utf8' });
-    }
-
-    private generateSequenceId(): number {
-        if (this.trialSequenceId === -1) {
-            this.trialSequenceId = getInitTrialSequenceId();
-        }
-
-        return this.trialSequenceId++;
     }
 }
 

--- a/src/nni_manager/training_service/pai/paiData.ts
+++ b/src/nni_manager/training_service/pai/paiData.ts
@@ -19,7 +19,7 @@
 
 'use strict';
 
-import { JobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
+import { TrialJobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
 
 /**
  * PAI trial job detail
@@ -34,13 +34,13 @@ export class PAITrialJobDetail implements TrialJobDetail {
     public tags?: string[];
     public url?: string;
     public workingDirectory: string;
-    public form: JobApplicationForm;
+    public form: TrialJobApplicationForm;
     public sequenceId: number;
     public hdfsLogPath: string;
     public isEarlyStopped?: boolean;
 
     constructor(id: string, status: TrialJobStatus, paiJobName : string,
-                submitTime: number, workingDirectory: string, form: JobApplicationForm, sequenceId: number, hdfsLogPath: string) {
+                submitTime: number, workingDirectory: string, form: TrialJobApplicationForm, sequenceId: number, hdfsLogPath: string) {
         this.id = id;
         this.status = status;
         this.paiJobName = paiJobName;

--- a/src/nni_manager/training_service/pai/paiData.ts
+++ b/src/nni_manager/training_service/pai/paiData.ts
@@ -35,19 +35,17 @@ export class PAITrialJobDetail implements TrialJobDetail {
     public url?: string;
     public workingDirectory: string;
     public form: TrialJobApplicationForm;
-    public sequenceId: number;
     public hdfsLogPath: string;
     public isEarlyStopped?: boolean;
 
     constructor(id: string, status: TrialJobStatus, paiJobName : string,
-                submitTime: number, workingDirectory: string, form: TrialJobApplicationForm, sequenceId: number, hdfsLogPath: string) {
+                submitTime: number, workingDirectory: string, form: TrialJobApplicationForm, hdfsLogPath: string) {
         this.id = id;
         this.status = status;
         this.paiJobName = paiJobName;
         this.submitTime = submitTime;
         this.workingDirectory = workingDirectory;
         this.form = form;
-        this.sequenceId = sequenceId;
         this.tags = [];
         this.hdfsLogPath = hdfsLogPath;
     }

--- a/src/nni_manager/training_service/pai/paiTrainingService.ts
+++ b/src/nni_manager/training_service/pai/paiTrainingService.ts
@@ -179,7 +179,7 @@ class PAITrainingService implements TrainingService {
         if (trialJobDetail === undefined) {
             throw new Error(`updateTrialJob failed: ${trialJobId} not found`);
         }
-        await this.writeParameterFile(trialJobId, (<TrialJobApplicationForm>form).hyperParameters);
+        await this.writeParameterFile(trialJobId, form.hyperParameters);
         return trialJobDetail;
     }
 
@@ -447,7 +447,7 @@ class PAITrainingService implements TrainingService {
             `$PWD/${trialJobId}/nnioutput`,
             trialJobId,
             this.experimentId,
-            trialJobDetail.form.sequenceId,  // TODO: check if this is required
+            trialJobDetail.form.sequenceId,
             this.isMultiPhase,
             this.paiTrialConfig.command,
             nniManagerIp,

--- a/src/nni_manager/training_service/remote_machine/remoteMachineData.ts
+++ b/src/nni_manager/training_service/remote_machine/remoteMachineData.ts
@@ -22,7 +22,7 @@
 import * as fs from 'fs';
 import { Client, ConnectConfig } from 'ssh2';
 import { Deferred } from 'ts-deferred';
-import { JobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
+import { TrialJobApplicationForm, TrialJobDetail, TrialJobStatus  } from '../../common/trainingService';
 import { GPUInfo, GPUSummary } from '../common/gpuData';
 
 /**
@@ -82,20 +82,18 @@ export class RemoteMachineTrialJobDetail implements TrialJobDetail {
     public tags?: string[];
     public url?: string;
     public workingDirectory: string;
-    public form: JobApplicationForm;
-    public sequenceId: number;
+    public form: TrialJobApplicationForm;
     public rmMeta?: RemoteMachineMeta;
     public isEarlyStopped?: boolean;
     public gpuIndices: GPUInfo[];
 
     constructor(id: string, status: TrialJobStatus, submitTime: number,
-                workingDirectory: string, form: JobApplicationForm, sequenceId: number) {
+                workingDirectory: string, form: TrialJobApplicationForm) {
         this.id = id;
         this.status = status;
         this.submitTime = submitTime;
         this.workingDirectory = workingDirectory;
         this.form = form;
-        this.sequenceId = sequenceId;
         this.tags = [];
         this.gpuIndices = [];
     }

--- a/src/nni_manager/training_service/test/localTrainingService.test.ts
+++ b/src/nni_manager/training_service/test/localTrainingService.test.ts
@@ -76,7 +76,7 @@ describe('Unit Test for LocalTrainingService', () => {
 
         // submit job
         const form: TrialJobApplicationForm = {
-            jobType: 'TRIAL',
+            sequenceId: 0,
             hyperParameters: {
                 value: 'mock hyperparameters',
                 index: 0
@@ -95,7 +95,7 @@ describe('Unit Test for LocalTrainingService', () => {
 
         // submit job
         const form: TrialJobApplicationForm = {
-            jobType: 'TRIAL',
+            sequenceId: 0,
             hyperParameters: {
                 value: 'mock hyperparameters',
                 index: 0

--- a/src/nni_manager/training_service/test/paiTrainingService.test.ts
+++ b/src/nni_manager/training_service/test/paiTrainingService.test.ts
@@ -24,6 +24,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
 import * as tmp from 'tmp';
 import * as component from '../../common/component';
+import { TrialJobApplicationForm } from '../../common/trainingService';
 import { cleanupUnitTest, prepareUnitTest } from '../../common/utils';
 import { TrialConfigMetadataKey } from '../common/trialConfigMetadataKey';
 import { PAITrainingService } from '../pai/paiTrainingService';
@@ -85,7 +86,14 @@ describe('Unit Test for PAITrainingService', () => {
         await paiTrainingService.setClusterMetadata(TrialConfigMetadataKey.PAI_CLUSTER_CONFIG, paiCluster);
         await paiTrainingService.setClusterMetadata(TrialConfigMetadataKey.TRIAL_CONFIG, paiTrialConfig);
         try {
-            const trialDetail = await paiTrainingService.submitTrialJob({jobType : 'TRIAL'});
+            const form: TrialJobApplicationForm = {
+                sequenceId: 0,
+                hyperParameters: {
+                    value: '',
+                    index: 0
+                }
+            };
+            const trialDetail = await paiTrainingService.submitTrialJob(form);
             chai.expect(trialDetail.status).to.be.equals('WAITING');
         } catch(error) {
             console.log('Submit job failed:' + error);

--- a/src/nni_manager/training_service/test/remoteMachineTrainingService.test.ts
+++ b/src/nni_manager/training_service/test/remoteMachineTrainingService.test.ts
@@ -99,11 +99,11 @@ describe('Unit Test for RemoteMachineTrainingService', () => {
         await remoteMachineTrainingService.setClusterMetadata(
             TrialConfigMetadataKey.TRIAL_CONFIG, `{"command":"sleep 1h && echo ","codeDir":"${localCodeDir}","gpuNum":1}`);
         const form: TrialJobApplicationForm = {
-                jobType: 'TRIAL',
-                hyperParameters: {
-                    value: 'mock hyperparameters',
-                    index: 0
-                }
+            sequenceId: 0,
+            hyperParameters: {
+                value: 'mock hyperparameters',
+                index: 0
+            }
         };
         const trialJob = await remoteMachineTrainingService.submitTrialJob(form);
 
@@ -137,7 +137,7 @@ describe('Unit Test for RemoteMachineTrainingService', () => {
 
         // submit job
         const form: TrialJobApplicationForm = {
-            jobType: 'TRIAL',
+            sequenceId: 0,
             hyperParameters: {
                 value: 'mock hyperparameters',
                 index: 0

--- a/test/naive_test/resubmit.yml
+++ b/test/naive_test/resubmit.yml
@@ -1,0 +1,28 @@
+authorName: nni
+experimentName: naive-resubmit
+trialConcurrency: 3
+maxExecDuration: 1h
+maxTrialNum: 11  # TODO: does this include resubmitted trials?
+#choice: local, remote
+trainingServicePlatform: local
+searchSpacePath: search_space.json
+#choice: true, false
+useAnnotation: false
+tuner:
+    codeDir: .
+    classFileName: naive_tuner.py
+    className: NaiveTuner
+    classArgs:
+        optimize_mode: maximize
+    gpuNum: 0
+assessor:
+    codeDir: .
+    classFileName: naive_assessor.py
+    className: NaiveAssessor
+    classArgs:
+        optimize_mode: maximize
+    gpuNum: 0
+trial:
+    command: python3 resubmitable_trial.py
+    codeDir: .
+    gpuNum: 0

--- a/test/naive_test/resubmitable_trial.py
+++ b/test/naive_test/resubmitable_trial.py
@@ -1,0 +1,22 @@
+import os
+import time
+
+import nni
+
+params = nni.get_next_parameter()
+print('params:', params)
+x = params['x']
+
+if x == 2:
+    lock_path = os.path.join(os.path.dirname(__file__), 'resubmit.lock')
+    try:
+        open(lock_path, 'x')
+        exit(1)
+    except FileExistsError:
+        pass
+
+for i in range(1, 10):
+    nni.report_intermediate_result(x ** i)
+    time.sleep(0.5)
+
+nni.report_final_result(x ** 10)

--- a/test/resubmit_test.py
+++ b/test/resubmit_test.py
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge,
+# to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import json
+import subprocess
+import sys
+import time
+import traceback
+
+from utils import is_experiment_done, get_experiment_id, get_nni_log_path, read_last_line, remove_files, setup_experiment, detect_port, snooze
+from utils import GREEN, RED, CLEAR, EXPERIMENT_URL
+
+def naive_test():
+    '''run naive integration test'''
+    to_remove = ['tuner_search_space.json', 'tuner_result.txt', 'assessor_result.txt', 'resubmit.lock' ]
+    to_remove = list(map(lambda file: 'naive_test/' + file, to_remove))
+    remove_files(to_remove)
+
+    proc = subprocess.run(['nnictl', 'create', '--config', 'naive_test/resubmit.yml'])
+    assert proc.returncode == 0, '`nnictl create` failed with code %d' % proc.returncode
+
+    print('Spawning trials...')
+
+    nnimanager_log_path = get_nni_log_path(EXPERIMENT_URL)
+    current_trial = 0
+
+    for sec in range(120):
+        time.sleep(1)
+        if sec == 10:
+            resubmit = subprocess.run(['nnictl', 'trial', 'resubmit', '--seq_id', '1'])
+            assert resubmit.returncode == 0, 'resubmit failed with code %d' % resubmit.returncode
+
+        tuner_status = read_last_line('naive_test/tuner_result.txt')
+        assessor_status = read_last_line('naive_test/assessor_result.txt')
+        experiment_status = is_experiment_done(nnimanager_log_path)
+
+        assert tuner_status != 'ERROR', 'Tuner exited with error'
+        assert assessor_status != 'ERROR', 'Assessor exited with error'
+
+        if experiment_status:
+            break
+
+        if tuner_status is not None:
+            for line in open('naive_test/tuner_result.txt'):
+                if line.strip() == 'ERROR':
+                    break
+                trial = int(line.split(' ')[0])
+                if trial > current_trial:
+                    current_trial = trial
+                    print('Trial #%d done' % trial)
+
+    assert experiment_status, 'Failed to finish in 2 min'
+
+    ss1 = json.load(open('naive_test/search_space.json'))
+    ss2 = json.load(open('naive_test/tuner_search_space.json'))
+    assert ss1 == ss2, 'Tuner got wrong search space'
+
+    tuner_result = set(open('naive_test/tuner_result.txt'))
+    expected = set(open('naive_test/expected_tuner_result.txt'))
+    # Trials may complete before NNI gets assessor's result,
+    # so it is possible to have more final result than expected
+    assert tuner_result.issuperset(expected), 'Bad tuner result'
+
+    assessor_result = set(open('naive_test/assessor_result.txt'))
+    expected = set(open('naive_test/expected_assessor_result.txt'))
+    assert assessor_result == expected, 'Bad assessor result'
+
+    subprocess.run(['nnictl', 'stop'])
+
+
+if __name__ == '__main__':
+    installed = (sys.argv[-1] != '--preinstall')
+    setup_experiment(installed)
+    try:
+        naive_test()
+        # TODO: check the output of rest server
+        print(GREEN + 'PASS' + CLEAR)
+    except Exception as error:
+        print(RED + 'FAIL' + CLEAR)
+        print('%r' % error)
+        traceback.print_exc()
+        sys.exit(1)

--- a/tools/nni_cmd/nnictl.py
+++ b/tools/nni_cmd/nnictl.py
@@ -108,6 +108,10 @@ def parse_args():
     parser_trial_codegen.add_argument('id', nargs='?', help='the id of experiment')
     parser_trial_codegen.add_argument('--trial_id', '-T', required=True, dest='trial_id', help='the id of trial to do code generation')
     parser_trial_codegen.set_defaults(func=trial_codegen)
+    parser_trial_resubmit = parser_trial_subparsers.add_parser('resubmit', help='resubmit a trial')
+    parser_trial_resubmit.add_argument('id', nargs='?', help='the id of experiment')
+    parser_trial_resubmit.add_argument('--seq_id', '-S', required=True, dest='seq_id', help='the sequence id of trial')
+    parser_trial_resubmit.set_defaults(func=trial_resubmit)
 
     #parse experiment command
     parser_experiment = subparsers.add_parser('experiment', help='get experiment information')

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -31,7 +31,7 @@ import shutil
 from subprocess import call, check_output
 from nni_annotation import expand_annotations
 from .rest_utils import rest_get, rest_delete, check_rest_server_quick, check_response
-from .url_utils import trial_jobs_url, experiment_url, trial_job_id_url, export_data_url
+from .url_utils import trial_jobs_url, experiment_url, trial_job_id_url, export_data_url, resubmit_url
 from .config_utils import Config, Experiments
 from .constants import NNICTL_HOME_DIR, EXPERIMENT_INFORMATION_FORMAT, EXPERIMENT_DETAIL_FORMAT, \
      EXPERIMENT_MONITOR_INFO, TRIAL_MONITOR_HEAD, TRIAL_MONITOR_CONTENT, TRIAL_MONITOR_TAIL, REST_TIME_OUT
@@ -280,11 +280,29 @@ def trial_kill(args):
         return
     running, _ = check_rest_server_quick(rest_port)
     if running:
-        response = rest_delete(trial_job_id_url(rest_port, args.trial_id), REST_TIME_OUT)
+        response = rest_get(trial_job_id_url(rest_port, args.trial_id), REST_TIME_OUT)
         if response and check_response(response):
             print(response.text)
         else:
             print_error('Kill trial job failed...')
+    else:
+        print_error('Restful server is not running...')
+
+def trial_resubmit(args):
+    '''Resubmit trial'''
+    nni_config = Config(get_config_filename(args))
+    rest_port = nni_config.get_config('restServerPort')
+    rest_pid = nni_config.get_config('restServerPid')
+    if not detect_process(rest_pid):
+        print_error('Experiment is not running...')
+        return
+    running, _ = check_rest_server_quick(rest_port)
+    if running:
+        response = rest_get(resubmit_url(rest_port, args.seq_id), REST_TIME_OUT)
+        if response and check_response(response):
+            print(response.text)
+        else:
+            print_error('Resubmit trial job failed...')
     else:
         print_error('Restful server is not running...')
 

--- a/tools/nni_cmd/url_utils.py
+++ b/tools/nni_cmd/url_utils.py
@@ -35,6 +35,8 @@ CHECK_STATUS_API = '/check-status'
 
 TRIAL_JOBS_API = '/trial-jobs'
 
+RESUBMIT_API = '/resubmit'
+
 EXPORT_DATA_API = '/export-data'
 
 TENSORBOARD_API = '/tensorboard'
@@ -68,6 +70,10 @@ def trial_jobs_url(port):
 def trial_job_id_url(port, job_id):
     '''get trial_jobs with id url'''
     return '{0}:{1}{2}{3}/{4}'.format(BASE_URL, port, API_ROOT_URL, TRIAL_JOBS_API, job_id)
+
+
+def resubmit_url(port, seq_id):
+    return '{0}:{1}{2}{3}/{4}'.format(BASE_URL, port, API_ROOT_URL, RESUBMIT_API, seq_id)
 
 
 def export_data_url(port):


### PR DESCRIPTION
DEMO, DON'T MERGE

# What

This PR proposes a demo implementation of trial resubmitting, from nnictl to NNI manager. WebUI and dispatcher are not covered.

You can run the new integration test `test/resubmit_test.py` manually to get an overall feeling.
It creates experiment defined in `test/naive_test/resubmit.yml`. The second trial (Trial No. 1) of this experiment will fail intentionally. Then the test script will use `nnictl trial resubmit 1` to re-run the trial, and this time it will succeed.

You may notice that resubmitted trials will have same *Sequence ID* (a.k.a. Trial No.) with the original trial.

# How

This PR detachs `sequenceId` from training services. Now it is maintained by NNI manager instead.

Because the *Sequence ID* is decoupled from *Trial ID*, it is no longer required to be unique.
And therefore we can use this ID to record the relationship with original and resubmitted trials.

In fact, the meaning of "Sequence ID" is completely redefined in this PR.
Now it identifies a unit of user's "experiment" (literally, not the term of NNI) instead of a process or a container.

We keep the old name merely to make codes compatible.

# Why

In NNI there are training service, NNI manager, and dispatcher.
We have noticed that each of them has a somewhat unique definition on the term *trial*.

In dispatcher's, or tuning algorithm designer's perspective, a "trial" represents a set of (hyper-)parameters and the related reward. This kind of "trials" are identified by *Parameter ID*.

In training service's, or hardware's perspective, a "trial" is a process and its resources. This is *Trial (Job) ID*.

But we lack a corresponding concept from NNI manager's, or end users' perspective. That's the idea behind the "new" *Sequence ID*.

# Benefits

It makes the UI easy to implement I believe.

If a user uses Sequence ID to determine a trial's role (e.g. to choose a slice of input data), reusing Sequence ID will provide the correct behaviour.

# Drawback

*Host job* is (temporarily) disabled. Seems noboy is using it currently.

This design requires the training service to keep track of an ID during the process of lauching a trial.
This was considered not elegant in our early discussion (a year ago). But I feel it's okay now.

# To Be Discussed

## Glossaries

Now the word *trial* has two meanings:
  1. from user's perspective, a unit of experiment
  2. from hardware's perspective, a process and its resources

This can be misleading. I suggest introducing in a new term to distinguish them.

And `sequeceId` is obviously not a good name.

## REST API

The REST API is an ad-hoc implementation and needs rewrite.

We need to decide whether it should take a *Sequence ID* or a *Trial ID* as parameter.

And `GET` method doesn't seem to be a good choice.

## WebUI

NNI manager will not check trials' status since it's designed to be able to resubmit trials in any state.

So it is WebUI's responsibility to determine whether or not allowing users to resubmit successful trials.