### PR TITLE
add support for pytorchjob crd version 'v1'

### DIFF
--- a/src/nni_manager/config/kubeflow/pytorchjob-crd-v1.json
+++ b/src/nni_manager/config/kubeflow/pytorchjob-crd-v1.json
@@ -10,7 +10,7 @@
             "singular": "pytorchjob"
         }
     },
-    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "apiVersion": "kubeflow.org/v1",
     "metadata": {
         "name": "pytorchjobs.kubeflow.org"
     }

--- a/src/nni_manager/config/kubeflow/pytorchjob-crd-v1.json
+++ b/src/nni_manager/config/kubeflow/pytorchjob-crd-v1.json
@@ -1,0 +1,17 @@
+{
+    "kind": "CustomResourceDefinition",
+    "spec": {
+        "scope": "Namespaced",
+        "version": "v1",
+        "group": "kubeflow.org",
+        "names": {
+            "kind": "PyTorchJob",
+            "plural": "pytorchjobs",
+            "singular": "pytorchjob"
+        }
+    },
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "metadata": {
+        "name": "pytorchjobs.kubeflow.org"
+    }
+}

--- a/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowApiClient.ts
+++ b/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowApiClient.ts
@@ -83,7 +83,24 @@ class TFOperatorClientV1 extends KubernetesCRDClient {
         return 'tensorflow';
     }
 }
+class PyTorchOperatorClientV1 extends KubernetesCRDClient {
+    /**
+     * constructor, to initialize tfjob CRD definition
+     */
+    public constructor() {
+        super();
+        this.crdSchema = JSON.parse(fs.readFileSync('./config/kubeflow/pytorchjob-crd-v1.json', 'utf8'));
+        this.client.addCustomResourceDefinition(this.crdSchema);
+    }
 
+    protected get operator(): any {
+        return this.client.apis['kubeflow.org'].v1.namespaces('default').pytorchjobs;
+    }
+
+    public get containerName(): string {
+        return 'pytorch';
+    }
+}
 class PyTorchOperatorClientV1Alpha2 extends KubernetesCRDClient {
     /**
      * constructor, to initialize tfjob CRD definition
@@ -178,6 +195,9 @@ class KubeflowOperatorClientFactory {
                     }
                     case 'v1beta2': {
                         return new PyTorchOperatorClientV1Beta2();
+                    }
+                    case 'v1': {
+                        return new PyTorchOperatorClientV1();
                     }
                     default:
                         throw new Error(`Invalid pytorch-operator apiVersion ${operatorApiVersion}`);

--- a/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowConfig.ts
+++ b/src/nni_manager/training_service/kubernetes/kubeflow/kubeflowConfig.ts
@@ -13,7 +13,7 @@ import { AzureStorage, KeyVaultConfig, KubernetesClusterConfig, KubernetesCluste
 export type KubeflowOperator = 'tf-operator' | 'pytorch-operator' ;
 export type DistTrainRole = 'worker' | 'ps' | 'master';
 export type KubeflowJobStatus = 'Created' | 'Running' | 'Failed' | 'Succeeded';
-export type OperatorApiVersion = 'v1alpha2' | 'v1beta1' | 'v1beta2';
+export type OperatorApiVersion = 'v1alpha2' | 'v1beta1' | 'v1beta2' | 'v1';
 
 /**
  * Kubeflow Cluster Configuration


### PR DESCRIPTION
As supported by kubeflow 0.7,  the new crd version ```v1``` has been added for ```TFJob``` about two month ago via commit #1814 . So the version ```v1```  should be added for ```PyTorchJob``` 