### PR TITLE
unify trial job id name

### DIFF
--- a/src/nni_manager/common/datastore.ts
+++ b/src/nni_manager/common/datastore.ts
@@ -43,7 +43,7 @@ interface MetricDataRecord {
 }
 
 interface TrialJobInfo {
-    id: string;
+    trialJobId: string;
     sequenceId?: number;
     status: TrialJobStatus;
     startTime?: number;
@@ -63,7 +63,7 @@ interface HyperParameterFormat {
 interface ExportedDataFormat {
     parameter: Record<string, any>;
     value: Record<string, any>;
-    id: string;
+    trialJobId: string;
 }
 
 abstract class DataStore {

--- a/src/nni_manager/core/nniDataStore.ts
+++ b/src/nni_manager/core/nniDataStore.ts
@@ -168,7 +168,7 @@ class NNIDataStore implements DataStore {
                     const oneEntry: ExportedDataFormat = {
                         parameter: parameters.parameters,
                         value: JSON.parse(job.finalMetricData[0].data),
-                        id: job.id
+                        trialJobId: job.trialJobId
                     };
                     exportedData.push(oneEntry);
                 } else {
@@ -188,7 +188,7 @@ class NNIDataStore implements DataStore {
                             const oneEntry: ExportedDataFormat = {
                                 parameter: value,
                                 value: metricValue,
-                                id: job.id
+                                trialJobId: job.trialJobId
                             };
                             exportedData.push(oneEntry);
                         }
@@ -229,7 +229,7 @@ class NNIDataStore implements DataStore {
             }
             if (!(status !== undefined && jobInfo.status !== status)) {
                 if (jobInfo.status === 'SUCCEEDED') {
-                    jobInfo.finalMetricData = finalMetricsMap.get(jobInfo.id);
+                    jobInfo.finalMetricData = finalMetricsMap.get(jobInfo.trialJobId);
                 }
                 result.push(jobInfo);
             }
@@ -320,7 +320,7 @@ class NNIDataStore implements DataStore {
                 jobInfo = map.get(record.trialJobId);
             } else {
                 jobInfo = {
-                    id: record.trialJobId,
+                    trialJobId: record.trialJobId,
                     status: this.getJobStatusByLatestEvent('UNKNOWN', record.event),
                     hyperParameters: []
                 };
@@ -364,14 +364,14 @@ class NNIDataStore implements DataStore {
                 const newHParam: any = this.parseHyperParameter(record.data);
                 if (newHParam !== undefined) {
                     if (jobInfo.hyperParameters !== undefined) {
-                        let hParamIds: Set<number> | undefined = hParamIdMap.get(jobInfo.id);
+                        let hParamIds: Set<number> | undefined = hParamIdMap.get(jobInfo.trialJobId);
                         if (hParamIds === undefined) {
                             hParamIds = new Set();
                         }
                         if (!hParamIds.has(newHParam.parameter_index)) {
                             jobInfo.hyperParameters.push(JSON.stringify(newHParam));
                             hParamIds.add(newHParam.parameter_index);
-                            hParamIdMap.set(jobInfo.id, hParamIds);
+                            hParamIdMap.set(jobInfo.trialJobId, hParamIds);
                         }
                     } else {
                         assert(false, 'jobInfo.hyperParameters is undefined');

--- a/src/nni_manager/core/nnimanager.ts
+++ b/src/nni_manager/core/nnimanager.ts
@@ -227,7 +227,7 @@ class NNIManager implements Manager {
         // Check the final status for WAITING and RUNNING jobs
         await Promise.all(allTrialJobs
             .filter((job: TrialJobInfo) => job.status === 'WAITING' || job.status === 'RUNNING')
-            .map((job: TrialJobInfo) => this.dataStore.storeTrialJobEvent('FAILED', job.id)));
+            .map((job: TrialJobInfo) => this.dataStore.storeTrialJobEvent('FAILED', job.trialJobId)));
 
         // Collect generated trials and imported trials
         const finishedTrialData: string = await this.exportData();
@@ -300,7 +300,7 @@ class NNIManager implements Manager {
             // FIXME: can this be undefined?
             trial.sequenceId !== undefined && minSeqId <= trial.sequenceId && trial.sequenceId <= maxSeqId
         ));
-        const targetTrialIds = new Set(targetTrials.map(trial => trial.id));
+        const targetTrialIds = new Set(targetTrials.map(trial => trial.trialJobId));
 
         const allMetrics = await this.dataStore.getMetricData();
         return allMetrics.filter(metric => targetTrialIds.has(metric.trialJobId));

--- a/src/nni_manager/core/test/mockedDatastore.ts
+++ b/src/nni_manager/core/test/mockedDatastore.ts
@@ -161,7 +161,7 @@ class MockedDataStore implements DataStore {
             }
             if (!(status && jobInfo.status !== status)) {
                 if (jobInfo.status === 'SUCCEEDED') {
-                    jobInfo.finalMetricData = await this.getFinalMetricData(jobInfo.id);
+                    jobInfo.finalMetricData = await this.getFinalMetricData(jobInfo.trialJobId);
                 }
                 result.push(jobInfo);
             }
@@ -206,7 +206,7 @@ class MockedDataStore implements DataStore {
 
     public getTrialJob(trialJobId: string): Promise<TrialJobInfo> {
         return Promise.resolve({
-            id: '1234',
+            trialJobId: '1234',
             status: 'SUCCEEDED',
             startTime: Date.now(),
             endTime: Date.now()
@@ -242,7 +242,7 @@ class MockedDataStore implements DataStore {
                 jobInfo = map.get(record.trialJobId);
             } else {
                 jobInfo = {
-                    id: record.trialJobId,
+                    trialJobId: record.trialJobId,
                     status: this.getJobStatusByLatestEvent(record.event),
                 };
             }

--- a/src/nni_manager/core/test/nnimanager.test.ts
+++ b/src/nni_manager/core/test/nnimanager.test.ts
@@ -122,7 +122,7 @@ describe('Unit test for nnimanager', function () {
     it('test getTrialJob valid', () => {
         //query a exist id
         return nniManager.getTrialJob('1234').then(function (trialJobDetail) {
-            expect(trialJobDetail.id).to.be.equal('1234');
+            expect(trialJobDetail.trialJobId).to.be.equal('1234');
         }).catch((error) => {
             assert.fail(error);
         })

--- a/src/nni_manager/rest_server/test/mockedNNIManager.ts
+++ b/src/nni_manager/rest_server/test/mockedNNIManager.ts
@@ -97,7 +97,7 @@ export class MockedNNIManager extends Manager {
     public getTrialJob(trialJobId: string): Promise<TrialJobInfo> {
         const deferred: Deferred<TrialJobInfo> = new Deferred<TrialJobInfo>();
         const jobInfo: TrialJobInfo = {
-            id: '1234',
+            trialJobId: '1234',
             status: 'SUCCEEDED',
             startTime: Date.now(),
             endTime: Date.now()
@@ -148,7 +148,7 @@ export class MockedNNIManager extends Manager {
     }
     public listTrialJobs(status?: TrialJobStatus): Promise<TrialJobInfo[]> {
         const job1: TrialJobInfo = {
-            id: '1234',
+            trialJobId: '1234',
             status: 'SUCCEEDED',
             startTime: Date.now(),
             endTime: Date.now(),
@@ -162,7 +162,7 @@ export class MockedNNIManager extends Manager {
             }]
         };
         const job2: TrialJobInfo = {
-            id: '3456',
+            trialJobId: '3456',
             status: 'FAILED',
             startTime: Date.now(),
             endTime: Date.now(),

--- a/src/nni_manager/rest_server/test/restserver.test.ts
+++ b/src/nni_manager/rest_server/test/restserver.test.ts
@@ -57,7 +57,7 @@ describe('Unit test for rest server', () => {
                 assert.fail(err.message);
             } else {
                 expect(res.statusCode).to.equal(200);
-                expect(JSON.parse(body).id).to.equal('1234');
+                expect(JSON.parse(body).trialJobId).to.equal('1234');
             }
             done();
         });

--- a/src/sdk/pycli/nnicli/nni_client.py
+++ b/src/sdk/pycli/nnicli/nni_client.py
@@ -99,10 +99,7 @@ class TrialResult:
         self.value = None
         self.trialJobId = None
         for key in json_obj.keys():
-            if key == 'id':
-                setattr(self, 'trialJobId', json_obj[key])
-            elif hasattr(self, key):
-                setattr(self, key, json_obj[key])
+            setattr(self, key, json_obj[key])
         self.value = json.loads(self.value)
 
     def __repr__(self):
@@ -219,10 +216,7 @@ class TrialJob:
         self.finalMetricData = None
         self.stderrPath = None
         for key in json_obj.keys():
-            if key == 'id':
-                setattr(self, 'trialJobId', json_obj[key])
-            elif hasattr(self, key):
-                setattr(self, key, json_obj[key])
+            setattr(self, key, json_obj[key])
         if self.hyperParameters:
             self.hyperParameters = [TrialHyperParameters(json.loads(e)) for e in self.hyperParameters]
         if self.finalMetricData:

--- a/src/webui/src/components/Overview.tsx
+++ b/src/webui/src/components/Overview.tsx
@@ -155,7 +155,7 @@ class Overview extends React.Component<OverviewProps, OverviewState> {
                             />
                         </div>
                         <div style={{ width: '60%'}}>
-                            <SuccessTable trialIds={bestTrials.map(trial => trial.info.id)} />
+                            <SuccessTable trialIds={bestTrials.map(trial => trial.info.trialJobId)} />
                         </div>
                     </Stack>
                 </Stack>

--- a/src/webui/src/components/TrialsDetail.tsx
+++ b/src/webui/src/components/TrialsDetail.tsx
@@ -57,7 +57,7 @@ class TrialsDetail extends React.Component<TrialsDetailProps, TrialDetailState> 
         }
         switch (this.state.searchType) {
             case 'id':
-                filter = (trial): boolean => trial.info.id.toUpperCase().includes(targetValue.toUpperCase());
+                filter = (trial): boolean => trial.info.trialJobId.toUpperCase().includes(targetValue.toUpperCase());
                 break;
             case 'Trial No.':
                 filter = (trial): boolean => trial.info.sequenceId.toString() === targetValue;

--- a/src/webui/src/components/trial-detail/TableList.tsx
+++ b/src/webui/src/components/trial-detail/TableList.tsx
@@ -255,7 +255,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
     showIntermediateModal = async (record: TrialJobInfo, event: React.SyntheticEvent<EventTarget>): Promise<void> => {
         event.preventDefault();
         event.stopPropagation();
-        const res = await axios.get(`${MANAGER_IP}/metric-data/${record.id}`);
+        const res = await axios.get(`${MANAGER_IP}/metric-data/${record.trialJobId}`);
         if (res.status === 200) {
             const intermediateArr: number[] = [];
             // support intermediate result is dict because the last intermediate result is
@@ -285,12 +285,12 @@ class TableList extends React.Component<TableListProps, TableListState> {
                     }
                 }
             });
-            const intermediate = intermediateGraphOption(intermediateArr, record.id);
+            const intermediate = intermediateGraphOption(intermediateArr, record.trialJobId);
             this.setState({
                 intermediateData: res.data, // store origin intermediate data for a trial
                 intermediateOption: intermediate,
                 intermediateOtherKeys: otherkeys,
-                intermediateId: record.id
+                intermediateId: record.trialJobId
             });
         }
         this.setState({ modalVisible: true });

--- a/src/webui/src/static/interface.ts
+++ b/src/webui/src/static/interface.ts
@@ -130,7 +130,7 @@ interface MetricDataRecord {
 }
 
 interface TrialJobInfo {
-    id: string;
+    trialJobId: string;
     sequenceId: number;
     status: string;
     startTime?: number;

--- a/src/webui/src/static/model/trial.ts
+++ b/src/webui/src/static/model/trial.ts
@@ -121,9 +121,9 @@ class Trial implements TableObj {
         }
 
         return {
-            key: this.info.id,
+            key: this.info.trialJobId,
             sequenceId: this.info.sequenceId,
-            id: this.info.id,
+            id: this.info.trialJobId,
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             startTime: this.info.startTime!,
             endTime: this.info.endTime,
@@ -146,7 +146,7 @@ class Trial implements TableObj {
     }
 
     get id(): string {
-        return this.info.id;
+        return this.info.trialJobId;
     }
 
     get duration(): number {

--- a/src/webui/src/static/model/trialmanager.ts
+++ b/src/webui/src/static/model/trialmanager.ts
@@ -173,11 +173,11 @@ class TrialManager {
         requestAxios(`${MANAGER_IP}/trial-jobs`)
             .then(data => {
                 for (const trialInfo of data as TrialJobInfo[]) {
-                    if (this.trials.has(trialInfo.id)) {
+                    if (this.trials.has(trialInfo.trialJobId)) {
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        updated = this.trials.get(trialInfo.id)!.updateTrialJobInfo(trialInfo) || updated;
+                        updated = this.trials.get(trialInfo.trialJobId)!.updateTrialJobInfo(trialInfo) || updated;
                     } else {
-                        this.trials.set(trialInfo.id, new Trial(trialInfo, undefined));
+                        this.trials.set(trialInfo.trialJobId, new Trial(trialInfo, undefined));
                         updated = true;
                     }
                     this.maxSequenceId = Math.max(this.maxSequenceId, trialInfo.sequenceId);

--- a/test/nni_test/nnitest/utils.py
+++ b/test/nni_test/nnitest/utils.py
@@ -123,7 +123,7 @@ def print_file_content(filepath):
 def print_trial_job_log(training_service, trial_jobs_url):
     trial_jobs = get_trial_jobs(trial_jobs_url)
     for trial_job in trial_jobs:
-        trial_log_dir = os.path.join(get_experiment_dir(EXPERIMENT_URL), 'trials', trial_job['id'])
+        trial_log_dir = os.path.join(get_experiment_dir(EXPERIMENT_URL), 'trials', trial_job['trialJobId'])
         log_files = ['stderr', 'trial.log'] if training_service == 'local' else ['stdout_log_collection.log']
         for log_file in log_files:
             print_file_content(os.path.join(trial_log_dir, log_file))

--- a/tools/nni_cmd/nnictl_utils.py
+++ b/tools/nni_cmd/nnictl_utils.py
@@ -380,9 +380,9 @@ def log_trial(args):
         if response and check_response(response):
             content = json.loads(response.text)
             for trial in content:
-                trial_id_list.append(trial.get('id'))
+                trial_id_list.append(trial.get('trialJobId'))
                 if trial.get('logPath'):
-                    trial_id_path_dict[trial.get('id')] = trial['logPath']
+                    trial_id_path_dict[trial.get('trialJobId')] = trial['logPath']
     else:
         print_error('Restful server is not running...')
         exit(1)
@@ -664,7 +664,7 @@ def show_experiment_info():
                 content = json.loads(response.text)
                 for index, value in enumerate(content):
                     content[index] = convert_time_stamp_to_date(value)
-                    print(TRIAL_MONITOR_CONTENT % (content[index].get('id'), content[index].get('startTime'), \
+                    print(TRIAL_MONITOR_CONTENT % (content[index].get('trialJobId'), content[index].get('startTime'), \
                           content[index].get('endTime'), content[index].get('status')))
         print(TRIAL_MONITOR_TAIL)
 
@@ -737,7 +737,7 @@ def export_trials_data(args):
                 return
             intermediate_results = groupby_trial_id(json.loads(intermediate_results_response.text))
             for record in content:
-                record['intermediate'] = intermediate_results[record['id']]
+                record['intermediate'] = intermediate_results[record['trialJobId']]
         if args.type == 'json':
             with open(args.path, 'w') as file:
                 file.write(json.dumps(content))
@@ -749,9 +749,9 @@ def export_trials_data(args):
                     formated_record['intermediate'] = '[' + ','.join(record['intermediate']) + ']'
                 record_value = json.loads(record['value'])
                 if not isinstance(record_value, (float, int)):
-                    formated_record.update({**record['parameter'], **record_value, **{'id': record['id']}})
+                    formated_record.update({**record['parameter'], **record_value, **{'trialJobId': record['trialJobId']}})
                 else:
-                    formated_record.update({**record['parameter'], **{'reward': record_value, 'id': record['id']}})
+                    formated_record.update({**record['parameter'], **{'reward': record_value, 'trialJobId': record['trialJobId']}})
                 trial_records.append(formated_record)
             if not trial_records:
                 print_error('No trial results collected! Please check your trial log...')

--- a/tools/nni_cmd/tensorboard_utils.py
+++ b/tools/nni_cmd/tensorboard_utils.py
@@ -19,7 +19,7 @@ def parse_log_path(args, trial_content):
     path_list = []
     host_list = []
     for trial in trial_content:
-        if args.trial_id and args.trial_id != 'all' and trial.get('id') != args.trial_id:
+        if args.trial_id and args.trial_id != 'all' and trial.get('trialJobId') != args.trial_id:
             continue
         pattern = r'(?P<head>.+)://(?P<host>.+):(?P<path>.*)'
         match = re.search(pattern, trial['logPath'])
@@ -40,7 +40,7 @@ def copy_data_from_remote(args, nni_config, trial_content, path_list, host_list,
         machine_dict[machine['ip']] = {'port': machine['port'], 'passwd': machine['passwd'], 'username': machine['username'],
                                        'sshKeyPath': machine.get('sshKeyPath'), 'passphrase': machine.get('passphrase')}
     for index, host in enumerate(host_list):
-        local_path = os.path.join(temp_nni_path, trial_content[index].get('id'))
+        local_path = os.path.join(temp_nni_path, trial_content[index].get('trialJobId'))
         local_path_list.append(local_path)
         print_normal('Copying log data from %s to %s' % (host + ':' + path_list[index], local_path))
         sftp = create_ssh_sftp_client(host, machine_dict[host]['port'], machine_dict[host]['username'], machine_dict[host]['passwd'],


### PR DESCRIPTION
Unify incomplete...

Change `TrialJobInfo.id` -> `TrialJobInfo.trialJobId` in `src/nni_manager/common/datastore.ts`
Change `ExportedDataFormat.id` -> `ExportedDataFormat.trialJobId` in `src/nni_manager/common/datastore.ts`
Change `TrialJobInfo.id` -> `TrialJobInfo.trialJobId` in `src/webui/src/static/interface.ts`

Modify relevant code affected by interface changes.

? `src/nni_manager/common/trainingService.ts` `TrialJobDetail.id` `TrialJobMetric.id`
? `src/nni_manager/training_service/reusable/trial.ts` `TrialDetail.id`