### PR TITLE
Refactor get_current_parameter to avoid using trial._params

### DIFF
--- a/src/sdk/pynni/nni/nas_utils.py
+++ b/src/sdk/pynni/nni/nas_utils.py
@@ -32,7 +32,7 @@ def classic_mode(
     '''Execute the chosen function and inputs directly.
     In this mode, the trial code is only running the chosen subgraph (i.e., the chosen ops and inputs),
     without touching the full model graph.'''
-    if trial._params is None:
+    if trial.get_current_parameter() is None:
         trial.get_next_parameter()
     mutable_block = trial.get_current_parameter(mutable_id)
     chosen_layer = mutable_block[mutable_layer_id]["chosen_layer"]
@@ -118,7 +118,7 @@ def oneshot_mode(
     The difference is that oneshot mode does not receive subgraph.
     Instead, it uses dropout to randomly dropout inputs and ops.'''
     # NNI requires to get_next_parameter before report a result. But the parameter will not be used in this mode
-    if trial._params is None:
+    if trial.get_current_parameter() is None:
         trial.get_next_parameter()
     optional_inputs = list(optional_inputs.values())
     inputs_num = len(optional_inputs)

--- a/src/sdk/pynni/nni/smartparam.py
+++ b/src/sdk/pynni/nni/smartparam.py
@@ -189,6 +189,6 @@ else:
         raise RuntimeError('Unrecognized mode: %s' % mode)
 
     def _get_param(key):
-        if trial._params is None:
+        if trial.get_current_parameter() is None:
             trial.get_next_parameter()
         return trial.get_current_parameter(key)

--- a/src/sdk/pynni/nni/trial.py
+++ b/src/sdk/pynni/nni/trial.py
@@ -50,10 +50,12 @@ def get_next_parameter():
         return None
     return _params['parameters']
 
-def get_current_parameter(tag):
+def get_current_parameter(tag=None):
     global _params
     if _params is None:
         return None
+    if tag is None:
+        return _params['parameters']
     return _params['parameters'][tag]
 
 def get_experiment_id():


### PR DESCRIPTION
Currently, there are a few usage of `trial._params`, which I believe is a bad practice, since the underline is a sign of "don't use it outside this module".

By making tag an optional argument, I can retrieve `trial._params` by using `get_current_parameter`. The main reason I want to do this, instead of refactor it into `has_current_parameter` is that, I'm currently implementing something in NAS that needs to retrieve current parameter multiple times. #1432 