### PR TITLE
quick fix exp-duration pause timing under no_more_trial status

### DIFF
--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -468,7 +468,7 @@ class NNIManager implements Manager {
         let count: number = 1;
         while (!['ERROR', 'STOPPING', 'STOPPED'].includes(this.status.status)) {
             await delay(1000 * 1); // 1 seconds
-            if (this.status.status === 'RUNNING') {
+            if (['RUNNING', 'NO_MORE_TRIAL', 'TUNER_NO_MORE_TRIAL'].includes(this.status.status)) {
                 this.experimentProfile.execDuration += 1;
                 if (count % 10 === 0) {
                     await this.storeExperimentProfile();


### PR DESCRIPTION
In the previous situation, experiment duration only timing under `RUNNING` status. But this may be different from the timing expected by the user, i.e. , timing will pause under `NO_MORE_TRIAL` and `TUNER_NO_MORE_TRIAL` status with some trials still running. 

This PR is a quick fix that when the status is `NO_MORE_TRIAL` or `TUNER_NO_MORE_TRIAL`, let the timing continue. But maybe we need give a clearer definition about `execDuration`.