### PR TITLE
Udpated concat axis to match image_data_format in keras

### DIFF
--- a/src/sdk/pynni/nni/nas/tensorflow/mutator.py
+++ b/src/sdk/pynni/nni/nas/tensorflow/mutator.py
@@ -66,7 +66,12 @@ class Mutator(BaseMutator):
         if reduction_type == 'mean':
             return sum(tensor_list) / len(tensor_list)
         if reduction_type == 'concat':
-            return tf.concat(tensor_list, axis=0)
+            image_data_format = tf.keras.backend.image_data_format()
+            if image_data_format == "channels_first":
+                axis = 0
+            else:
+                axis = -1
+            return tf.concat(tensor_list, axis=axis)
         raise ValueError('Unrecognized reduction policy: "{}'.format(reduction_type))
 
     def _get_decision(self, mutable):


### PR DESCRIPTION
**What would you like to be added:**

The concatenation axis in src/sdk/pynni/nni/nas/tensorflow/mutator.py is fixed to 0 which does not reflect image_data_format setting in keras.json config.

**Why is this needed:**

This will cause the model to concatenate multiple inputs in the skip connections in the wrong dimensions. Users might get Incompatible shapes error if he uses multiple filter sizes.

**Without this feature, how does current nni work：**
nni only allows concatenating in the first dimension. This will fail if image_data_format is channel_last.

**Components that may involve changes:**
src/sdk/pynni/nni/nas/tensorflow/mutator.py