### PR TITLE
add search space key as table additional column

### DIFF
--- a/src/webui/src/components/Modal/Compare.tsx
+++ b/src/webui/src/components/Modal/Compare.tsx
@@ -26,11 +26,12 @@ class Compare extends React.Component<CompareProps, {}> {
         const idsList: Array<string> = [];
         Object.keys(compareRows).map(item => {
             const temp = compareRows[item];
+            const trial = TRIALS.getTrial(temp.id);
             trialIntermediate.push({
                 name: temp.id,
-                data: temp.description.intermediate,
+                data: trial.description.intermediate,
                 type: 'line',
-                hyperPara: temp.description.parameters
+                hyperPara: trial.description.parameters
             });
             idsList.push(temp.id);
         });
@@ -208,7 +209,7 @@ class Compare extends React.Component<CompareProps, {}> {
             >
                 <Row className="compare-intermediate">
                     {this.intermediate()}
-                    <Row className="compare-yAxis"># Intermediate</Row>
+                    <Row className="compare-yAxis"># Intermediate result</Row>
                 </Row>
                 <Row>{this.initColumn()}</Row>
             </Modal>

--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -117,7 +117,6 @@ class TrialsDetail extends React.Component<TrialsDetailProps, TrialDetailState> 
         const { columnList, changeColumn } = this.props;
         const source = TRIALS.filter(this.state.searchFilter);
         const trialIds = TRIALS.filter(this.state.searchFilter).map(trial => trial.id);
-
         return (
             <div>
                 <div className="trial" id="tabsty">

--- a/src/webui/src/components/overview/Progress.tsx
+++ b/src/webui/src/components/overview/Progress.tsx
@@ -86,7 +86,7 @@ class Progressed extends React.Component<ProgressProps, ProgressState> {
         const percent = (EXPERIMENT.profile.execDuration / EXPERIMENT.profile.params.maxExecDuration) * 100;
         const remaining = convertTime(EXPERIMENT.profile.params.maxExecDuration - EXPERIMENT.profile.execDuration);
         const maxDuration = convertTime(EXPERIMENT.profile.params.maxExecDuration);
-        const maxTrialNum = convertTime(EXPERIMENT.profile.params.maxTrialNum);
+        const maxTrialNum = EXPERIMENT.profile.params.maxTrialNum;
         const execDuration = convertTime(EXPERIMENT.profile.execDuration);
 
         let errorContent;

--- a/src/webui/src/components/public-child/OpenRow.tsx
+++ b/src/webui/src/components/public-child/OpenRow.tsx
@@ -59,7 +59,6 @@ class OpenRow extends React.Component<OpenRowProps, OpenRowState> {
         const { isShowFormatModal, formatStr } = this.state;
         const trialId = this.props.trialId;
         const trial = TRIALS.getTrial(trialId);
-        let isClick = false;
         const trialLink: string = `${MANAGER_IP}/trial-jobs/${trialId}`;
         const logPathRow = trial.info.logPath || 'This trial\'s log path is not available.';
         const multiProgress = trial.info.hyperParameters === undefined ? 0 : trial.info.hyperParameters.length;
@@ -76,7 +75,7 @@ class OpenRow extends React.Component<OpenRowProps, OpenRowState> {
                                     <br />
                                     For the entire parameter set, please refer to the following "
                                     <a href={trialLink} target="_blank">{trialLink}</a>".
-                                    <br/>
+                                    <br />
                                     Current Phase: {multiProgress}.
                                 </Row>
                                 :
@@ -87,18 +86,12 @@ class OpenRow extends React.Component<OpenRowProps, OpenRowState> {
                                 ?
                                 <Row id="description">
                                     <Row className="bgHyper">
-                                        {
-                                            isClick
-                                                ?
-                                                <pre>{JSON.stringify(trial.info.hyperParameters, null, 4)}</pre>
-                                                :
-                                                <JSONTree
-                                                    hideRoot={true}
-                                                    shouldExpandNode={() => true}  // default expandNode
-                                                    getItemString={() => (<span />)}  // remove the {} items
-                                                    data={trial.info.hyperParameters}
-                                                />
-                                        }
+                                        <JSONTree
+                                            hideRoot={true}
+                                            shouldExpandNode={() => true}  // default expandNode
+                                            getItemString={() => (<span />)}  // remove the {} items
+                                            data={trial.description.parameters}
+                                        />
                                     </Row>
                                     <Row className="copy">
                                         <Button

--- a/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
+++ b/src/webui/src/components/trial-detail/DefaultMetricPoint.tsx
@@ -124,7 +124,7 @@ function generateScatterSeries(trials: Trial[]) {
     const data = trials.map(trial => [
         trial.sequenceId,
         trial.accuracy,
-        trial.info.hyperParameters,
+        trial.description.parameters,
     ]);
     return {
         symbolSize: 6,

--- a/src/webui/src/components/trial-detail/Intermediate.tsx
+++ b/src/webui/src/components/trial-detail/Intermediate.tsx
@@ -272,7 +272,7 @@ class Intermediate extends React.Component<IntermediateProps, IntermediateState>
                         isFilter
                             ?
                             <span>
-                                <span className="filter-x"># Intermediate</span>
+                                <span className="filter-x"># Intermediate result</span>
                                 <input
                                     // placeholder="point"
                                     ref={input => this.pointInput = input}
@@ -307,7 +307,7 @@ class Intermediate extends React.Component<IntermediateProps, IntermediateState>
                         style={{ width: '100%', height: 418, margin: '0 auto' }}
                         notMerge={true} // update now
                     />
-                    <div className="yAxis"># Intermediate</div>
+                    <div className="yAxis"># Intermediate result</div>
                 </Row>
             </div>
         );

--- a/src/webui/src/components/trial-detail/Para.tsx
+++ b/src/webui/src/components/trial-detail/Para.tsx
@@ -326,7 +326,7 @@ class Para extends React.Component<ParaProps, ParaState> {
         } else {
             Object.keys(dataSource).map(item => {
                 const trial = dataSource[item];
-                eachTrialParams.push(trial.description.parameters.error || '');
+                eachTrialParams.push(trial.description.parameters || '');
                 // may be a succeed trial hasn't final result
                 // all detail page may be break down if havn't if
                 if (trial.acc !== undefined) {

--- a/src/webui/src/components/trial-detail/TableList.tsx
+++ b/src/webui/src/components/trial-detail/TableList.tsx
@@ -174,7 +174,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
                 case 'Status':
                 case 'Operation':
                 case 'Default':
-                case 'Intermediate count':
+                case 'Intermediate result':
                     break;
                 default:
                     finalKeys.push(checkedValues[m]);
@@ -237,7 +237,6 @@ class TableList extends React.Component<TableListProps, TableListState> {
     render() {
         const { pageSize, columnList } = this.props;
         const tableSource: Array<TableRecord> = JSON.parse(JSON.stringify(this.props.tableSource));
-        console.log('rerender table', tableSource);
         const { intermediateOption, modalVisible, isShowColumn,
             selectRows, isShowCompareModal, selectedRowKeys, intermediateOtherKeys } = this.state;
         const rowSelection = {
@@ -286,7 +285,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
                 case 'Status':
                     showColumn.push(StatusColumnConfig);
                     break;
-                case 'Intermediate count':
+                case 'Intermediate result':
                     showColumn.push(IntermediateCountColumnConfig);
                     break;
                 case 'Default':
@@ -328,26 +327,6 @@ class TableList extends React.Component<TableListProps, TableListState> {
                                         </Button>
                                     </Popconfirm>
                                 </Row>
-                            );
-                        },
-                    });
-                    break;
-
-                case 'Intermediate result':
-                    showColumn.push({
-                        title: 'Intermediate result',
-                        dataIndex: 'intermediate',
-                        key: 'intermediate',
-                        width: '16%',
-                        render: (text: string, record: TableRecord) => {
-                            return (
-                                <Button
-                                    type="primary"
-                                    className="tableButton"
-                                    onClick={this.showIntermediateModal.bind(this, record.id)}
-                                >
-                                    Intermediate
-                                </Button>
                             );
                         },
                     });
@@ -495,7 +474,7 @@ const StatusColumnConfig: ColumnProps<TableRecord> = {
 };
 
 const IntermediateCountColumnConfig: ColumnProps<TableRecord> = {
-    title: 'Intermediate count',
+    title: 'Intermediate result',
     dataIndex: 'intermediateCount',
     width: 86,
     render: (text, record) => (

--- a/src/webui/src/static/const.ts
+++ b/src/webui/src/static/const.ts
@@ -3,6 +3,7 @@ const METRIC_GROUP_UPDATE_THRESHOLD = 100;
 const METRIC_GROUP_UPDATE_SIZE = 20;
 
 const MANAGER_IP = `/api/v1/nni`;
+// const MANAGER_IP = `/api/v1/nni`;
 const DOWNLOAD_IP = `/logs`;
 const trialJobStatus = [
     'UNKNOWN',
@@ -38,11 +39,11 @@ const COLUMN_INDEX = [
         index: 2
     },
     {
-        name: 'StartTime',
+        name: 'Start Time',
         index: 3
     },
     {
-        name: 'EndTime',
+        name: 'End Time',
         index: 4
     },
     {
@@ -54,7 +55,7 @@ const COLUMN_INDEX = [
         index: 6
     },
     {
-        name: 'Intermediate count',
+        name: 'Intermediate result',
         index: 7
     },
     {
@@ -70,7 +71,7 @@ const COLUMN_INDEX = [
 const COLUMN = ['Trial No.', 'ID', 'Duration', 'Status', 'Default', 'Operation'];
 // all choice column !dictory final
 const COLUMNPro = ['Trial No.', 'ID', 'Start Time', 'End Time', 'Duration', 'Status',
-'Intermediate count', 'Default', 'Operation'];
+'Intermediate result', 'Default', 'Operation'];
 export {
     MANAGER_IP, DOWNLOAD_IP, trialJobStatus, COLUMNPro,
     CONTROLTYPE, MONACO, COLUMN, COLUMN_INDEX, DRAWEROPTION,

--- a/src/webui/src/static/const.ts
+++ b/src/webui/src/static/const.ts
@@ -3,7 +3,6 @@ const METRIC_GROUP_UPDATE_THRESHOLD = 100;
 const METRIC_GROUP_UPDATE_SIZE = 20;
 
 const MANAGER_IP = `/api/v1/nni`;
-// const MANAGER_IP = `/api/v1/nni`;
 const DOWNLOAD_IP = `/logs`;
 const trialJobStatus = [
     'UNKNOWN',


### PR DESCRIPTION
1.  the column `Intermediate count` rename `Intermediate result`
2.  add `search space` column options

![image](https://user-images.githubusercontent.com/35484733/65740237-97947900-e11a-11e9-8af7-9a6f8bab56f8.png)

3. add scroll-x with many columns

![image](https://user-images.githubusercontent.com/35484733/65740245-9fecb400-e11a-11e9-9593-cc0cab945a0b.png)

4. This PR also fix hyper parameter issue.
 fixed the `Parameters` style when hover in the default metric graph.
before:
![image](https://user-images.githubusercontent.com/35484733/65740036-f6a5be00-e119-11e9-9e92-b5f25805fcb4.png)

update:
![image](https://user-images.githubusercontent.com/35484733/65740017-ebeb2900-e119-11e9-8424-897f6c2b7aa3.png)

5. 同4， `Parameters` 
before:
![image](https://user-images.githubusercontent.com/35484733/65740637-06be9d00-e11c-11e9-96ab-814acbe12504.png)

update:
![image](https://user-images.githubusercontent.com/35484733/65739910-94e55400-e119-11e9-860f-2bf43cf2c240.png)