### PR TITLE
Add pygments as dependency for docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.1.0
 recommonmark==0.5.0
+pygments==2.7.1
 hyperopt
 json_tricks
 numpy


### PR DESCRIPTION
Preview: https://nni.readthedocs.io/en/fix-pygments/

Pygments is downgraded for some reason. The same issue on pipeline has already been fixed in #2888.