### PR TITLE
fix trial export

### DIFF
--- a/test/config/integration_tests.yml
+++ b/test/config/integration_tests.yml
@@ -77,6 +77,14 @@ testCases:
     kwargs:
       expected_result_file: expected_metrics.json
 
+- name: export-float
+  configFile: test/config/metrics_test/config.yml
+  config:
+    maxTrialNum: 1
+    trialConcurrency: 1
+  validator:
+    class: ExportValidator 
+
 - name: metrics-dict
   configFile: test/config/metrics_test/config_dict_metrics.yml
   config:
@@ -86,6 +94,14 @@ testCases:
     class: MetricsValidator
     kwargs:
       expected_result_file: expected_metrics_dict.json
+
+- name: export-dict
+  configFile: test/config/metrics_test/config_dict_metrics.yml
+  config:
+    maxTrialNum: 1
+    trialConcurrency: 1
+  validator:
+    class: ExportValidator 
 
 - name: nnicli
   configFile: test/config/examples/sklearn-regression.yml

--- a/test/nni_test/nnitest/validators.py
+++ b/test/nni_test/nnitest/validators.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import os.path as osp
+import subprocess
 import json
 import requests
 import nnicli as nc
@@ -12,6 +13,13 @@ class ITValidator:
     def __call__(self, rest_endpoint, experiment_dir, nni_source_dir, **kwargs):
         pass
 
+class ExportValidator(ITValidator):
+    def __call__(self, rest_endpoint, experiment_dir, nni_source_dir, **kwargs):
+        exp_id = osp.split(experiment_dir)[-1]
+        proc1 = subprocess.run(["nnictl", "experiment", "export", exp_id, "-t", "csv", "-f", "report.csv"])
+        assert proc1.returncode == 0, '`nnictl experiment export -t csv` failed with code %d' % proc1.returncode
+        proc2 = subprocess.run(["nnictl", "experiment", "export", exp_id, "-t", "json", "-f", "report.json"])
+        assert proc2.returncode == 0, '`nnictl experiment export -t json` failed with code %d' % proc2.returncode
 
 class MetricsValidator(ITValidator):
     def __call__(self, rest_endpoint, experiment_dir, nni_source_dir, **kwargs):

--- a/test/nni_test/nnitest/validators.py
+++ b/test/nni_test/nnitest/validators.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import os.path as osp
+from os import remove
 import subprocess
 import json
 import requests
@@ -18,8 +19,19 @@ class ExportValidator(ITValidator):
         exp_id = osp.split(experiment_dir)[-1]
         proc1 = subprocess.run(["nnictl", "experiment", "export", exp_id, "-t", "csv", "-f", "report.csv"])
         assert proc1.returncode == 0, '`nnictl experiment export -t csv` failed with code %d' % proc1.returncode
+        with open("report.csv", 'r') as f:
+            print('Exported CSV file: \n')
+            print(''.join(f.readlines()))
+            print('\n\n')
+        remove('report.csv')
+
         proc2 = subprocess.run(["nnictl", "experiment", "export", exp_id, "-t", "json", "-f", "report.json"])
         assert proc2.returncode == 0, '`nnictl experiment export -t json` failed with code %d' % proc2.returncode
+        with open("report.json", 'r') as f:
+            print('Exported JSON file: \n')
+            print('\n'.join(f.readlines()))
+            print('\n\n')
+        remove('report.json')
 
 class MetricsValidator(ITValidator):
     def __call__(self, rest_endpoint, experiment_dir, nni_source_dir, **kwargs):

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -700,11 +700,11 @@ def export_trials_data(args):
                 trial_records = []
                 for record in content:
                     if not isinstance(record['value'], (float, int)):
-                        formated_record = {**record['parameter'], **record['value'], **{'id': record['id']}}
+                        formated_record = {**record['parameter'], **json.loads(record['value']), **{'id': record['id']}}
                     else:
                         formated_record = {**record['parameter'], **{'reward': record['value'], 'id': record['id']}}
                     trial_records.append(formated_record)
-                with open(args.path, 'w') as file:
+                with open(args.path, 'w', newline='') as file:
                     writer = csv.DictWriter(file, set.union(*[set(r.keys()) for r in trial_records]))
                     writer.writeheader()
                     writer.writerows(trial_records)

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -699,10 +699,11 @@ def export_trials_data(args):
                 content = json.loads(response.text)
                 trial_records = []
                 for record in content:
-                    if not isinstance(record['value'], (float, int)):
-                        formated_record = {**record['parameter'], **json.loads(record['value']), **{'id': record['id']}}
+                    record_value = json.loads(record['value'])
+                    if not isinstance(record_value, (float, int)):
+                        formated_record = {**record['parameter'], **record_value, **{'id': record['id']}}
                     else:
-                        formated_record = {**record['parameter'], **{'reward': record['value'], 'id': record['id']}}
+                        formated_record = {**record['parameter'], **{'reward': record_value, 'id': record['id']}}
                     trial_records.append(formated_record)
                 with open(args.path, 'w', newline='') as file:
                     writer = csv.DictWriter(file, set.union(*[set(r.keys()) for r in trial_records]))


### PR DESCRIPTION
fix `nnictl experiment export` with the following error:
```python
Traceback (most recent call last):
  File "c:\program files\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\program files\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Program Files\Python37\Scripts\nnictl.exe\__main__.py", line 9, in <module>
  File "c:\program files\python37\lib\site-packages\nni_cmd\nnictl.py", line 219, in parse_args
    args.func(args)
  File "c:\program files\python37\lib\site-packages\nni_cmd\nnictl_utils.py", line 694, in export_trials_data
    raise(e)
  File "c:\program files\python37\lib\site-packages\nni_cmd\nnictl_utils.py", line 689, in export_trials_data
    formated_record = {**record['parameter'], **record['value'], **{'id': record['id']}}
TypeError: 'str' object is not a mapping
```
also fix blank new line issue on exported csv file :) 