### PR TITLE
Allow serializing NaN in SDK

### DIFF
--- a/src/sdk/pynni/nni/msg_dispatcher.py
+++ b/src/sdk/pynni/nni/msg_dispatcher.py
@@ -79,7 +79,7 @@ def _pack_parameter(parameter_id, params, customized=False, trial_job_id=None, p
         ret['parameter_index'] = parameter_index
     else:
         ret['parameter_index'] = 0
-    return json_tricks.dumps(ret)
+    return json_tricks.dumps(ret, allow_nan=True)
 
 
 class MsgDispatcher(MsgDispatcherBase):

--- a/src/sdk/pynni/nni/platform/local.py
+++ b/src/sdk/pynni/nni/platform/local.py
@@ -52,7 +52,7 @@ def request_next_parameter():
         'type': 'REQUEST_PARAMETER',
         'sequence': 0,
         'parameter_index': _param_index
-    })
+    }, allow_nan=True)
     send_metric(metric)
 
 def get_next_parameter():

--- a/src/sdk/pynni/nni/trial.py
+++ b/src/sdk/pynni/nni/trial.py
@@ -82,7 +82,7 @@ def report_intermediate_result(metric):
         'type': 'PERIODICAL',
         'sequence': _intermediate_seq,
         'value': metric
-    })
+    }, allow_nan=True)
     _intermediate_seq += 1
     platform.send_metric(metric)
 
@@ -98,5 +98,5 @@ def report_final_result(metric):
         'type': 'FINAL',
         'sequence': 0,
         'value': metric
-    })
+    }, allow_nan=True)
     platform.send_metric(metric)


### PR DESCRIPTION
I found `json_tricks` has a parameter `allow_nan`, which can hopefully solve issue #1589 .
But this may introduce other problems, because NaN is not part of JSON standard and cannot be deserialized in major browsers or Node.js.

Update: Maybe we can use [JSON5](https://www.npmjs.com/package/json5) in TypeScript side. However our JSONs can be really large so we should assess its performance before using it.

The pipeline failed for "cannot find module sqlite3". Seems we have some version problems again. @chicm-ms 