### PR TITLE
Use cmd.exe to avoid name conflicts of cmd

### DIFF
--- a/src/nni_manager/common/utils.ts
+++ b/src/nni_manager/common/utils.ts
@@ -456,10 +456,10 @@ function getTunerProc(command: string, stdio: StdioOptions, newCwd: string, newE
 /**
  * judge whether the process is alive
  */
-async function isAlive(pid:any): Promise<boolean> {
+async function isAlive(pid: any): Promise<boolean> {
     let deferred : Deferred<boolean> = new Deferred<boolean>();
     let alive: boolean = false;
-    if(process.platform ==='win32'){
+    if (process.platform === 'win32') {
         try {
             const str = cp.execSync(`powershell.exe Get-Process -Id ${pid} -ErrorAction SilentlyContinue`).toString();
             if (str) {
@@ -469,7 +469,7 @@ async function isAlive(pid:any): Promise<boolean> {
         catch (error) {
         }
     }
-    else{
+    else {
         try {
             await cpp.exec(`kill -0 ${pid}`);
             alive = true;
@@ -484,11 +484,11 @@ async function isAlive(pid:any): Promise<boolean> {
 /**
  * kill process
  */
-async function killPid(pid:any): Promise<void> {
+async function killPid(pid: any): Promise<void> {
     let deferred : Deferred<void> = new Deferred<void>();
     try {
         if (process.platform === "win32") {
-            await cpp.exec(`cmd /c taskkill /PID ${pid} /F`);
+            await cpp.exec(`cmd.exe /c taskkill /PID ${pid} /F`);
         }
         else{
             await cpp.exec(`kill -9 ${pid}`);

--- a/src/nni_manager/training_service/common/util.ts
+++ b/src/nni_manager/training_service/common/util.ts
@@ -156,7 +156,7 @@ export async function execRemove(directory: string): Promise<void> {
  */
 export async function execKill(pid: string): Promise<void> {
     if (process.platform === 'win32') {
-        await cpp.exec(`cmd /c taskkill /PID ${pid} /T /F`);
+        await cpp.exec(`cmd.exe /c taskkill /PID ${pid} /T /F`);
     } else {
         await cpp.exec(`pkill -P ${pid}`);
     }

--- a/src/nni_manager/training_service/local/localTrainingService.ts
+++ b/src/nni_manager/training_service/local/localTrainingService.ts
@@ -490,7 +490,7 @@ class LocalTrainingService implements TrainingService {
         const script: string[] = [];
         if (process.platform === 'win32') {
             script.push(
-                `cmd /c ${localTrialConfig.command} 2>${path.join(workingDirectory, 'stderr')}`,
+                `cmd.exe /c ${localTrialConfig.command} 2>${path.join(workingDirectory, 'stderr')}`,
                 `$NOW_DATE = [int64](([datetime]::UtcNow)-(get-date "1/1/1970")).TotalSeconds`,
                 `$NOW_DATE = "$NOW_DATE" + (Get-Date -Format fff).ToString()`,
                 `Write $LASTEXITCODE " " $NOW_DATE  | Out-File ${path.join(workingDirectory, '.nni', 'state')} -NoNewline -encoding utf8`);


### PR DESCRIPTION
Fix #1367. Trials fail because there is a name called `cmd` produced by Anaconda in environment path. Use `cmd.exe` instead.