### PR TITLE
example mnist was not compatible with tersorflowv2

### DIFF
--- a/examples/trials/mnist/mnist.py
+++ b/examples/trials/mnist/mnist.py
@@ -6,7 +6,8 @@ import math
 import tempfile
 import time
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 from tensorflow.examples.tutorials.mnist import input_data
 
 import nni


### PR DESCRIPTION
replace line 9  with tensorflow.compat.v1,the cause  was not able to  compatible with tersorflowv2