### PR TITLE
Fix IT pipeline

### DIFF
--- a/test/pipelines-it-local-windows.yml
+++ b/test/pipelines-it-local-windows.yml
@@ -1,5 +1,6 @@
 jobs:
-- job: 'Test'
+- job: 'integration_test_local_windows'
+  timeoutInMinutes: 0
 
   steps:
   - script: |
@@ -9,7 +10,6 @@ jobs:
       python -m pip install scikit-learn==0.20.0 --user
       python -m pip install keras==2.1.6 --user
       python -m pip install torch===1.2.0 torchvision===0.4.1 -f https://download.pytorch.org/whl/torch_stable.html --user
-      python -m pip install torchvision --user
       python -m pip install tensorflow-gpu==1.11.0 --user
     displayName: 'Install dependencies for integration tests'
   - script: |
@@ -18,7 +18,7 @@ jobs:
     displayName: 'generate config files'
   - script: |
       cd test
-      python config_test.py --ts local --local_gpu --exclude smac,bohb
+      python config_test.py --ts local --local_gpu --exclude smac,bohb,cifar10
     displayName: 'Examples and advanced features tests on local machine'
   - script: |
       cd test

--- a/test/pipelines-it-local.yml
+++ b/test/pipelines-it-local.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: 'integration_test_local_ubuntu'
+  timeoutInMinutes: 0
 
   steps:
   - script: python3 -m pip install --upgrade pip setuptools --user

--- a/test/pipelines-it-remote-windows.yml
+++ b/test/pipelines-it-remote-windows.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: 'integration_test_remote_windows'
+  timeoutInMinutes: 0
 
   steps:
   - script: python -m pip install --upgrade pip setuptools

--- a/test/pipelines-it-remote.yml
+++ b/test/pipelines-it-remote.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: 'integration_test_remote'
+  timeoutInMinutes: 0
 
   steps:
   - script: python3 -m pip install --upgrade pip setuptools --user


### PR DESCRIPTION
cifar10 example is temporarily disabled on local windows due to timeout with torch 1.2.0 and torchvision 0.4.1

default IT pipeline timeout is 60 minutes which is not enough for our pipelines.