### PR TITLE
Update implementation of PDARTS export due to mutator refactor

### DIFF
--- a/src/sdk/pynni/nni/nas/pytorch/mutator.py
+++ b/src/sdk/pynni/nni/nas/pytorch/mutator.py
@@ -281,25 +281,23 @@ class Mutator(BaseMutator):
         # If it's a boolean array, we can do optimization.
         if all([t == 0 or t == 1 for t in multihot_list]):
             if isinstance(mutable, LayerChoice):
-                if len(multihot_list) != len(mutable):
-                    logger.warning("Results returned from 'sample_final()' (%s: %s) either too short or too long. Mutable length is %d. "
-                                   "The result is preserved in case this is your intention.", mutable.key, multihot_list, len(mutable))
+                assert len(multihot_list) == len(mutable), \
+                    "Results returned from 'sample_final()' (%s: %s) either too short or too long." \
+                        % (mutable.key, multihot_list)
+                # check if all modules have different names and they indeed have names
+                if len(set(mutable.names)) == len(mutable) and not all(d.isdigit() for d in mutable.names):
+                    converted = [name for i, name in enumerate(mutable.names) if multihot_list[i]]
                 else:
-                    # check if all modules have different names and they indeed have names
-                    if len(set(mutable.names)) == len(mutable) and not all(d.isdigit() for d in mutable.names):
-                        converted = [name for i, name in enumerate(mutable.names) if multihot_list[i]]
-                    else:
-                        converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
+                    converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
             if isinstance(mutable, InputChoice):
-                if len(multihot_list) != mutable.n_candidates:
-                    logger.warning("Results returned from 'sample_final()' (%s: %s) either too short or too long. Mutable length is %d. "
-                                   "The result is preserved in case this is your intention.", mutable.key, multihot_list, len(mutable))
+                assert len(multihot_list) == mutable.n_candidates, \
+                    "Results returned from 'sample_final()' (%s: %s) either too short or too long." \
+                        % (mutable.key, multihot_list)
+                # check if all input candidates have different names
+                if len(set(mutable.choose_from)) == mutable.n_candidates:
+                    converted = [name for i, name in enumerate(mutable.choose_from) if multihot_list[i]]
                 else:
-                    # check if all input candidates have different names
-                    if len(set(mutable.choose_from)) == mutable.n_candidates:
-                        converted = [name for i, name in enumerate(mutable.choose_from) if multihot_list[i]]
-                    else:
-                        converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
+                    converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
         if converted is not None:
             # if only one element, then remove the bracket
             if len(converted) == 1:

--- a/src/sdk/pynni/nni/nas/pytorch/mutator.py
+++ b/src/sdk/pynni/nni/nas/pytorch/mutator.py
@@ -281,23 +281,25 @@ class Mutator(BaseMutator):
         # If it's a boolean array, we can do optimization.
         if all([t == 0 or t == 1 for t in multihot_list]):
             if isinstance(mutable, LayerChoice):
-                assert len(multihot_list) == len(mutable), \
-                    "Results returned from 'sample_final()' (%s: %s) either too short or too long." \
-                        % (mutable.key, multihot_list)
-                # check if all modules have different names and they indeed have names
-                if len(set(mutable.names)) == len(mutable) and not all(d.isdigit() for d in mutable.names):
-                    converted = [name for i, name in enumerate(mutable.names) if multihot_list[i]]
+                if len(multihot_list) != len(mutable):
+                    logger.warning("Results returned from 'sample_final()' (%s: %s) either too short or too long. Mutable length is %d. "
+                                   "The result is preserved in case this is your intention.", mutable.key, multihot_list, len(mutable))
                 else:
-                    converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
+                    # check if all modules have different names and they indeed have names
+                    if len(set(mutable.names)) == len(mutable) and not all(d.isdigit() for d in mutable.names):
+                        converted = [name for i, name in enumerate(mutable.names) if multihot_list[i]]
+                    else:
+                        converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
             if isinstance(mutable, InputChoice):
-                assert len(multihot_list) == mutable.n_candidates, \
-                    "Results returned from 'sample_final()' (%s: %s) either too short or too long." \
-                        % (mutable.key, multihot_list)
-                # check if all input candidates have different names
-                if len(set(mutable.choose_from)) == mutable.n_candidates:
-                    converted = [name for i, name in enumerate(mutable.choose_from) if multihot_list[i]]
+                if len(multihot_list) != mutable.n_candidates:
+                    logger.warning("Results returned from 'sample_final()' (%s: %s) either too short or too long. Mutable length is %d. "
+                                   "The result is preserved in case this is your intention.", mutable.key, multihot_list, len(mutable))
                 else:
-                    converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
+                    # check if all input candidates have different names
+                    if len(set(mutable.choose_from)) == mutable.n_candidates:
+                        converted = [name for i, name in enumerate(mutable.choose_from) if multihot_list[i]]
+                    else:
+                        converted = [i for i in range(len(multihot_list)) if multihot_list[i]]
         if converted is not None:
             # if only one element, then remove the bracket
             if len(converted) == 1:

--- a/src/sdk/pynni/nni/nas/pytorch/pdarts/mutator.py
+++ b/src/sdk/pynni/nni/nas/pytorch/pdarts/mutator.py
@@ -55,7 +55,8 @@ class PdartsMutator(DartsMutator):
                             del module[index]
                 assert len(module) <= len(choices), "Failed to remove dropped choices."
 
-    def sample_final(self):
+    def export(self):
+        # Cannot rely on super().export() because P-DARTS has deleted some of the choices and has misaligned length.
         results = super().sample_final()
         for mutable in self.mutables:
             if isinstance(mutable, LayerChoice):


### PR DESCRIPTION
Mutator now forces mutable to have the same length as the choice vector during export. PDARTS doesn't conform with such limitation as it deletes elements from layer choice but still return a choice vector with original length. So it needs to implement its own export.