### PR TITLE
Fix swig version at 3 and upgrade macOS image version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
 
 - job: 'basic_test_pr_macOS'
   pool:
-    vmImage: 'macOS 10.15'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
 
 - job: 'basic_test_pr_macOS'
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.15'
   strategy:
     matrix:
       Python36:
@@ -94,9 +94,8 @@ jobs:
       python3 -m pip install torch==1.2.0 --user
       python3 -m pip install torchvision==0.4.0 --user
       python3 -m pip install tensorflow==1.13.1 --user
-      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null
       brew install swig@3
-      ls -al /usr/local/bin
+      rm /usr/local/bin/swig
       ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
       swig -version
       nnictl package install --name=SMAC

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,9 @@ jobs:
       python3 -m pip install tensorflow==1.13.1 --user
       ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null
       brew install swig@3
+      ls -al /usr/local/bin
       ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
+      swig -version
       nnictl package install --name=SMAC
     displayName: 'Install dependencies'
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,6 @@ jobs:
       brew install swig@3
       rm /usr/local/bin/swig
       ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
-      swig -version
       nnictl package install --name=SMAC
     displayName: 'Install dependencies'
   - script: |


### PR DESCRIPTION
Turns out that macOS image has a built-in swig. Removing the soft link.

macOS 10.13 is upgraded to 10.15 by the request of Azure pipeline warning.