### PR TITLE
Fix the doc building error for the CompressionReference.md

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,7 @@ json_tricks
 numpy
 scipy
 coverage
+schema
+tensorboard
 scikit-learn==0.20
 https://download.pytorch.org/whl/cpu/torch-1.3.1%2Bcpu-cp37-cp37m-linux_x86_64.whl


### PR DESCRIPTION
These tools have a dependency on the `schema` package and the
`tensorboard` package. When compiling the documents corresponding
to these tools, these packages are required to successfully compile
the document.

Error link:
https://nni.readthedocs.io/en/latest/Compressor/CompressionReference.html#sensitivity-utilities