### PR TITLE
modify the pythonPath of PythonShell to support aml mode under Windows

### DIFF
--- a/src/nni_manager/training_service/reusable/aml/amlClient.ts
+++ b/src/nni_manager/training_service/reusable/aml/amlClient.ts
@@ -41,6 +41,7 @@ export class AMLClient {
         const deferred: Deferred<string> = new Deferred<string>();
         this.pythonShellClient = new PythonShell('amlUtil.py', {
             scriptPath: './config/aml',
+            pythonPath: process.platform === 'win32' ? 'python' : 'python3',
             pythonOptions: ['-u'], // get print results in real-time
             args: [
                 '--subscription_id', this.subscriptionId,


### PR DESCRIPTION
By default, PythonShell will use py.exe under Windows, but not everyone will install py.exe. And it will not inherit the current python environment but the python specified in the python file, if use py.exe. So modify it.