### PR TITLE
DLTS: Get NNI manager IP / port from endpoints

### DIFF
--- a/src/nni_manager/training_service/dlts/dltsTrainingService.ts
+++ b/src/nni_manager/training_service/dlts/dltsTrainingService.ts
@@ -82,24 +82,24 @@ class DLTSTrainingService implements TrainingService {
         const { dashboard, cluster, email, password } = this.dltsClusterConfig;
         const jobId = process.env['DLTS_JOB_ID'] + '';
         const uri = `${dashboard}api/clusters/${cluster}/jobs/${jobId}/endpoints`;
-        const qs = { email, password }
+        const qs = { email, password };
 
-        while (true) {
-            this.log.debug('Checking endpoints')
+        do {
+            this.log.debug('Checking endpoints');
             const endpoints = await new Promise((resolve, reject) => {
                 request.get(uri, { qs, json: true }, function (error, response, body) {
                     if (error) {
-                        reject(error)
+                        reject(error);
                     } else {
-                        resolve(body)
+                        resolve(body);
                     }
-                })
-            })
-            this.log.debug('Endpoints: %o', endpoints)
+                });
+            });
+            this.log.debug('Endpoints: %o', endpoints);
             if (Array.isArray(endpoints)) {
-                const restServerEndpoint = endpoints.find(({ podPort }) => podPort === port)
+                const restServerEndpoint = endpoints.find(({ podPort }) => podPort === port);
                 if (restServerEndpoint == null) {
-                    this.log.debug('Exposing %d', port)
+                    this.log.debug('Exposing %d', port);
                     await new Promise((resolve, reject) => {
                         request.post(uri, {
                             qs,
@@ -112,21 +112,20 @@ class DLTSTrainingService implements TrainingService {
                             }
                         }, function (error) {
                             if (error) {
-                                reject(error)
+                                reject(error);
                             } else {
-                                resolve()
+                                resolve();
                             }
-                        })
+                        });
                     });
                 } else if (restServerEndpoint['status'] === 'running') {
                     // We get an exposed restserver port
-                    this.dltsRestServerHost = restServerEndpoint['nodeName']
-                    this.dltsRestServerPort = restServerEndpoint['port']
+                    this.dltsRestServerHost = restServerEndpoint['nodeName'];
+                    this.dltsRestServerPort = restServerEndpoint['port'];
                     break;
                 }
             }
-            await new Promise(resolve => setTimeout(resolve, 1000));
-        }
+        } while (await new Promise(resolve => setTimeout(resolve, 1000)));
     }
 
     private async statusCheckingLoop(): Promise<void> {

--- a/src/nni_manager/training_service/dlts/dltsTrainingService.ts
+++ b/src/nni_manager/training_service/dlts/dltsTrainingService.ts
@@ -463,7 +463,6 @@ class DLTSTrainingService implements TrainingService {
         // tslint:disable-next-line: strict-boolean-expressions
         const nniManagerIp: string = this.nniManagerIpConfig ? this.nniManagerIpConfig.nniManagerIp : this.dltsRestServerHost;
         const version: string = this.versionCheck ? await getVersion() : '';
-        
         const nniDLTSTrialCommand: string = String.Format(
             DLTS_TRIAL_COMMAND_FORMAT,
             trialLocalFolder,

--- a/src/nni_manager/training_service/dlts/dltsTrainingService.ts
+++ b/src/nni_manager/training_service/dlts/dltsTrainingService.ts
@@ -114,6 +114,7 @@ class DLTSTrainingService implements TrainingService {
                             }
                         })
                     })
+                    continue;
                 } else if (restServerEndpoint['status'] !== 'running') {
                     await new Promise(resolve => setTimeout(resolve, 1000));
                     continue;

--- a/src/nni_manager/training_service/dlts/dltsTrainingService.ts
+++ b/src/nni_manager/training_service/dlts/dltsTrainingService.ts
@@ -125,7 +125,7 @@ class DLTSTrainingService implements TrainingService {
                     break;
                 }
             }
-        } while (await new Promise(resolve => setTimeout(resolve, 1000)));
+        } while (await new Promise(resolve => setTimeout(resolve, 1000, true)));
     }
 
     private async statusCheckingLoop(): Promise<void> {

--- a/src/nni_manager/training_service/dlts/dltsTrainingService.ts
+++ b/src/nni_manager/training_service/dlts/dltsTrainingService.ts
@@ -461,6 +461,7 @@ class DLTSTrainingService implements TrainingService {
             );
         }
         // tslint:disable-next-line: strict-boolean-expressions
+        const nniManagerIp: string = this.nniManagerIpConfig ? this.nniManagerIpConfig.nniManagerIp : this.dltsRestServerHost;
         const version: string = this.versionCheck ? await getVersion() : '';
         
         const nniDLTSTrialCommand: string = String.Format(
@@ -473,7 +474,7 @@ class DLTSTrainingService implements TrainingService {
             false,
             this.dltsTrialConfig.codeDir,
             this.dltsTrialConfig.command,
-            this.dltsRestServerHost,
+            nniManagerIp,
             this.dltsRestServerPort,
             version,
             this.logCollection


### PR DESCRIPTION
Previously, DLTS training service is using Kubernetes internal network to make to connections between different workers, which is not supported by all deployments.

This PR is switching it into **job endpoints**, which is officially supported by DLTS. Therefore, a manager job should:

1. Expose **container port** of RestServer to public as a **job endpoint**
2. Wait the exposed job endpoint be ready, and than get the **hostname** and **host port** (which is different from the container port) of the job endpoint
3. Start trial job with the hostname and host port as the address of RestServer.