### PR TITLE
Rewrite search space documentation for choice

### DIFF
--- a/docs/en_US/TrainingService/LocalMode.md
+++ b/docs/en_US/TrainingService/LocalMode.md
@@ -56,7 +56,7 @@ The hyper-parameters used in `Step 1.2 - Get predefined parameters` is defined i
     "learning_rate":{"_type":"uniform","_value":[0.0001, 0.1]}
 }
 ```
-Refer to [SearchSpaceSpec.md](../Tutorial/SearchSpaceSpec.md) to learn more about search space.
+Refer to [define search space](../Tutorial/SearchSpaceSpec.md) to learn more about search space.
 
 >Step 3 - Define Experiment
 

--- a/docs/en_US/Tutorial/SearchSpaceSpec.md
+++ b/docs/en_US/Tutorial/SearchSpaceSpec.md
@@ -27,9 +27,8 @@ All types of sampling strategies and their parameter are listed here:
 
 * `{"_type": "choice", "_value": options}`
 
-  * Which means the variable's value is one of the options. Here 'options' should be a list. Each element of options is a number of string. It could also be a nested sub-search-space, this sub-search-space takes effect only when the corresponding element is chosen. The variables in this sub-search-space could be seen as conditional variables.
-
-  * An simple [example](https://github.com/microsoft/nni/tree/master/examples/trials/mnist-nested-search-space/search_space.json) of [nested] search space definition. If an element in the options list is a dict, it is a sub-search-space, and for our built-in tuners you have to add a key `_name` in this dict, which helps you to identify which element is chosen. Accordingly, here is a [sample](https://github.com/microsoft/nni/tree/master/examples/trials/mnist-nested-search-space/sample.json) which users can get from nni with nested search space definition. Tuners which support nested search space is as follows:
+  * Which means the variable's value is one of the options. Here `options` should be a list of numbers or a list of strings. Using arbitrary objects as members of this list (like sublists, a mixture of numbers and strings, or null values) should work in most cases, but may trigger undefined behaviors.
+  * `options` could also be a nested sub-search-space, this sub-search-space takes effect only when the corresponding element is chosen. The variables in this sub-search-space could be seen as conditional variables. Here is an simple [example of nested search space definition](https://github.com/microsoft/nni/tree/master/examples/trials/mnist-nested-search-space/search_space.json). If an element in the options list is a dict, it is a sub-search-space, and for our built-in tuners you have to add a key `_name` in this dict, which helps you to identify which element is chosen. Accordingly, here is a [sample](https://github.com/microsoft/nni/tree/master/examples/trials/mnist-nested-search-space/sample.json) which users can get from nni with nested search space definition. Tuners which support nested search space are as follows:
 
     - Random Search 
     - TPE


### PR DESCRIPTION
#1475 

According to @lvybriage , there are still some problems and ambiguities when displaying on hyper-parameter page if we allow users to define a search space of choice like `[null, "128", 256, 512]`. The quick yet elegant solution is to add a "disclaimer" in the documentation that a search space like this might cause undefined behaviors.

This PR also refines the docs of that part by fixing a few issues and typos.