### PR TITLE
Upgrade sphinx to 3.2.1

### DIFF
--- a/docs/en_US/conf.py
+++ b/docs/en_US/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'nbsphinx',
+    'myst_parser'
 ]
 
 # Add mock modules
@@ -60,9 +61,9 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_parsers = {
-    '.md': CommonMarkParser
-}
+# source_parsers = {
+#     '.md': CommonMarkParser
+# }
 
 source_suffix = ['.rst', '.md']
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
-sphinx==1.8.3
+sphinx==3.2.1
 sphinx-argparse==0.2.5
 sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.1.0
-recommonmark==0.5.0
+myst-parser==0.12.10
 pygments==2.7.1
 hyperopt
 json_tricks

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ sphinx-argparse==0.2.5
 sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.1.0
+recommonmark==0.5.0
 myst-parser==0.12.10
 pygments==2.7.1
 hyperopt

--- a/docs/zh_CN/conf.py
+++ b/docs/zh_CN/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'nbsphinx',
+    'myst_parser'
 ]
 
 # 添加示例模块
@@ -60,9 +61,9 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_parsers = {
-    '.md': CommonMarkParser
-}
+# source_parsers = {
+#     '.md': CommonMarkParser
+# }
 
 source_suffix = ['.rst', '.md']
 


### PR DESCRIPTION
Due to Recommonmark stopping updates, a new dependency is introduced (myst-parser).
But our doc heavily relies on `eval_rst` and we still need Recommonmark to handle this.