### PR TITLE
Hotfix for /tmp/nni permission problem

### DIFF
--- a/src/nni_manager/training_service/common/util.ts
+++ b/src/nni_manager/training_service/common/util.ts
@@ -46,7 +46,7 @@ export async function validateCodeDir(codeDir: string) : Promise<number> {
     }
     try {
         fileNameValid = await validateFileNameRecursively(codeDir);
-    } catch(error) {
+    } catch (error) {
         throw new Error(`Validate file name error: ${error}`);
     }
 
@@ -55,23 +55,24 @@ export async function validateCodeDir(codeDir: string) : Promise<number> {
                                     + ` please check if it's a valid code dir`;
         throw new Error(errMessage);
     }
-    
-    if(!fileNameValid) {
-        const errMessage: string = `File name in ${codeDir} is not valid, please check file names, only support digit number、alphabet and (.-_) in file name.`; 
-        throw new Error(errMessage);    
+
+    if (!fileNameValid) {
+        const errMessage: string = `File name in ${codeDir} is not valid, please check file names, only support digit number、alphabet and (.-_) in file name.`;
+        throw new Error(errMessage);
     }
 
     return fileCount;
 }
 
-
 /**
  * crete a new directory
  * @param directory
  */
-export async function execMkdir(directory: string): Promise<void> {
+export async function execMkdir(directory: string, share: boolean = false): Promise<void> {
     if (process.platform === 'win32') {
         await cpp.exec(`powershell.exe New-Item -Path ${directory} -ItemType "directory" -Force`);
+    } else if (share) {
+        await cpp.exec(`(umask 0; mkdir -p ${directory})`);
     } else {
         await cpp.exec(`mkdir -p ${directory}`);
     }

--- a/src/nni_manager/training_service/local/gpuScheduler.ts
+++ b/src/nni_manager/training_service/local/gpuScheduler.ts
@@ -97,7 +97,7 @@ class GPUScheduler {
      * used to run in remote machine, and will be deleted after uploaded from local.
      */
     private async runGpuMetricsCollectorScript(): Promise<void> {
-        await execMkdir(this.gpuMetricCollectorScriptFolder);
+        await execMkdir(this.gpuMetricCollectorScriptFolder, true);
         //generate gpu_metrics_collector script
         const gpuMetricsCollectorScriptPath: string =
             path.join(this.gpuMetricCollectorScriptFolder, getScriptName('gpu_metrics_collector'));

--- a/src/nni_manager/training_service/local/localTrainingService.ts
+++ b/src/nni_manager/training_service/local/localTrainingService.ts
@@ -359,8 +359,8 @@ class LocalTrainingService implements TrainingService {
         this.log.info('Stopping local machine training service...');
         this.stopping = true;
         for (const stream of this.jobStreamMap.values()) {
-            stream.end(0)
-            stream.emit('end')
+            stream.end(0);
+            stream.emit('end');
         }
         if (this.gpuScheduler !== undefined) {
             await this.gpuScheduler.stop();
@@ -378,8 +378,8 @@ class LocalTrainingService implements TrainingService {
                     throw new Error(`Could not find stream in trial ${trialJob.id}`);
                 }
                 //Refer https://github.com/Juul/tail-stream/issues/20
-                stream.end(0)
-                stream.emit('end')
+                stream.end(0);
+                stream.emit('end');
                 this.jobStreamMap.delete(trialJob.id);
             }
         }
@@ -494,7 +494,7 @@ class LocalTrainingService implements TrainingService {
                     if (!success) {
                         break;
                     }
-                    
+
                     this.occupyResource(resource);
                     await this.runTrialJob(trialJobId, resource);
                 }


### PR DESCRIPTION
This is a hotfix for issue #1433

When NNI runs in local mode, it will create folder `/tmp/nni` with permission 755 or 775.
If then another user uses the same machine as a remote server, NNI will fail because it does not have the permission to create `/tmp/nni/experiments`.

We may consider move experiment directories to `/tmp/$USER/nni` in next version.