### PR TITLE
[Fixed issue#1218 V2] Show the best metric curve during search progress in webui

### DIFF
--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -343,8 +343,8 @@ class TrialsDetail extends React.Component<TrialsDetailProps, TrialDetailState> 
                     if (tuner !== undefined) {
                         if (tuner.classArgs !== undefined) {
                             if (tuner.classArgs.optimize_mode !== undefined) {
-                                if (tuner.classArgs.optimize_mode !== 'maximize') {
-                                    optimize = 'other';
+                                if (tuner.classArgs.optimize_mode === 'minimize') {
+                                    optimize = 'minimize';
                                 }
                             }
                         }

--- a/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
+++ b/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
@@ -171,10 +171,7 @@ class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState>
                 data: resultList
             }, {
                 type: 'line',
-                // smooth: true,
-                lineStyle: {
-                    color: '#0071BC'
-                },
+                lineStyle: { color: '#FF6600' },
                 data: realDefault
             }]
         };

--- a/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
+++ b/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
@@ -267,18 +267,12 @@ class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState>
 
     render() {
         const { height } = this.props;
-        const { defaultSource, accNodata, isViewBestCurve } = this.state;
+        const { defaultSource, accNodata } = this.state;
         return (
             <div>
                 <div className="default-metric">
                     <div className="position">
-                        {
-                            isViewBestCurve
-                                ?
-                                <span className="bold">Click here to show <span>default curve</span></span>
-                                :
-                                <span className="bold">Click here to show <span>optimization curve</span></span>
-                        }
+                        <span className="bold">optimization curve</span>
                         <Switch defaultChecked={false} onChange={this.loadDefault} />
                     </div>
                 </div>

--- a/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
+++ b/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Switch } from 'antd';
 import ReactEcharts from 'echarts-for-react';
 import { filterByStatus } from '../../static/function';
 import { TableObj, DetailAccurPoint, TooltipForAccuracy } from '../../static/interface';
@@ -10,32 +11,36 @@ interface DefaultPointProps {
     showSource: Array<TableObj>;
     height: number;
     whichGraph: string;
+    optimize: string;
 }
 
 interface DefaultPointState {
     defaultSource: object;
     accNodata: string;
     succeedTrials: number;
+    isViewBestCurve: boolean;
 }
 
 class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState> {
-    public _isMounted = false;
+    public _isDefaultMounted = false;
 
     constructor(props: DefaultPointProps) {
         super(props);
         this.state = {
             defaultSource: {},
             accNodata: '',
-            succeedTrials: 10000000
+            succeedTrials: 10000000,
+            isViewBestCurve: false
         };
     }
 
-    defaultMetric = (succeedSource: Array<TableObj>) => {
+    defaultMetric = (succeedSource: Array<TableObj>, isCurve: boolean) => {
+        const { optimize } = this.props;
         const accSource: Array<DetailAccurPoint> = [];
         const showSource: Array<TableObj> = succeedSource.filter(filterByStatus);
         const lengthOfSource = showSource.length;
         const tooltipDefault = lengthOfSource === 0 ? 'No data' : '';
-        if (this._isMounted === true) {
+        if (this._isDefaultMounted === true) {
             this.setState(() => ({
                 succeedTrials: lengthOfSource,
                 accNodata: tooltipDefault
@@ -55,95 +60,198 @@ class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState>
                     type: 'value',
                 }
             };
-            if (this._isMounted === true) {
+            if (this._isDefaultMounted === true) {
                 this.setState(() => ({
                     defaultSource: nullGraph
                 }));
             }
         } else {
-            const resultList: Array<number | string>[] = [];
+            const resultList: Array<number | object>[] = [];
+            const lineListDefault: Array<number> = [];
             Object.keys(showSource).map(item => {
                 const temp = showSource[item];
                 if (temp.acc !== undefined) {
                     if (temp.acc.default !== undefined) {
                         const searchSpace = temp.description.parameters;
+                        lineListDefault.push(temp.acc.default);
                         accSource.push({
                             acc: temp.acc.default,
                             index: temp.sequenceId,
-                            searchSpace: JSON.stringify(searchSpace)
+                            searchSpace: searchSpace
                         });
                     }
                 }
             });
+            // deal with best metric line
+            const bestCurve: Array<number | object>[] = []; // best curve data source
+            bestCurve.push([0, lineListDefault[0], accSource[0].searchSpace]); // push the first value
+            if (optimize === 'maximize') {
+                for (let i = 1; i < lineListDefault.length; i++) {
+                    const val = lineListDefault[i];
+                    const latest = bestCurve[bestCurve.length - 1][1];
+                    if (val >= latest) {
+                        bestCurve.push([i, val, accSource[i].searchSpace]);
+                    } else {
+                        bestCurve.push([i, latest, accSource[i].searchSpace]);
+                    }
+                }
+            } else {
+                for (let i = 1; i < lineListDefault.length; i++) {
+                    const val = lineListDefault[i];
+                    const latest = bestCurve[bestCurve.length - 1][1];
+                    if (val <= latest) {
+                        bestCurve.push([i, val, accSource[i].searchSpace]);
+                    } else {
+                        bestCurve.push([i, latest, accSource[i].searchSpace]);
+                    }
+                }
+            }
             Object.keys(accSource).map(item => {
                 const items = accSource[item];
-                let temp: Array<number | string>;
-                temp = [items.index, items.acc, JSON.parse(items.searchSpace)];
+                let temp: Array<number | object>;
+                temp = [items.index, items.acc, items.searchSpace];
                 resultList.push(temp);
             });
+            // isViewBestCurve: false show default metric graph
+            // isViewBestCurve: true  show best curve
+            if (isCurve === true) {
+                if (this._isDefaultMounted === true) {
+                    this.setState(() => ({
+                        defaultSource: this.drawBestcurve(bestCurve, resultList)
+                    }));
+                }
+            } else {
+                if (this._isDefaultMounted === true) {
+                    this.setState(() => ({
+                        defaultSource: this.drawDefaultMetric(resultList)
+                    }));
+                }
+            }
+        }
+    }
 
-            const allAcuracy = {
-                grid: {
-                    left: '8%'
-                },
-                tooltip: {
-                    trigger: 'item',
-                    enterable: true,
-                    position: function (point: Array<number>, data: TooltipForAccuracy) {
-                        if (data.data[0] < resultList.length / 2) {
-                            return [point[0], 80];
-                        } else {
-                            return [point[0] - 300, 80];
-                        }
-                    },
-                    formatter: function (data: TooltipForAccuracy) {
-                        const result = '<div class="tooldetailAccuracy">' +
-                            '<div>Trial No.: ' + data.data[0] + '</div>' +
-                            '<div>Default metric: ' + data.data[1] + '</div>' +
-                            '<div>Parameters: ' +
-                            '<pre>' + JSON.stringify(data.data[2], null, 4) + '</pre>' +
-                            '</div>' +
-                            '</div>';
-                        return result;
+    drawBestcurve = (realDefault: Array<number | object>[], resultList: Array<number | object>[]) => {
+        return {
+            grid: {
+                left: '8%'
+            },
+            tooltip: {
+                trigger: 'item',
+                enterable: true,
+                position: function (point: Array<number>, data: TooltipForAccuracy) {
+                    if (data.data[0] < realDefault.length / 2) {
+                        return [point[0], 80];
+                    } else {
+                        return [point[0] - 300, 80];
                     }
                 },
-                xAxis: {
-                    name: 'Trial',
-                    type: 'category',
+                formatter: function (data: TooltipForAccuracy) {
+                    const result = '<div class="tooldetailAccuracy">' +
+                        '<div>Trial No.: ' + data.data[0] + '</div>' +
+                        '<div>Optimization curve: ' + data.data[1] + '</div>' +
+                        '<div>Parameters: ' +
+                        '<pre>' + JSON.stringify(data.data[2], null, 4) + '</pre>' +
+                        '</div>' +
+                        '</div>';
+                    return result;
+                }
+            },
+            xAxis: {
+                name: 'Trial',
+                type: 'category',
+            },
+            yAxis: {
+                name: 'Default metric',
+                type: 'value',
+                scale: true
+            },
+            series: [{
+                symbolSize: 6,
+                type: 'scatter',
+                data: resultList
+            }, {
+                type: 'line',
+                // smooth: true,
+                lineStyle: {
+                    color: '#0071BC'
                 },
-                yAxis: {
-                    name: 'Default metric',
-                    type: 'value',
-                    scale: true
+                data: realDefault
+            }]
+        };
+    }
+
+    drawDefaultMetric = (resultList: Array<number | object>[]) => {
+        return {
+            grid: {
+                left: '8%'
+            },
+            tooltip: {
+                trigger: 'item',
+                enterable: true,
+                position: function (point: Array<number>, data: TooltipForAccuracy) {
+                    if (data.data[0] < resultList.length / 2) {
+                        return [point[0], 80];
+                    } else {
+                        return [point[0] - 300, 80];
+                    }
                 },
-                series: [{
-                    symbolSize: 6,
-                    type: 'scatter',
-                    data: resultList
-                }]
-            };
-            if (this._isMounted === true) {
-                this.setState(() => ({
-                    defaultSource: allAcuracy
-                }));
-            }
+                formatter: function (data: TooltipForAccuracy) {
+                    const result = '<div class="tooldetailAccuracy">' +
+                        '<div>Trial No.: ' + data.data[0] + '</div>' +
+                        '<div>Default metric: ' + data.data[1] + '</div>' +
+                        '<div>Parameters: ' +
+                        '<pre>' + JSON.stringify(data.data[2], null, 4) + '</pre>' +
+                        '</div>' +
+                        '</div>';
+                    return result;
+                }
+            },
+            xAxis: {
+                name: 'Trial',
+                type: 'category',
+            },
+            yAxis: {
+                name: 'Default metric',
+                type: 'value',
+                scale: true
+            },
+            series: [{
+                symbolSize: 6,
+                type: 'scatter',
+                data: resultList
+            }]
+        };
+    }
+
+    loadDefault = (checked: boolean) => {
+        // checked: true show best metric curve
+        const { showSource } = this.props;
+        if (this._isDefaultMounted === true) {
+            this.defaultMetric(showSource, checked);
+            // ** deal with data and then update view layer
+            this.setState(() => ({ isViewBestCurve: checked }));
         }
     }
 
     // update parent component state
     componentWillReceiveProps(nextProps: DefaultPointProps) {
-       
+
         const { whichGraph, showSource } = nextProps;
+        const { isViewBestCurve } = this.state;
         if (whichGraph === '1') {
-            this.defaultMetric(showSource);
+            this.defaultMetric(showSource, isViewBestCurve);
         }
     }
 
     shouldComponentUpdate(nextProps: DefaultPointProps, nextState: DefaultPointState) {
         const { whichGraph } = nextProps;
-        const succTrial = this.state.succeedTrials;
-        const { succeedTrials } = nextState;
         if (whichGraph === '1') {
+            const { succeedTrials, isViewBestCurve } = nextState;
+            const succTrial = this.state.succeedTrials;
+            const isViewBestCurveBefore = this.state.isViewBestCurve;
+            if (isViewBestCurveBefore !== isViewBestCurve) {
+                return true;
+            }
             if (succeedTrials !== succTrial) {
                 return true;
             }
@@ -153,18 +261,30 @@ class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState>
     }
 
     componentDidMount() {
-        this._isMounted = true;
+        this._isDefaultMounted = true;
     }
 
     componentWillUnmount() {
-        this._isMounted = false;
+        this._isDefaultMounted = false;
     }
 
     render() {
         const { height } = this.props;
-        const { defaultSource, accNodata } = this.state;
+        const { defaultSource, accNodata, isViewBestCurve } = this.state;
         return (
             <div>
+                <div className="default-metric">
+                    <div className="position">
+                        {
+                            isViewBestCurve
+                                ?
+                                <span className="bold">Click here to show <span>default curve</span></span>
+                                :
+                                <span className="bold">Click here to show <span>optimization curve</span></span>
+                        }
+                        <Switch defaultChecked={false} onChange={this.loadDefault} />
+                    </div>
+                </div>
                 <ReactEcharts
                     option={defaultSource}
                     style={{
@@ -174,7 +294,6 @@ class DefaultPoint extends React.Component<DefaultPointProps, DefaultPointState>
                     }}
                     theme="my_theme"
                     notMerge={true} // update now
-                    // lazyUpdate={true}
                 />
                 <div className="showMess">{accNodata}</div>
             </div>

--- a/src/webui/src/components/trial-detail/Intermeidate.tsx
+++ b/src/webui/src/components/trial-detail/Intermeidate.tsx
@@ -114,7 +114,7 @@ class Intermediate extends React.Component<IntermediateProps, IntermediateState>
                 },
                 yAxis: {
                     type: 'value',
-                    name: 'metric'
+                    name: 'Metric'
                 },
                 series: trialIntermediate
             };
@@ -136,7 +136,7 @@ class Intermediate extends React.Component<IntermediateProps, IntermediateState>
                 },
                 yAxis: {
                     type: 'value',
-                    name: 'metric'
+                    name: 'Metric'
                 }
             };
             if (this._isMounted) {
@@ -283,9 +283,9 @@ class Intermediate extends React.Component<IntermediateProps, IntermediateState>
                 {/* style in para.scss */}
                 <Row className="meline intermediate">
                     <Col span={8} />
-                    <Col span={3} style={{ height: 34 }}>
+                    <Col span={3} className="inter-filter-btn">
                         {/* filter message */}
-                        <span>filter</span>
+                        <span>Filter</span>
                         <Switch
                             defaultChecked={false}
                             onChange={this.switchTurn}

--- a/src/webui/src/static/interface.ts
+++ b/src/webui/src/static/interface.ts
@@ -59,7 +59,7 @@ interface AccurPoint {
 interface DetailAccurPoint {
     acc: number;
     index: number;
-    searchSpace: string;
+    searchSpace: object;
 }
 
 interface TooltipForIntermediate {
@@ -117,8 +117,13 @@ interface Intermedia {
     hyperPara: object; // each trial hyperpara value
 }
 
+interface ExperimentInfo {
+    platform: string;
+    optimizeMode: string;
+}
+
 export {
     TableObj, Parameters, Experiment, AccurPoint, TrialNumber, TrialJob,
     DetailAccurPoint, TooltipForAccuracy, ParaObj, Dimobj, FinalResult, FinalType,
-    TooltipForIntermediate, SearchSpace, Intermedia
+    TooltipForIntermediate, SearchSpace, Intermedia, ExperimentInfo
 };

--- a/src/webui/src/static/style/para.scss
+++ b/src/webui/src/static/style/para.scss
@@ -36,6 +36,10 @@
     .strange{
         margin-top: 2px;
     }
+    .inter-filter-btn{
+        height: 34px;
+        line-height: 34px;
+    }
     .range{
         .heng{
             margin-left: 6px;

--- a/src/webui/src/static/style/table.scss
+++ b/src/webui/src/static/style/table.scss
@@ -31,14 +31,12 @@
         text-align: center;
         color:#212121;
         font-size: 14px;
-        /* background-color: #f2f2f2; */
     }
     th{
         padding: 2px;
         background-color:white !important;
         font-size: 14px;
         color: #808080;
-        border-bottom: 1px solid #d0d0d0;
         text-align: center;
     }
 
@@ -104,4 +102,10 @@
 /*disable select all checkbox in detail page*/
 .ant-table-selection{
     display: none;
+}
+
+/* fix the border-bottom bug in firefox and edge */
+.ant-table-thead > tr > th .ant-table-column-sorters::before{
+    padding-bottom: 25px;
+    border-bottom: 1px solid #e8e8e8;
 }

--- a/src/webui/src/static/style/trialsDetail.scss
+++ b/src/webui/src/static/style/trialsDetail.scss
@@ -70,3 +70,18 @@
 .allList{
     margin-top: 15px;
 }
+
+.default-metric{
+    width: 90%;
+    text-align: right;
+    margin-top: 15px;
+    .position{
+        color: #333;
+        .bold{
+            span{
+                font-weight: 600;
+                margin-right: 10px;
+            }
+        }
+    }
+}

--- a/src/webui/src/static/style/trialsDetail.scss
+++ b/src/webui/src/static/style/trialsDetail.scss
@@ -78,10 +78,8 @@
     .position{
         color: #333;
         .bold{
-            span{
                 font-weight: 600;
                 margin-right: 10px;
             }
-        }
     }
 }


### PR DESCRIPTION
#1218 
1. when user set `optimize_mode: maximize`, best metric graph is: 
![image](https://user-images.githubusercontent.com/35484733/62199272-c5c53900-b3b5-11e9-99b7-4371f91a6dbe.png)

 and default metric graph is:
![image](https://user-images.githubusercontent.com/35484733/62190065-0ebfc200-b3a3-11e9-8d62-403170bd750f.png)

2. when user set `optimize_mode: minimize`, best metric graph is: 
![image](https://user-images.githubusercontent.com/35484733/62199370-eee5c980-b3b5-11e9-9f01-f08087206bc8.png)

3. the filed `optimize_mode: minimize |  maximize` is from tuner.classArgs.optimize_mode