### PR TITLE
Compression support for tf.keras.Sequential

### DIFF
--- a/examples/model_compress/model_prune_tf.py
+++ b/examples/model_compress/model_prune_tf.py
@@ -28,31 +28,21 @@ def get_dataset(dataset_name='mnist'):
 
 def create_model(model_name='naive'):
     assert model_name == 'naive'
-    return NaiveModel()
-
-class NaiveModel(tf.keras.Model):
-    def __init__(self):
-        super().__init__()
-        self.seq_layers = [
-            tf.keras.layers.Conv2D(filters=20, kernel_size=5),
-            tf.keras.layers.BatchNormalization(),
-            tf.keras.layers.ReLU(),
-            tf.keras.layers.MaxPool2D(pool_size=2),
-            tf.keras.layers.Conv2D(filters=20, kernel_size=5),
-            tf.keras.layers.BatchNormalization(),
-            tf.keras.layers.ReLU(),
-            tf.keras.layers.MaxPool2D(pool_size=2),
-            tf.keras.layers.Flatten(),
-            tf.keras.layers.Dense(units=500),
-            tf.keras.layers.ReLU(),
-            tf.keras.layers.Dense(units=10),
-            tf.keras.layers.Softmax()
-        ]
-
-    def call(self, x):
-        for layer in self.seq_layers:
-            x = layer(x)
-        return x
+    return tf.keras.Sequential([
+        tf.keras.layers.Conv2D(filters=20, kernel_size=5),
+        tf.keras.layers.BatchNormalization(),
+        tf.keras.layers.ReLU(),
+        tf.keras.layers.MaxPool2D(pool_size=2),
+        tf.keras.layers.Conv2D(filters=20, kernel_size=5),
+        tf.keras.layers.BatchNormalization(),
+        tf.keras.layers.ReLU(),
+        tf.keras.layers.MaxPool2D(pool_size=2),
+        tf.keras.layers.Flatten(),
+        tf.keras.layers.Dense(units=500),
+        tf.keras.layers.ReLU(),
+        tf.keras.layers.Dense(units=10),
+        tf.keras.layers.Softmax()
+    ])
 
 
 def create_pruner(model, pruner_name):

--- a/src/sdk/pynni/nni/compression/tensorflow/compressor.py
+++ b/src/sdk/pynni/nni/compression/tensorflow/compressor.py
@@ -55,7 +55,7 @@ class Compressor:
         for wrapper in self.wrappers:
             setattr(wrapper, name, value)
 
-    def validate_config(model, config_list):
+    def validate_config(self, model, config_list):
         """
         Compression algorithm should overload this function to validate configuration.
         """


### PR DESCRIPTION
"A little bit breaking" change: `Compressor.compress()` no longer guarantees to return the original model.

This is because `tf.keras.Sequential` is designed for read-only usage and therefore is too tricky to compress in place. So we create a new `Sequential` with instrumented layers instead.