### PR TITLE
Show more log info for failed test cases

### DIFF
--- a/test/nni_test/nnitest/run_tests.py
+++ b/test/nni_test/nnitest/run_tests.py
@@ -154,10 +154,6 @@ def launch_test(config_file, training_service, test_case_config):
             time.sleep(3)
     except:
         print_experiment_log(experiment_id=experiment_id)
-        print('nnictl log stderr:')
-        subprocess.run(shlex.split('nnictl log stderr'))
-        print('nnictl log stdout:')
-        subprocess.run(shlex.split('nnictl log stdout'))
         raise
     print(str(datetime.datetime.now()), ' waiting done', flush=True)
     if get_experiment_status(STATUS_URL) == 'ERROR':

--- a/test/nni_test/nnitest/utils.py
+++ b/test/nni_test/nnitest/utils.py
@@ -10,6 +10,7 @@ import subprocess
 import requests
 import time
 import ruamel.yaml as yaml
+import shlex
 
 EXPERIMENT_DONE_SIGNAL = 'Experiment done'
 
@@ -132,6 +133,11 @@ def print_experiment_log(experiment_id):
     for log_file in ['dispatcher.log', 'nnimanager.log']:
         filepath = os.path.join(log_dir, log_file)
         print_file_content(filepath)
+
+    print('nnictl log stderr:')
+    subprocess.run(shlex.split('nnictl log stderr {}'.format(experiment_id)))
+    print('nnictl log stdout:')
+    subprocess.run(shlex.split('nnictl log stdout {}'.format(experiment_id)))
 
 def parse_max_duration_time(max_exec_duration):
     unit = max_exec_duration[-1]

--- a/test/nni_test/nnitest/utils.py
+++ b/test/nni_test/nnitest/utils.py
@@ -65,14 +65,16 @@ def get_experiment_id(experiment_url):
     experiment_id = requests.get(experiment_url).json()['id']
     return experiment_id
 
-def get_experiment_dir(experiment_url):
+def get_experiment_dir(experiment_url=None, experiment_id=None):
     '''get experiment root directory'''
-    experiment_id = get_experiment_id(experiment_url)
+    assert any([experiment_url, experiment_id])
+    if experiment_id is None:
+        experiment_id = get_experiment_id(experiment_url)
     return os.path.join(os.path.expanduser('~'), 'nni', 'experiments', experiment_id)
 
-def get_nni_log_dir(experiment_url):
+def get_nni_log_dir(experiment_url=None, experiment_id=None):
     '''get nni's log directory from nni's experiment url'''
-    return os.path.join(get_experiment_dir(experiment_url), 'log')
+    return os.path.join(get_experiment_dir(experiment_url, experiment_id), 'log')
 
 def get_nni_log_path(experiment_url):
     '''get nni's log path from nni's experiment url'''
@@ -125,8 +127,8 @@ def print_trial_job_log(training_service, trial_jobs_url):
         for log_file in log_files:
             print_file_content(os.path.join(trial_log_dir, log_file))
 
-def print_experiment_log(experiment_url):
-    log_dir = get_nni_log_dir(experiment_url)
+def print_experiment_log(experiment_id):
+    log_dir = get_nni_log_dir(experiment_id=experiment_id)
     for log_file in ['dispatcher.log', 'nnimanager.log']:
         filepath = os.path.join(log_dir, log_file)
         print_file_content(filepath)


### PR DESCRIPTION
Fix issue #2290
Show experiment log when:
1.  Failed to retrieve experiment info via rest api
2.  Validator fails.