### PR TITLE
fix bug of advisor and assesor written backwards

### DIFF
--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -9,12 +9,12 @@ export const Command1 = (): any => {
     let title = '';
     let builtinName = '';
     if (tuner !== undefined) {
-        title = title.concat('Tuner');
+        title = 'Tuner';
         if (tuner.builtinTunerName !== undefined) {
             builtinName = builtinName.concat(tuner.builtinTunerName);
         }
     }
-    
+
     if (assessor !== undefined) {
         title = title.concat('/ Assessor');
         if (assessor.builtinAssessorName !== undefined) {
@@ -23,9 +23,13 @@ export const Command1 = (): any => {
     }
 
     if (advisor !== undefined) {
-        title = title.concat('Advisor');
+        title = 'Advisor';
         if (advisor.builtinAdvisorName !== undefined) {
             builtinName = builtinName.concat(advisor.builtinAdvisorName);
+        }
+        if (advisor.className !== undefined) {
+            builtinName = builtinName.concat(advisor.className);
+
         }
     }
 

--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -15,13 +15,6 @@ export const Command1 = (): any => {
         }
     }
 
-    if (assessor !== undefined) {
-        title = title.concat('/ Assessor');
-        if (assessor.builtinAssessorName !== undefined) {
-            builtinName = builtinName.concat(assessor.builtinAssessorName);
-        }
-    }
-
     if (advisor !== undefined) {
         title = 'Advisor';
         if (advisor.builtinAdvisorName !== undefined) {
@@ -29,7 +22,13 @@ export const Command1 = (): any => {
         }
         if (advisor.className !== undefined) {
             builtinName = builtinName.concat(advisor.className);
+        }
+    }
 
+    if (assessor !== undefined) {
+        title = title.concat('/ Assessor');
+        if (assessor.builtinAssessorName !== undefined) {
+            builtinName = builtinName.concat(assessor.builtinAssessorName);
         }
     }
 

--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -11,24 +11,24 @@ export const Command1 = (): any => {
     if (tuner !== undefined) {
         title = 'Tuner';
         if (tuner.builtinTunerName !== undefined) {
-            builtinName = builtinName.concat(tuner.builtinTunerName);
+            builtinName = `${tuner.builtinTunerName}`;
         }
     }
 
     if (advisor !== undefined) {
-        title = 'Advisor';
+        title = `${title}/Advisor`;
         if (advisor.builtinAdvisorName !== undefined) {
-            builtinName = builtinName.concat(advisor.builtinAdvisorName);
+            builtinName = `${builtinName}/${advisor.builtinAdvisorName}`;
         }
         if (advisor.className !== undefined) {
-            builtinName = builtinName.concat(advisor.className);
+            builtinName = `${builtinName}/${advisor.className}`;
         }
     }
 
     if (assessor !== undefined) {
-        title = title.concat('/ Assessor');
+        title = `${title}/Assessor`;
         if (assessor.builtinAssessorName !== undefined) {
-            builtinName = builtinName.concat(assessor.builtinAssessorName);
+            builtinName = `${builtinName}/${assessor.builtinAssessorName}`;
         }
     }
 

--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -14,16 +14,18 @@ export const Command1 = (): any => {
             builtinName = builtinName.concat(tuner.builtinTunerName);
         }
     }
-    if (advisor !== undefined) {
-        title = title.concat('/ Assessor');
-        if (advisor.builtinAdvisorName !== undefined) {
-            builtinName = builtinName.concat(advisor.builtinAdvisorName);
-        }
-    }
+    
     if (assessor !== undefined) {
-        title = title.concat('/ Addvisor');
+        title = title.concat('/ Assessor');
         if (assessor.builtinAssessorName !== undefined) {
             builtinName = builtinName.concat(assessor.builtinAssessorName);
+        }
+    }
+
+    if (advisor !== undefined) {
+        title = title.concat('Advisor');
+        if (advisor.builtinAdvisorName !== undefined) {
+            builtinName = builtinName.concat(advisor.builtinAdvisorName);
         }
     }
 

--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -6,29 +6,29 @@ export const Command1 = (): any => {
     const tuner = EXPERIMENT.profile.params.tuner;
     const advisor = EXPERIMENT.profile.params.advisor;
     const assessor = EXPERIMENT.profile.params.assessor;
-    let title = '';
-    let builtinName = '';
+    const title: string[] = [];
+    const builtinName: string[] = [];
     if (tuner !== undefined) {
-        title = 'Tuner';
+        title.push('Tuner');
         if (tuner.builtinTunerName !== undefined) {
-            builtinName = `${tuner.builtinTunerName}`;
+            builtinName.push(tuner.builtinTunerName);
         }
     }
 
     if (advisor !== undefined) {
-        title = `${title}/Advisor`;
+        title.push('Advisor');
         if (advisor.builtinAdvisorName !== undefined) {
-            builtinName = `${builtinName}/${advisor.builtinAdvisorName}`;
+            builtinName.push(advisor.builtinAdvisorName);
         }
         if (advisor.className !== undefined) {
-            builtinName = `${builtinName}/${advisor.className}`;
+            builtinName.push(advisor.className);
         }
     }
 
     if (assessor !== undefined) {
-        title = `${title}/Assessor`;
+        title.push('Assessor');
         if (assessor.builtinAssessorName !== undefined) {
-            builtinName = `${builtinName}/${assessor.builtinAssessorName}`;
+            builtinName.push(assessor.builtinAssessorName);
         }
     }
 
@@ -37,8 +37,8 @@ export const Command1 = (): any => {
             <div>
                 <p className='command'>Training platform</p>
                 <div className='nowrap'>{EXPERIMENT.profile.params.trainingServicePlatform}</div>
-                <p className='lineMargin'>{title}</p>
-                <div className='nowrap'>{builtinName}</div>
+                <p className='lineMargin'>{title.join('/')}</p>
+                <div className='nowrap'>{builtinName.join('/')}</div>
             </div>
         </div>
     );


### PR DESCRIPTION
- [x] `advisor.builtinAdvisorName` is written on webui, but when user use other name instead of the field `builtinAdvisorName`, webui will miss this value