### PR TITLE
Upgrade node and yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ _END := $(shell echo -e '\033[0m')
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
     OS_SPEC := linux
-    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-linux-x64.tar.xz
+    NODE_URL := https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
     OS_SPEC := darwin
-    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-darwin-x64.tar.xz
+    NODE_URL := https://nodejs.org/dist/v10.22.1/node-v10.22.1-darwin-x64.tar.xz
 else
     $(error platform $(UNAME_S) not supported)
 endif

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ _END := $(shell echo -e '\033[0m')
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
     OS_SPEC := linux
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
     OS_SPEC := darwin
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz
 else
 	$(error platform $(UNAME_S) not supported)
 endif
@@ -142,12 +144,8 @@ clean:
 # Helper targets
 
 $(NNI_NODE_TARBALL):
-#$(_INFO) Downloading Node.js $(_END)
-ifeq ($(OS_SPEC), linux)
-	wget https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz -O $(NNI_NODE_TARBALL)
-else ifeq ($(OS_SPEC), darwin)
-	wget https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz -O $(NNI_NODE_TARBALL)
-endif
+	#$(_INFO) Downloading Node.js $(_END)
+	wget $(NODE_URL) -O $(NNI_NODE_TARBALL)
 
 $(NNI_YARN_TARBALL):
 	#$(_INFO) Downloading Yarn $(_END)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ $(NNI_NODE_TARBALL):
 
 $(NNI_YARN_TARBALL):
 	#$(_INFO) Downloading Yarn $(_END)
-	wget https://yarnpkg.com/latest.tar.gz -O $(NNI_YARN_TARBALL)
+	wget https://github.com/yarnpkg/yarn/releases/download/v1.22.5/yarn-v1.22.5.tar.gz -O $(NNI_YARN_TARBALL)
 
 .PHONY: install-dependencies
 install-dependencies: $(NNI_NODE_TARBALL) $(NNI_YARN_TARBALL)

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ _END := $(shell echo -e '\033[0m')
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
     OS_SPEC := linux
-    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz
+    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
     OS_SPEC := darwin
-    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz
+    NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-darwin-x64.tar.xz
 else
     $(error platform $(UNAME_S) not supported)
 endif

--- a/Makefile
+++ b/Makefile
@@ -142,12 +142,16 @@ clean:
 # Helper targets
 
 $(NNI_NODE_TARBALL):
-	#$(_INFO) Downloading Node.js $(_END)
-	wget https://aka.ms/nni/nodejs-download/$(OS_SPEC) -O $(NNI_NODE_TARBALL)
+#$(_INFO) Downloading Node.js $(_END)
+ifeq ($(OS_SPEC), linux)
+	wget https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz -O $(NNI_NODE_TARBALL)
+else ifeq ($(OS_SPEC), darwin)
+	wget https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz -O $(NNI_NODE_TARBALL)
+endif
 
 $(NNI_YARN_TARBALL):
 	#$(_INFO) Downloading Yarn $(_END)
-	wget https://aka.ms/yarn-download -O $(NNI_YARN_TARBALL)
+	wget https://yarnpkg.com/latest.tar.gz -O $(NNI_YARN_TARBALL)
 
 .PHONY: install-dependencies
 install-dependencies: $(NNI_NODE_TARBALL) $(NNI_YARN_TARBALL)

--- a/deployment/pypi/Makefile
+++ b/deployment/pypi/Makefile
@@ -4,9 +4,11 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
 	OS_SPEC := linux
 	WHEEL_SPEC := manylinux1_x86_64
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
 	OS_SPEC := darwin
 	WHEEL_SPEC := macosx_10_9_x86_64
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz
 else
 	$(error platform $(UNAME_S) not supported)
 endif
@@ -28,11 +30,11 @@ NNI_YARN := PATH=$(CWD)node-$(OS_SPEC)-x64/bin:$${PATH} $(NNI_YARN_FOLDER)/bin/y
 build:
 	# Building version $(NNI_VERSION_VALUE)
 	python3 -m pip install --user --upgrade setuptools wheel
-	wget -q https://aka.ms/nni/nodejs-download/$(OS_SPEC) -O $(CWD)node-$(OS_SPEC)-x64.tar.xz
+	wget -q $(NODE_URL) -O $(CWD)node-$(OS_SPEC)-x64.tar.xz
 	rm -rf $(CWD)node-$(OS_SPEC)-x64
 	mkdir $(CWD)node-$(OS_SPEC)-x64
 	tar xf $(CWD)node-$(OS_SPEC)-x64.tar.xz -C node-$(OS_SPEC)-x64 --strip-components 1
-	wget -q https://aka.ms/yarn-download -O $(NNI_YARN_TARBALL)
+	wget -q https://yarnpkg.com/latest.tar.gz -O $(NNI_YARN_TARBALL)
 	rm -rf $(NNI_YARN_FOLDER)
 	mkdir $(NNI_YARN_FOLDER)
 	tar -xf $(NNI_YARN_TARBALL) -C $(NNI_YARN_FOLDER) --strip-components 1

--- a/deployment/pypi/Makefile
+++ b/deployment/pypi/Makefile
@@ -34,7 +34,7 @@ build:
 	rm -rf $(CWD)node-$(OS_SPEC)-x64
 	mkdir $(CWD)node-$(OS_SPEC)-x64
 	tar xf $(CWD)node-$(OS_SPEC)-x64.tar.xz -C node-$(OS_SPEC)-x64 --strip-components 1
-	wget -q https://yarnpkg.com/latest.tar.gz -O $(NNI_YARN_TARBALL)
+	wget -q https://github.com/yarnpkg/yarn/releases/download/v1.22.5/yarn-v1.22.5.tar.gz -O $(NNI_YARN_TARBALL)
 	rm -rf $(NNI_YARN_FOLDER)
 	mkdir $(NNI_YARN_FOLDER)
 	tar -xf $(NNI_YARN_TARBALL) -C $(NNI_YARN_FOLDER) --strip-components 1

--- a/deployment/pypi/Makefile
+++ b/deployment/pypi/Makefile
@@ -4,11 +4,11 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
 	OS_SPEC := linux
 	WHEEL_SPEC := manylinux1_x86_64
-	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-linux-x64.tar.xz
+	NODE_URL := https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
 	OS_SPEC := darwin
 	WHEEL_SPEC := macosx_10_9_x86_64
-	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-darwin-x64.tar.xz
+	NODE_URL := https://nodejs.org/dist/v10.22.1/node-v10.22.1-darwin-x64.tar.xz
 else
 	$(error platform $(UNAME_S) not supported)
 endif

--- a/deployment/pypi/Makefile
+++ b/deployment/pypi/Makefile
@@ -4,11 +4,11 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
 	OS_SPEC := linux
 	WHEEL_SPEC := manylinux1_x86_64
-	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-linux-x64.tar.xz
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-linux-x64.tar.xz
 else ifeq ($(UNAME_S), Darwin)
 	OS_SPEC := darwin
 	WHEEL_SPEC := macosx_10_9_x86_64
-	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.0-darwin-x64.tar.xz
+	NODE_URL := https://nodejs.org/dist/latest-v10.x/node-v10.22.1-darwin-x64.tar.xz
 else
 	$(error platform $(UNAME_S) not supported)
 endif

--- a/deployment/pypi/install.ps1
+++ b/deployment/pypi/install.ps1
@@ -7,10 +7,12 @@ $OS_SPEC = "windows"
 if($version_os -eq 64){
     $OS_VERSION = 'win64'
     $WHEEL_SPEC = 'win_amd64'
+    $NODE_URL = 'https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x64.zip'
 }
 else{
     $OS_VERSION = 'win32'
     $WHEEL_SPEC = 'win32'
+    $NODE_URL = 'https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x86.zip'
 }
 
 $TIME_STAMP = date -u "+%y%m%d%H%M"
@@ -28,11 +30,10 @@ $NNI_VERSION_TEMPLATE = "999.0.0-developing"
 
 python -m pip install --upgrade setuptools wheel
 
-$nodeUrl = "https://aka.ms/nni/nodejs-download/" + $OS_VERSION
 $NNI_NODE_ZIP = "$CWD\node-$OS_SPEC.zip"
 $NNI_NODE_FOLDER = "$CWD\node-$OS_SPEC"
 $unzipNodeDir = "node-v*"
-(New-Object Net.WebClient).DownloadFile($nodeUrl, $NNI_NODE_ZIP)
+(New-Object Net.WebClient).DownloadFile($NODE_URL, $NNI_NODE_ZIP)
 if(Test-Path $NNI_NODE_FOLDER){
     Remove-Item $NNI_NODE_FOLDER -Recurse -Force
 }

--- a/deployment/pypi/install.ps1
+++ b/deployment/pypi/install.ps1
@@ -7,12 +7,12 @@ $OS_SPEC = "windows"
 if($version_os -eq 64){
     $OS_VERSION = 'win64'
     $WHEEL_SPEC = 'win_amd64'
-    $NODE_URL = 'https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x64.zip'
+    $NODE_URL = 'https://nodejs.org/download/release/v10.22.1/node-v10.22.1-win-x64.zip'
 }
 else{
     $OS_VERSION = 'win32'
     $WHEEL_SPEC = 'win32'
-    $NODE_URL = 'https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x86.zip'
+    $NODE_URL = 'https://nodejs.org/download/release/v10.22.1/node-v10.22.1-win-x86.zip'
 }
 
 $TIME_STAMP = date -u "+%y%m%d%H%M"

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@ else {
     $nodeUrl = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x86.zip"
 }
 # nodejs
-$yarnUrl = "https://yarnpkg.com/latest.tar.gz"
+$yarnUrl = "https://github.com/yarnpkg/yarn/releases/download/v1.22.5/yarn-v1.22.5.tar.gz"
 $unzipNodeDir = "node-v*"
 $unzipYarnDir = "yarn-v*"
 

--- a/install.ps1
+++ b/install.ps1
@@ -7,11 +7,11 @@ $install_yarn = $true
 
 if ([Environment]::Is64BitOperatingSystem) {
     $OS_VERSION = 'win64'
-    $nodeUrl = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x64.zip"
+    $nodeUrl = "https://nodejs.org/download/release/v10.22.1/node-v10.22.1-win-x64.zip"
 }
 else {
     $OS_VERSION = 'win32'
-    $nodeUrl = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x86.zip"
+    $nodeUrl = "https://nodejs.org/download/release/v10.22.1/node-v10.22.1-win-x86.zip"
 }
 # nodejs
 $yarnUrl = "https://github.com/yarnpkg/yarn/releases/download/v1.22.5/yarn-v1.22.5.tar.gz"

--- a/install.ps1
+++ b/install.ps1
@@ -7,12 +7,13 @@ $install_yarn = $true
 
 if ([Environment]::Is64BitOperatingSystem) {
     $OS_VERSION = 'win64'
+    $nodeUrl = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x64.zip"
 }
 else {
     $OS_VERSION = 'win32'
+    $nodeUrl = "https://nodejs.org/download/release/v10.22.0/node-v10.22.0-win-x86.zip"
 }
 # nodejs
-$nodeUrl = "https://aka.ms/nni/nodejs-download/" + $OS_VERSION
 $yarnUrl = "https://yarnpkg.com/latest.tar.gz"
 $unzipNodeDir = "node-v*"
 $unzipYarnDir = "yarn-v*"


### PR DESCRIPTION
~Makefile in deployment folder still needs to be updated correspondingly.~

~Yarn will use the latest version per @liuzhe-lz 's suggestion.~

Node.js 10.13 -> 10.22

yarn 1.12.1 -> 1.22.5