### PR TITLE
Fixed Import Error

### DIFF
--- a/src/sdk/pynni/nni/feature_engineering/gradient_selector/fginitialize.py
+++ b/src/sdk/pynni/nni/feature_engineering/gradient_selector/fginitialize.py
@@ -31,7 +31,10 @@ from sklearn.datasets import load_svmlight_file
 import torch
 from torch.utils.data import DataLoader, Dataset
 # pylint: disable=E0611
-from torch.utils.data.dataloader import _DataLoaderIter, _utils
+try:
+    from torch.utils.data.dataloader import _DataLoaderIter
+except ImportError:
+    from torch.utils.data.dataloader import _BaseDataLoaderIter as _DataLoaderIter
 
 from . import constants
 from . import syssettings


### PR DESCRIPTION

In the latest version, PyTorch or upper 1.0  _DataLoaderIter is no more exist. 

so `ImportError: cannot import name '_DataLoaderIter'` raise some Import error.(in gradient_selector/fginitialize.py)

I do some exception handling code the head of code. and replace `_DataLoaderIter` to `_BaseDataLoaderIter`.

Thanks for your works.