### PR TITLE
Send SIGINT instead of SIGKILL

### DIFF
--- a/ts/nni_manager/training_service/local/localTrainingService.ts
+++ b/ts/nni_manager/training_service/local/localTrainingService.ts
@@ -253,7 +253,8 @@ class LocalTrainingService implements TrainingService {
 
             return Promise.resolve();
         }
-        tkill(trialJob.pid, 'SIGKILL');
+        tkill(trialJob.pid, 'SIGINT');
+        await utils_1.delay(1000);
         this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
 
         return Promise.resolve();


### PR DESCRIPTION
the process of trialJob cannot exit gracely because sigkill cannot be caught