### PR TITLE
fix smac quniform issue

### DIFF
--- a/docs/en_US/Tuner/SmacTuner.md
+++ b/docs/en_US/Tuner/SmacTuner.md
@@ -5,4 +5,4 @@ SMAC Tuner on NNI
 
 [SMAC](https://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf) is based on Sequential Model-Based Optimization (SMBO). It adapts the most prominent previously used model class (Gaussian stochastic process models) and introduces the model class of random forests to SMBO, in order to handle categorical parameters. The SMAC supported by nni is a wrapper on [the SMAC3 github repo](https://github.com/automl/SMAC3).
 
-Note that SMAC on nni only supports a subset of the types in [search space spec](../Tutorial/SearchSpaceSpec.md), including `choice`, `randint`, `uniform`, `loguniform`, `quniform(q=1)`.
+Note that SMAC on nni only supports a subset of the types in [search space spec](../Tutorial/SearchSpaceSpec.md), including `choice`, `randint`, `uniform`, `loguniform`, `quniform`.

--- a/docs/zh_CN/Tuner/SmacTuner.md
+++ b/docs/zh_CN/Tuner/SmacTuner.md
@@ -4,4 +4,4 @@
 
 [SMAC](https://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf) 基于 Sequential Model-Based Optimization (SMBO). 它利用使用过的结果好的模型（高斯随机过程模型），并将随机森林引入到 SMBO 中，来处理分类参数。 NNI 的 SMAC 通过包装 [SMAC3](https://github.com/automl/SMAC3) 来支持。
 
-NNI 中的 SMAC 只支持部分类型的[搜索空间](../Tutorial/SearchSpaceSpec.md)，包括`choice`, `randint`, `uniform`, `loguniform`, `quniform(q=1)`。
+NNI 中的 SMAC 只支持部分类型的[搜索空间](../Tutorial/SearchSpaceSpec.md)，包括`choice`, `randint`, `uniform`, `loguniform`, `quniform`。

--- a/src/sdk/pynni/nni/smac_tuner/convert_ss_to_scenario.py
+++ b/src/sdk/pynni/nni/smac_tuner/convert_ss_to_scenario.py
@@ -105,13 +105,13 @@ def generate_pcs(nni_search_space_content):
                                 key,
                                 json.dumps(search_space[key]['_value']),
                                 json.dumps(search_space[key]['_value'][0])))
-                        elif search_space[key]['_type'] == 'quniform' \
-                            and search_space[key]['_value'][2] == 1:
-                            pcs_fd.write('%s integer [%d, %d] [%d]\n' % (
+                        elif search_space[key]['_type'] == 'quniform':
+                            low, high, q = search_space[key]['_value'][0:3]
+                            vals = np.clip(np.arange(np.round(low/q), np.round(high/q)+1) * q, low, high)
+                            pcs_fd.write('%s ordinal {%s} [%s]\n' % (
                                 key,
-                                search_space[key]['_value'][0],
-                                search_space[key]['_value'][1],
-                                search_space[key]['_value'][0]))
+                                json.dumps(vals)[1:-1],
+                                json.dumps(vals[0])))
                         else:
                             raise RuntimeError('unsupported _type %s' % search_space[key]['_type'])
                     except:

--- a/src/sdk/pynni/nni/smac_tuner/convert_ss_to_scenario.py
+++ b/src/sdk/pynni/nni/smac_tuner/convert_ss_to_scenario.py
@@ -107,7 +107,7 @@ def generate_pcs(nni_search_space_content):
                                 json.dumps(search_space[key]['_value'][0])))
                         elif search_space[key]['_type'] == 'quniform':
                             low, high, q = search_space[key]['_value'][0:3]
-                            vals = np.clip(np.arange(np.round(low/q), np.round(high/q)+1) * q, low, high)
+                            vals = np.clip(np.arange(np.round(low/q), np.round(high/q)+1) * q, low, high).tolist()
                             pcs_fd.write('%s ordinal {%s} [%s]\n' % (
                                 key,
                                 json.dumps(vals)[1:-1],


### PR DESCRIPTION
Previous version: SMAC in nni supports quniform only when q=1;
After : use "ordinal" type in SMAC to parse quniform
reference: 
- https://automl.github.io/SMAC3/dev/options.html
- https://www.cs.ubc.ca/labs/beta/Projects/SMAC/v2.10.02/manual.pdf 