### PR TITLE
Add Python SDK version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ install-dependencies: $(NNI_NODE_TARBALL) $(NNI_YARN_TARBALL)
 .PHONY: install-python-modules
 install-python-modules:
 	#$(_INFO) Installing Python SDK $(_END)
+	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' src/sdk/pynni/nni/__init__.py
 	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' setup.py && $(PIP_INSTALL) $(PIP_MODE) .
 
 .PHONY: dev-install-python-modules

--- a/deployment/deployment-pipelines.yml
+++ b/deployment/deployment-pipelines.yml
@@ -34,17 +34,6 @@ jobs:
     condition: eq( variables['build_type'], 'release' )
     displayName: 'Validate release version number and branch tag'
 
-  - script: |
-      export SDK_VERSION=`python3 -c 'import nni; print(nni.__version__)'`
-      echo $SDK_VERSION
-      if [[ $SDK_VERSION = $(build_version) ]]; then
-        echo 'SDK version match build version'
-      else
-        echo 'SDK version does not match build version'
-        exit 1
-      fi
-    displayName: 'Validate SDK version'
-
 
 - job: 'Build_upload_nni_ubuntu'
   dependsOn: version_number_validation

--- a/deployment/deployment-pipelines.yml
+++ b/deployment/deployment-pipelines.yml
@@ -34,6 +34,17 @@ jobs:
     condition: eq( variables['build_type'], 'release' )
     displayName: 'Validate release version number and branch tag'
 
+  - script: |
+      export SDK_VERSION=`python3 -c 'import nni; print(nni.__version__)'`
+      echo $SDK_VERSION
+      if [[ $SDK_VERSION = $(build_version) ]]; then
+        echo 'SDK version match build version'
+      else
+        echo 'SDK version does not match build version'
+        exit 1
+      fi
+    displayName: 'Validate SDK version'
+
 
 - job: 'Build_upload_nni_ubuntu'
   dependsOn: version_number_validation

--- a/deployment/pypi/Makefile
+++ b/deployment/pypi/Makefile
@@ -47,6 +47,7 @@ build:
 	cp $(CWD)../../src/nni_manager/package.json $(CWD)nni
 	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' $(CWD)nni/package.json
 	cd $(CWD)nni && $(NNI_YARN) --prod
+	sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' $(CWD)../../src/sdk/pynni/nni/__init__.py
 	cd $(CWD) && sed -ie 's/$(NNI_VERSION_TEMPLATE)/$(NNI_VERSION_VALUE)/' setup.py && python3 setup.py bdist_wheel -p $(WHEEL_SPEC)
 	cd $(CWD)
 

--- a/deployment/pypi/install.ps1
+++ b/deployment/pypi/install.ps1
@@ -60,6 +60,8 @@ Copy-Item $CWD\..\..\src\nni_manager\package.json $CWD\nni
 (Get-Content $CWD\nni\package.json).replace($NNI_VERSION_TEMPLATE, $NNI_VERSION_VALUE) | Set-Content $CWD\nni\package.json
 cd $CWD\nni
 yarn --prod
+cd $CWD\..\..\src\sdk\pynni\nni
+(Get-Content __init__.py).replace($NNI_VERSION_TEMPLATE, $NNI_VERSION_VALUE) | Set-Content __init__.py
 cd $CWD
 (Get-Content setup.py).replace($NNI_VERSION_TEMPLATE, $NNI_VERSION_VALUE) | Set-Content setup.py
 python setup.py bdist_wheel -p $WHEEL_SPEC

--- a/src/sdk/pynni/nni/__init__.py
+++ b/src/sdk/pynni/nni/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+__version__ = '999.0.0-developing'
+
 from .env_vars import dispatcher_env_vars
 
 if dispatcher_env_vars.SDK_PROCESS != 'dispatcher':


### PR DESCRIPTION
Test PYPI: [linux](https://test.pypi.org/project/nni/0.0.9.2005180212/#files) [windows](https://test.pypi.org/project/nni/0.0.9.2005180241/#files)

I'm confused by the letter "v" problem.
The version string placeholder is "999.0.0-developing", without leading letter "v". But during installation, it's replaced by git tag, which is something like "v1.5".
If the leading letter "v" is desired, we should fix the placeholder; and if it should not be there, we should fix `NNI_VERSION_VALUE` in makefiles. Personally I prefer not to include leading "v" in `NNI_VERSION_VALUE`, because that's Python's common practice as I know. If a module wants the leading "v", it can append it before placeholder and the replacement should work fine.