### PR TITLE
fix IT pruning example issue

### DIFF
--- a/examples/model_compress/model_prune_torch.py
+++ b/examples/model_compress/model_prune_torch.py
@@ -145,7 +145,10 @@ def create_model(model_name='naive'):
 def create_pruner(model, pruner_name, optimizer=None):
     pruner_class = prune_config[pruner_name]['pruner_class']
     config_list = prune_config[pruner_name]['config_list']
-    return pruner_class(model, config_list, optimizer)
+    if pruner_name in ['level', 'slim', 'fpgm', 'l1filter']:
+        return pruner_class(model, config_list)
+    else:
+        return pruner_class(model, config_list, optimizer)
 
 def train(model, device, train_loader, optimizer):
     model.train()

--- a/examples/model_compress/model_prune_torch.py
+++ b/examples/model_compress/model_prune_torch.py
@@ -145,10 +145,7 @@ def create_model(model_name='naive'):
 def create_pruner(model, pruner_name, optimizer=None):
     pruner_class = prune_config[pruner_name]['pruner_class']
     config_list = prune_config[pruner_name]['config_list']
-    if pruner_name in ['level', 'slim', 'fpgm', 'l1filter']:
-        return pruner_class(model, config_list)
-    else:
-        return pruner_class(model, config_list, optimizer)
+    return pruner_class(model, config_list, optimizer)
 
 def train(model, device, train_loader, optimizer):
     model.train()

--- a/src/sdk/pynni/nni/compression/torch/pruning/one_shot.py
+++ b/src/sdk/pynni/nni/compression/torch/pruning/one_shot.py
@@ -95,8 +95,8 @@ class LevelPruner(OneshotPruner):
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Operation types to prune.
     """
-    def __init__(self, model, config_list):
-        super().__init__(model, config_list, pruning_algorithm='level')
+    def __init__(self, model, config_list, optimizer=None):
+        super().__init__(model, config_list, pruning_algorithm='level', optimizer=optimizer)
 
 class SlimPruner(OneshotPruner):
     """
@@ -109,8 +109,8 @@ class SlimPruner(OneshotPruner):
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only BatchNorm2d is supported in Slim Pruner.
     """
-    def __init__(self, model, config_list):
-        super().__init__(model, config_list, pruning_algorithm='slim')
+    def __init__(self, model, config_list, optimizer=None):
+        super().__init__(model, config_list, pruning_algorithm='slim', optimizer=optimizer)
 
     def validate_config(self, model, config_list):
         schema = CompressorSchema([{
@@ -148,8 +148,8 @@ class L1FilterPruner(_StructuredFilterPruner):
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in L1FilterPruner.
     """
-    def __init__(self, model, config_list):
-        super().__init__(model, config_list, pruning_algorithm='l1')
+    def __init__(self, model, config_list, optimizer=None):
+        super().__init__(model, config_list, pruning_algorithm='l1', optimizer=optimizer)
 
 class L2FilterPruner(_StructuredFilterPruner):
     """
@@ -162,8 +162,8 @@ class L2FilterPruner(_StructuredFilterPruner):
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in L2FilterPruner.
     """
-    def __init__(self, model, config_list):
-        super().__init__(model, config_list, pruning_algorithm='l2')
+    def __init__(self, model, config_list, optimizer=None):
+        super().__init__(model, config_list, pruning_algorithm='l2', optimizer=optimizer)
 
 class FPGMPruner(_StructuredFilterPruner):
     """
@@ -176,8 +176,8 @@ class FPGMPruner(_StructuredFilterPruner):
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in FPGM Pruner.
     """
-    def __init__(self, model, config_list):
-        super().__init__(model, config_list, pruning_algorithm='fpgm')
+    def __init__(self, model, config_list, optimizer=None):
+        super().__init__(model, config_list, pruning_algorithm='fpgm', optimizer=optimizer)
 
 class TaylorFOWeightFilterPruner(_StructuredFilterPruner):
     """

--- a/src/sdk/pynni/nni/compression/torch/pruning/one_shot.py
+++ b/src/sdk/pynni/nni/compression/torch/pruning/one_shot.py
@@ -94,6 +94,8 @@ class LevelPruner(OneshotPruner):
         Supported keys:
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Operation types to prune.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, pruning_algorithm='level', optimizer=optimizer)
@@ -108,6 +110,8 @@ class SlimPruner(OneshotPruner):
         Supported keys:
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only BatchNorm2d is supported in Slim Pruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, pruning_algorithm='slim', optimizer=optimizer)
@@ -147,6 +151,8 @@ class L1FilterPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in L1FilterPruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, pruning_algorithm='l1', optimizer=optimizer)
@@ -161,6 +167,8 @@ class L2FilterPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in L2FilterPruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, pruning_algorithm='l2', optimizer=optimizer)
@@ -175,6 +183,8 @@ class FPGMPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : This is to specify the sparsity operations to be compressed to.
             - op_types : Only Conv2d is supported in FPGM Pruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, pruning_algorithm='fpgm', optimizer=optimizer)
@@ -189,6 +199,8 @@ class TaylorFOWeightFilterPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : How much percentage of convolutional filters are to be pruned.
             - op_types : Currently only Conv2d is supported in TaylorFOWeightFilterPruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None, statistics_batch_num=1):
         super().__init__(model, config_list, pruning_algorithm='taylorfo', optimizer=optimizer, statistics_batch_num=statistics_batch_num)
@@ -203,6 +215,8 @@ class ActivationAPoZRankFilterPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : How much percentage of convolutional filters are to be pruned.
             - op_types : Only Conv2d is supported in ActivationAPoZRankFilterPruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None, activation='relu', statistics_batch_num=1):
         super().__init__(model, config_list, pruning_algorithm='apoz', optimizer=optimizer, \
@@ -218,6 +232,8 @@ class ActivationMeanRankFilterPruner(_StructuredFilterPruner):
         Supported keys:
             - sparsity : How much percentage of convolutional filters are to be pruned.
             - op_types : Only Conv2d is supported in ActivationMeanRankFilterPruner.
+    optimizer: torch.optim.Optimizer
+            Optimizer used to train model
     """
     def __init__(self, model, config_list, optimizer=None, activation='relu', statistics_batch_num=1):
         super().__init__(model, config_list, pruning_algorithm='mean_activation', optimizer=optimizer, \

--- a/src/sdk/pynni/tests/test_pruners.py
+++ b/src/sdk/pynni/tests/test_pruners.py
@@ -192,9 +192,7 @@ def pruners_test(pruner_names=['level', 'agp', 'slim', 'fpgm', 'l1', 'l2', 'tayl
             pruner = prune_config[pruner_name]['pruner_class'](model, config_list, trainer=prune_config[pruner_name]['trainer'])
         elif pruner_name == 'autocompress':
             pruner = prune_config[pruner_name]['pruner_class'](model, config_list, trainer=prune_config[pruner_name]['trainer'], evaluator=prune_config[pruner_name]['evaluator'], dummy_input=x)
-        elif pruner_name in ['level', 'slim', 'fpgm', 'l1', 'l2']:
-            pruner = prune_config[pruner_name]['pruner_class'](model, config_list)
-        elif pruner_name in ['agp', 'taylorfo', 'mean_activation', 'apoz']:
+        else:
             pruner = prune_config[pruner_name]['pruner_class'](model, config_list, optimizer)
         pruner.compress()
 


### PR DESCRIPTION

Parameter 'optimizer '  was removed from Pruners ('level', 'slim', 'fpgm', 'l1', 'l2') in PR https://github.com/microsoft/nni/pull/2676.  This example should be changed accordingly.