### PR TITLE
ignore dot git folder

### DIFF
--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -370,9 +370,9 @@ function countFilesRecursively(directory: string, timeoutMilliSeconds?: number):
     let fileCount: number = -1;
     let cmd: string;
     if(process.platform === "win32") {
-        cmd = `powershell "Get-ChildItem -Path ${directory} -Recurse -File | Measure-Object | %{$_.Count}"`
+        cmd = `powershell "Get-ChildItem -Path ${directory} -Recurse -File | ? { $_.PsIsContainer -and $_.FullName -notmatch '.git' } |  Measure-Object | %{$_.Count}"`;
     } else {
-        cmd = `find ${directory} -type f | wc -l`;
+        cmd = `find ${directory} -type f ! -path "*/.git/*" | wc -l`;
     }
     cpp.exec(cmd).then((result) => {
         if(result.stdout && parseInt(result.stdout)) {

--- a/src/nni_manager/training_service/common/util.ts
+++ b/src/nni_manager/training_service/common/util.ts
@@ -193,6 +193,7 @@ export async function tarAdd(tarPath: string, sourcePath: string): Promise<void>
             `import os`,
             `import tarfile`,
             String.Format(`tar = tarfile.open("{0}","w:gz")\r\nfor root,dir,files in os.walk("{1}"):`, tarFilePath, sourceFilePath),
+            `    dir[:] = [d for d in dirs if d != '.git']`,
             `    for file in files:`,
             `        fullpath = os.path.join(root,file)`,
             `        tar.add(fullpath, arcname=file)`,


### PR DESCRIPTION
when doing setup for remote nni, counting .git folder may make total number of folder larger than 1,000(nni file transfer threshold). generally we don't need to include .git folder for remote execution for code. so I excluded .git folder when counting and zipping files. 