### PR TITLE
Enable viewcode in readthedocs

### DIFF
--- a/docs/en_US/conf.py
+++ b/docs/en_US/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx_markdown_tables',
     'sphinxarg.ext',
     'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
 ]
 
 # Add mock modules


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/8463288/79712252-ec891e00-82fc-11ea-88e5-f51d1148a06a.png)

Unfortunately it won't link to GitHub, but I think it suffies the need of #2338 