### PR TITLE
fix bug of hyper-parameter graph when search space has loguniform type

### DIFF
--- a/src/webui/src/components/trial-detail/Para.tsx
+++ b/src/webui/src/components/trial-detail/Para.tsx
@@ -87,13 +87,10 @@ class Para extends React.Component<ParaProps, ParaState> {
                 let temp: Array<number> = [];
                 for (let i = 0; i < dimName.length; i++) {
                     if ('type' in parallelAxis[i]) {
-                        temp.push(
-                            eachTrialParams[item][dimName[i]].toString()
-                        );
+                        temp.push(eachTrialParams[item][dimName[i]].toString());
                     } else {
-                        temp.push(
-                            eachTrialParams[item][dimName[i]]
-                        );
+                        // default metric
+                        temp.push(eachTrialParams[item][dimName[i]]);
                     }
                 }
                 paraYdata.push(temp);
@@ -199,11 +196,18 @@ class Para extends React.Component<ParaProps, ParaState> {
                     break;
                 // support log distribute
                 case 'loguniform':
-                    parallelAxis.push({
-                        dim: i,
-                        name: dimName[i],
-                        type: 'log',
-                    });
+                    if (lenOfDataSource > 1) {
+                        parallelAxis.push({
+                            dim: i,
+                            name: dimName[i],
+                            type: 'log',
+                        });
+                    } else {
+                        parallelAxis.push({
+                            dim: i,
+                            name: dimName[i]
+                        });
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
#1397 
`type: 'log'` doesn't support one line.
so set log distributed when lines' length > 1.