### PR TITLE
update lottery ticket pruner based on refactored compression code

### DIFF
--- a/examples/model_compress/lottery_torch_mnist_fc.py
+++ b/examples/model_compress/lottery_torch_mnist_fc.py
@@ -71,6 +71,8 @@ if __name__ == '__main__':
     pruner = LotteryTicketPruner(model, configure_list, optimizer)
     pruner.compress()
 
+    #model = nn.DataParallel(model)
+
     for i in pruner.get_prune_iterations():
         pruner.prune_iteration_start()
         loss = 0

--- a/examples/model_compress/multi_gpu.py
+++ b/examples/model_compress/multi_gpu.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     train_loader = torch.utils.data.DataLoader(traindataset, batch_size=60, shuffle=True, num_workers=10, drop_last=False)
     test_loader = torch.utils.data.DataLoader(testdataset, batch_size=60, shuffle=False, num_workers=10, drop_last=True)
 
-    device = torch.device("cuda: 0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = fc1()
     
     criterion = nn.CrossEntropyLoss()

--- a/src/sdk/pynni/nni/compression/torch/compressor.py
+++ b/src/sdk/pynni/nni/compression/torch/compressor.py
@@ -263,7 +263,7 @@ class Pruner(Compressor):
     def __init__(self, model, config_list):
         super().__init__(model, config_list)
 
-    def calc_mask(self, layer, config):
+    def calc_mask(self, layer, config, **kwargs):
         """
         Pruners should overload this method to provide mask for weight tensors.
         The mask must have the same shape and type comparing to the weight.

--- a/src/sdk/pynni/nni/compression/torch/compressor.py
+++ b/src/sdk/pynni/nni/compression/torch/compressor.py
@@ -295,7 +295,7 @@ class Pruner(Compressor):
         """
         _logger.info("compressing module %s.", layer.name)
         wrapper = PrunerModuleWrapper(layer.module, layer.name, layer.type, config, self)
-        # TODO: check weight exists
+        assert hasattr(layer.module, 'weight')
         wrapper.to(layer.module.weight.device)
         return wrapper
 

--- a/src/sdk/pynni/nni/compression/torch/pruners.py
+++ b/src/sdk/pynni/nni/compression/torch/pruners.py
@@ -365,9 +365,7 @@ class LotteryTicketPruner(Pruner):
             mask = self._calc_mask(layer.module.weight.data, sparsity, module_wrapper.weight_mask)
             # TODO: directly use weight_mask is not good
             module_wrapper.weight_mask.copy_(mask['weight'])
-            # TODO: support bias mask
-            if 'bias' in mask:
-                module_wrapper.bias_mask.copy_(mask['bias'])
+            # there is no mask for bias
 
         # reinit weights back to original after new masks are generated
         if self.reset_weights:


### PR DESCRIPTION
1. update lottery ticket pruner based on refactored compression code
2. fix bug: allow users to specify device of the model when exporting mask and model, used to place dummy input tensor for exporting onnx model.