### PR TITLE
support trial config deduplication in SMAC tuner

### DIFF
--- a/docs/en_US/Tuner/BuiltinTuner.md
+++ b/docs/en_US/Tuner/BuiltinTuner.md
@@ -160,6 +160,7 @@ Similar to TPE, SMAC is also a black-box tuner which can be tried in various sce
 **Requirement of classArgs**
 
 * **optimize_mode** (*maximize or minimize, optional, default = maximize*) - If 'maximize', the tuner will target to maximize metrics. If 'minimize', the tuner will target to minimize metrics.
+* **config_dedup** (*True or False, optional, default = False*) - If True, the tuner will not generate a configuration that has been already generated. If False, a configuration may be generated twice, but it is rare for relatively large search space.
 
 **Usage example**
 

--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -231,7 +231,9 @@ class SMACTuner(Tuner):
             return self.param_postprocess(init_challenger.get_dictionary())
         else:
             challengers = self.smbo_solver.nni_smac_request_challengers()
+            challengers_empty = True
             for challenger in challengers:
+                challengers_empty = False
                 if self.dedup:
                     match = [v for k, v in self.total_data.items() \
                              if v.get_dictionary() == challenger.get_dictionary()]
@@ -239,7 +241,7 @@ class SMACTuner(Tuner):
                         continue
                 self.total_data[parameter_id] = challenger
                 return self.param_postprocess(challenger.get_dictionary())
-            assert self.dedup is True
+            assert challengers_empty is False, 'The case that challengers is empty is not handled.'
             self.logger.info('In generate_parameters: No more new parameters.')
             raise nni.NoMoreTrialError('No more new parameters.')
 

--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -24,6 +24,8 @@ from nni.utils import OptimizeMode, extract_scalar_reward
 
 from .convert_ss_to_scenario import generate_scenario
 
+logger = logging.getLogger('smac_AutoML')
+
 class SMACTuner(Tuner):
     """
     This is a wrapper of [SMAC](https://github.com/automl/SMAC3) following NNI tuner interface.
@@ -37,8 +39,7 @@ class SMACTuner(Tuner):
         optimize_mode : str
             Optimize mode, 'maximize' or 'minimize', by default 'maximize'
         """
-        self.logger = logging.getLogger(
-            self.__module__ + "." + self.__class__.__name__)
+        self.logger = logger
         self.optimize_mode = OptimizeMode(optimize_mode)
         self.total_data = {}
         self.optimizer = None
@@ -129,7 +130,7 @@ class SMACTuner(Tuner):
         search_space : dict
             The format could be referred to search space spec (https://nni.readthedocs.io/en/latest/Tutorial/SearchSpaceSpec.html).
         """
-
+        self.logger.info('update search space in SMAC.')
         if not self.update_ss_done:
             self.categorical_dict = generate_scenario(search_space)
             if self.categorical_dict is None:

--- a/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
+++ b/src/sdk/pynni/nni/smac_tuner/smac_tuner.py
@@ -38,6 +38,9 @@ class SMACTuner(Tuner):
         ----------
         optimize_mode : str
             Optimize mode, 'maximize' or 'minimize', by default 'maximize'
+        config_dedup : bool
+            If True, the tuner will not generate a configuration that has been already generated.
+            If False, a configuration may be generated twice, but it is rare for relatively large search space.
         """
         self.logger = logger
         self.optimize_mode = OptimizeMode(optimize_mode)

--- a/tools/nni_cmd/config_schema.py
+++ b/tools/nni_cmd/config_schema.py
@@ -53,10 +53,19 @@ common_schema = {
     }
 }
 tuner_schema_dict = {
-    ('Anneal', 'SMAC'): {
-        'builtinTunerName': setChoice('builtinTunerName', 'Anneal', 'SMAC'),
+    'Anneal': {
+        'builtinTunerName': 'Anneal',
         Optional('classArgs'): {
             'optimize_mode': setChoice('optimize_mode', 'maximize', 'minimize'),
+        },
+        Optional('includeIntermediateResults'): setType('includeIntermediateResults', bool),
+        Optional('gpuIndices'): Or(int, And(str, lambda x: len([int(i) for i in x.split(',')]) > 0), error='gpuIndex format error!'),
+    },
+    'SMAC': {
+        'builtinTunerName': 'SMAC',
+        Optional('classArgs'): {
+            'optimize_mode': setChoice('optimize_mode', 'maximize', 'minimize'),
+            'config_dedup': setType('config_dedup', bool)
         },
         Optional('includeIntermediateResults'): setType('includeIntermediateResults', bool),
         Optional('gpuIndices'): Or(int, And(str, lambda x: len([int(i) for i in x.split(',')]) > 0), error='gpuIndex format error!'),


### PR DESCRIPTION
when `config_dedup` is True, a configuration will not be generated more than once