### PR TITLE
fix some bugs in v1.4 bug bash

### DIFF
--- a/src/webui/src/components/NavCon.tsx
+++ b/src/webui/src/components/NavCon.tsx
@@ -172,7 +172,7 @@ class NavCon extends React.Component<NavProps, NavState> {
                         />
                         <CommandBarButton
                             iconProps={infoIconAbout}
-                            text="about"
+                            text="About"
                             menuProps={aboutProps}
                         />
                     </Stack>

--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -65,7 +65,7 @@ class TrialsDetail extends React.Component<TrialsDetailProps, TrialDetailState> 
             case 'Status':
                 filter = (trial): boolean => trial.info.status.toUpperCase().includes(targetValue.toUpperCase());
                 break;
-            case 'parameters':
+            case 'Parameters':
                 // TODO: support filters like `x: 2` (instead of `"x": 2`)
                 filter = (trial): boolean => JSON.stringify(trial.info.hyperParameters, null, 4).includes(targetValue);
                 break;

--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -56,7 +56,7 @@ class TrialsDetail extends React.Component<TrialsDetailProps, TrialDetailState> 
             return;
         }
         switch (this.state.searchType) {
-            case 'id':
+            case 'Id':
                 filter = (trial): boolean => trial.info.id.toUpperCase().includes(targetValue.toUpperCase());
                 break;
             case 'Trial No.':

--- a/src/webui/src/components/trial-detail/TableList.tsx
+++ b/src/webui/src/components/trial-detail/TableList.tsx
@@ -128,7 +128,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
         name: 'Default metric',
         className: 'leftTitle',
         key: 'accuracy',
-        fieldName: 'accuracy',
+        fieldName: 'latestAccuracy',
         minWidth: 200,
         maxWidth: 300,
         isResizable: true,
@@ -534,8 +534,8 @@ class TableList extends React.Component<TableListProps, TableListState> {
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: TableListProps): void {
-        const { columnList } = nextProps;
-        this.setState({ tableColumns: this.initTableColumnList(columnList) });
+        const { columnList, tableSource } = nextProps;
+        this.setState({ tableSourceForSort: tableSource, tableColumns: this.initTableColumnList(columnList) });
 
     }
     render(): React.ReactNode {


### PR DESCRIPTION
fix issue #2057 

- refresh interval selectors doesn't work
- defatult metric sort is not correctly in details table, it's disordered when latest | final | --
- search trials by id | parameters, tooltip "Unexpected search filter Id" | "...parameters"

this item `点击空白处可以关闭log modal`:
add `isLightDismiss={true}` for Panel , but it doesn't work in the test. will continue to fix it in another PR.