### PR TITLE
Support OrderedDict for LayerChoice

### DIFF
--- a/examples/nas/classic_nas/mnist.py
+++ b/examples/nas/classic_nas/mnist.py
@@ -8,6 +8,8 @@ https://github.com/pytorch/examples/blob/master/mnist/main.py
 import os
 import argparse
 import logging
+from collections import OrderedDict
+
 import nni
 import torch
 import torch.nn as nn
@@ -26,13 +28,15 @@ class Net(nn.Module):
     def __init__(self, hidden_size):
         super(Net, self).__init__()
         # two options of conv1
-        self.conv1 = LayerChoice([nn.Conv2d(1, 20, 5, 1),
-                                  nn.Conv2d(1, 20, 3, 1)],
-                                 key='first_conv')
+        self.conv1 = LayerChoice(OrderedDict([
+            ("conv5x5", nn.Conv2d(1, 20, 5, 1)),
+            ("conv3x3", nn.Conv2d(1, 20, 3, 1))
+        ]), key='first_conv')
         # two options of mid_conv
-        self.mid_conv = LayerChoice([nn.Conv2d(20, 20, 3, 1, padding=1),
-                                     nn.Conv2d(20, 20, 5, 1, padding=2)],
-                                    key='mid_conv')
+        self.mid_conv = LayerChoice([
+            nn.Conv2d(20, 20, 3, 1, padding=1),
+            nn.Conv2d(20, 20, 5, 1, padding=2)
+        ], key='mid_conv')
         self.conv2 = nn.Conv2d(20, 50, 5, 1)
         self.fc1 = nn.Linear(4*4*50, hidden_size)
         self.fc2 = nn.Linear(hidden_size, 10)
@@ -166,7 +170,6 @@ def get_params():
                         help='disables CUDA training')
     parser.add_argument('--log_interval', type=int, default=1000, metavar='N',
                         help='how many batches to wait before logging training status')
-
 
     args, _ = parser.parse_known_args()
     return args

--- a/examples/nas/spos/network.py
+++ b/examples/nas/spos/network.py
@@ -151,6 +151,5 @@ def load_and_parse_state_dict(filepath="./data/checkpoint-150000.pth.tar"):
     for k, v in checkpoint["state_dict"].items():
         if k.startswith("module."):
             k = k[len("module."):]
-        k = re.sub(r"^(features.\d+).(\d+)", "\\1.choices.\\2", k)
         result[k] = v
     return result

--- a/src/sdk/pynni/nni/nas/pytorch/classic_nas/mutator.py
+++ b/src/sdk/pynni/nni/nas/pytorch/classic_nas/mutator.py
@@ -203,7 +203,7 @@ class ClassicMutator(Mutator):
             # for now we only generate flattened search space
             if isinstance(mutable, LayerChoice):
                 key = mutable.key
-                val = [repr(choice) for choice in mutable.choices]
+                val = mutable.names
                 search_space[key] = {"_type": LAYER_CHOICE, "_value": val}
             elif isinstance(mutable, InputChoice):
                 key = mutable.key

--- a/src/sdk/pynni/nni/nas/pytorch/mutables.py
+++ b/src/sdk/pynni/nni/nas/pytorch/mutables.py
@@ -144,6 +144,8 @@ class LayerChoice(Mutable):
     ----------
     length : int
         Number of ops to choose from.
+    names: list of str
+        Names of candidates.
 
     Notes
     -----
@@ -162,16 +164,19 @@ class LayerChoice(Mutable):
         super().__init__(key=key)
         self.length = len(op_candidates)
         self.choices = []
+        self.names = []
         if isinstance(op_candidates, OrderedDict):
             for name, module in op_candidates.items():
-                assert name not in ["length", "reduction", "return_mask", "_key", "key"], \
+                assert name not in ["length", "reduction", "return_mask", "_key", "key", "names"], \
                     "Please don't use a reserved name '{}' for your module.".format(name)
                 self.add_module(name, module)
                 self.choices.append(module)
+                self.names.append(name)
         elif isinstance(op_candidates, list):
             for i, module in enumerate(op_candidates):
                 self.add_module(str(i), module)
                 self.choices.append(module)
+                self.names.append(str(i))
         else:
             raise TypeError("Unsupported op_candidates type: {}".format(type(op_candidates)))
         self.reduction = reduction

--- a/src/sdk/pynni/nni/nas/pytorch/mutables.py
+++ b/src/sdk/pynni/nni/nas/pytorch/mutables.py
@@ -151,13 +151,14 @@ class LayerChoice(Mutable):
     -----
     ``op_candidates`` can be a list of modules or a ordered dict of named modules, for example,
 
-        .. code-block:: python
+    .. code-block:: python
 
         self.op_choice = LayerChoice(OrderedDict([
             ("conv3x3", nn.Conv2d(3, 16, 128)),
             ("conv5x5", nn.Conv2d(5, 16, 128)),
             ("conv7x7", nn.Conv2d(7, 16, 128))
         ]))
+
     """
 
     def __init__(self, op_candidates, reduction="sum", return_mask=False, key=None):


### PR DESCRIPTION
I'm bringing changes into NAS step by step. For this PR,

API change:

* `op_candidates` support `OrderedDict` now (#2112)
* Modules are stored without a `choices` layer, by directly being added into LayerChoice. For example, `op_choices.choices.0.bn` will be changed into `op_choices.0.bn`. Note that this will be a breaking change to all previously trained checkpoint.
* Add attributed `names` to LayerChoice that stores all the verbose names.

Usability improvement:

* Classic NAS now uses a more friendly naming pattern:

```
{
  "first_conv": {
    "_type": "layer_choice",
    "_value": [
      "conv5x5",
      "conv3x3"
    ]
  },
  "mid_conv": {
    "_type": "layer_choice",
    "_value": [
      "0",
      "1"
    ]
  },
  "skip": {
    "_type": "input_choice",
    "_value": {
      "candidates": [
        "",
        ""
      ],
      "n_chosen": 1
    }
  }
}
```

* Expand modules in mutables by default in `repr`.
* Improve DARTS, Classic NAS examples and update SPOS example accordingly.

Next step:

* I'll improve the exported format of mutator.