### PR TITLE
rename remote IT for clear, and fix partial success of remote-windows

### DIFF
--- a/test/pipelines/pipelines-it-remote-linux-to-linux.yml
+++ b/test/pipelines/pipelines-it-remote-linux-to-linux.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: 'integration_test_remote'
+- job: 'integration_test_remote_linux_to_linux'
   timeoutInMinutes: 120
 
   steps:

--- a/test/pipelines/pipelines-it-remote-windows-to-linux.yml
+++ b/test/pipelines/pipelines-it-remote-windows-to-linux.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: 'integration_test_remote_windows'
+- job: 'integration_test_remote_windows_to_linux'
   timeoutInMinutes: 120
 
   steps:
@@ -23,6 +23,7 @@ jobs:
       sshEndpoint: $(end_point)
       runOptions: inline
       inline: cd /tmp/nnitest/$(Build.BuildId)/nni-remote/deployment/pypi;make build
+      failOnStdErr: false
     continueOnError: true
     displayName: 'build nni bdsit_wheel'
   - task: SSH@0


### PR DESCRIPTION
1. When windows node is supported, current names of the two ITs are confusing. So rename them for clear.
1. Ignore SSH stderr to prevent partial success of windows installation.

Note, I will apply changes to Azure pipeline, once it's merged.