### PR TITLE
Update pr test cases for windows (#2267)

### DIFF
--- a/test/config/naive_trial/naive_trial.py
+++ b/test/config/naive_trial/naive_trial.py
@@ -1,0 +1,14 @@
+import time
+import nni
+
+if __name__ == '__main__':
+    print('trial start')
+    params = nni.get_next_parameter()
+    print('params:', params)
+    epochs = 2
+
+    for i in range(epochs):
+        nni.report_intermediate_result(0.1 * (i+1))
+        time.sleep(1)
+    nni.report_final_result(0.8)
+    print('trial done')

--- a/test/config/pr_tests.yml
+++ b/test/config/pr_tests.yml
@@ -70,12 +70,18 @@ testCases:
   config:
     maxTrialNum: 2
     trialConcurrency: 2
+    trial:
+      codeDir: ../naive_trial
+      command: python3 naive_trial.py
 
 - name: assessor-medianstop
   configFile: test/config/assessors/medianstop.yml
   config:
     maxTrialNum: 2
     trialConcurrency: 2
+    trial:
+      codeDir: ../naive_trial
+      command: python3 naive_trial.py
 
 #########################################################################
 # nni tuners test
@@ -89,7 +95,7 @@ testCases:
     searchSpacePath: ../naive_trial/search_space.json
     trial:
       codeDir: ../naive_trial
-      command: python3 trial.py
+      command: python3 naive_trial.py
 
 - name: tuner-evolution
   configFile: test/config/tuners/evolution.yml
@@ -100,7 +106,7 @@ testCases:
     searchSpacePath: ../naive_trial/search_space.json
     trial:
       codeDir: ../naive_trial
-      command: python3 trial.py
+      command: python3 naive_trial.py
 
 - name: tuner-random
   configFile: test/config/tuners/random.yml
@@ -111,7 +117,7 @@ testCases:
     searchSpacePath: ../naive_trial/search_space.json
     trial:
       codeDir: ../naive_trial
-      command: python3 trial.py
+      command: python3 naive_trial.py
 
 - name: tuner-tpe
   configFile: test/config/tuners/tpe.yml
@@ -122,7 +128,7 @@ testCases:
     searchSpacePath: ../naive_trial/search_space.json
     trial:
       codeDir: ../naive_trial
-      command: python3 trial.py
+      command: python3 naive_trial.py
 
 - name: tuner-batch
   configFile: test/config/tuners/batch.yml
@@ -144,7 +150,7 @@ testCases:
     searchSpacePath: ../naive_trial/search_space.json
     trial:
       codeDir: ../naive_trial
-      command: python3 trial.py
+      command: python3 naive_trial.py
 
 - name: tuner-grid
   configFile: test/config/tuners/gridsearch.yml


### PR DESCRIPTION
The Memory/CPU resource of azure provided hosts are very limited, it seems 20 intermediate results of each trial is too much, and causing problems on Windows.  It appears changing to 2 intermediate result for each trial solved the problem.

There is no intermediate result in the PR test cases in v1.4 and before,  and 20 intermediate results were added into each trial job in recent test refactoring.