### PR TITLE
turn off function no-use-before-define rule

### DIFF
--- a/src/webui/.eslintrc
+++ b/src/webui/.eslintrc
@@ -22,6 +22,7 @@
         "@typescript-eslint/no-namespace": 0,
         "@typescript-eslint/consistent-type-assertions": 0,
         "@typescript-eslint/no-inferrable-types": 0,
+        "@typescript-eslint/no-use-before-define": [2, "nofunc"],
         "no-inner-declarations": 0,
         "@typescript-eslint/no-var-requires": 0,
         "react/display-name": 0


### PR DESCRIPTION
- `This rule accepts "nofunc" string as an option. "nofunc" is the same as { "functions": false, "classes": true, "variables": true }.`

- It's correct: 


> f();
> function f() {}

- still check `variables and class`