### PR TITLE
Fix bug when expanding rows not on the first page

### DIFF
--- a/src/webui/src/components/trial-detail/TableList.tsx
+++ b/src/webui/src/components/trial-detail/TableList.tsx
@@ -249,7 +249,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
             {
                 key: '_expand',
                 name: '',
-                onRender: (item, index): any => {
+                onRender: (item): any => {
                     return (
                         <Icon
                             aria-hidden={true}
@@ -269,8 +269,9 @@ class TableList extends React.Component<TableListProps, TableListState> {
                                 } else {
                                     this._expandedTrialIds.delete(newItem.id);
                                 }
-                                const newItems = [...this.state.displayedItems];
-                                newItems[index as number] = newItem;
+                                const newItems = this.state.displayedItems.map(item =>
+                                    item.id === newItem.id ? newItem : item
+                                );
                                 this.setState({
                                     displayedItems: newItems
                                 });


### PR DESCRIPTION
When the current page is not on the first, using index to locate the item in item list is not correct. This PR is to fix the bug.