### PR TITLE
Print error detail on schema validation failure

### DIFF
--- a/src/webui/src/static/const.ts
+++ b/src/webui/src/static/const.ts
@@ -1,5 +1,4 @@
-const MANAGER_IP = `http://10.170.69.50:8080/api/v1/nni`;
-// const MANAGER_IP = `/api/v1/nni`;
+const MANAGER_IP = `/api/v1/nni`;
 const DOWNLOAD_IP = `/logs`;
 const trialJobStatus = [
     'UNKNOWN',

--- a/src/webui/src/static/const.ts
+++ b/src/webui/src/static/const.ts
@@ -1,4 +1,5 @@
-const MANAGER_IP = `/api/v1/nni`;
+const MANAGER_IP = `http://10.170.69.50:8080/api/v1/nni`;
+// const MANAGER_IP = `/api/v1/nni`;
 const DOWNLOAD_IP = `/logs`;
 const trialJobStatus = [
     'UNKNOWN',

--- a/tools/nni_cmd/launcher_utils.py
+++ b/tools/nni_cmd/launcher_utils.py
@@ -198,10 +198,7 @@ def validate_common_content(experiment_config):
                     Schema({**separate_schema_dict[separate_key]['customized']}).validate(experiment_config[separate_key])
     except SchemaError as error:
         print_error('Your config file is not correct, please check your config file content!')
-        if error.__str__().__contains__('Wrong key'):
-            print_error(' '.join(error.__str__().split()[:3]))
-        else:
-            print_error(error)
+        print_error(error.code)
         exit(1)
 
     #set default value


### PR DESCRIPTION
When the schema is wrong, nnictl prints nothing useful. Basically, this is due to the mishandling of the error information generated by `schema`.

Before this change, it would look like this:

```
INFO: expand searchSpacePath: search_space.json to /home/xxx/projects/nni/examples/trials/mnist/search_space.json 
INFO: expand codeDir: . to /home/xxx/projects/nni/examples/trials/mnist/. 
ERROR: Your config file is not correct, please check your config file content!
ERROR: Key 'trial' error:
```

After this change, it now looks like this:

```
INFO: expand searchSpacePath: search_space.json to /home/xxx/projects/nni/examples/trials/mnist/search_space.json 
INFO: expand codeDir: . to /home/xxx/projects/nni/examples/trials/mnist/. 
ERROR: Your config file is not correct, please check your config file content!
ERROR: Key 'trial' error:
Wrong key 'cpucpu' in {'command': 'python3 mnist.py', 'codeDir': '/home/xxx/projects/nni/examples/trials/mnist/.', 'gpuNum': 0, 'cpucpu': 1}
```
