### PR TITLE
Fix macOS unit test pipeline

### DIFF
--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -138,28 +138,13 @@ jobs:
 
   - script: |
       set -e
-      echo ${PATH}
-      python --version
-      python -c 'import sys ; print(sys.executable)'
-      python -c 'import site ; print(site.getsitepackages())'
-      python -c 'import site ; print(site.getusersitepackages())'
-      echo $USER
-      (cd ~ && pwd)
-
-      ls /Users/runner/hostedtoolcache/Python/3.8.6/x64
-      ls /Users/runner/.local
-
+      echo "##vso[task.setvariable variable=PATH]${PATH}:${HOME}/.local/bin"
       python -m pip install -U --upgrade pip setuptools wheel
       python -m pip install -U pytest coverage
     displayName: 'Install Python tools'
 
   - script: |
       python3 setup.py develop
-
-      echo 'vvv Find nnictl #1 vvv'
-      find /Users/runner/hostedtoolcache/Python/3.8.6/x64 -name nnictl
-      echo 'vvv Find nnictl #2 vvv'
-      find /Users/runner/.local -name nnictl
     displayName: 'Install NNI'
 
   #- script: |

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -131,12 +131,21 @@ jobs:
   # This platform runs TypeScript unit test first.
 
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: 3.8
+    displayName: Configure Python
+
   - script: |
       set -e
-      export PYTHON38_BIN_DIR=/usr/local/Cellar/python@3.8/`ls /usr/local/Cellar/python@3.8`/bin
-      echo "##vso[task.setvariable variable=PATH]${PYTHON38_BIN_DIR}:${HOME}/Library/Python/3.8/bin:${PATH}"
-      python3 -m pip install -U --upgrade pip setuptools
-      python3 -m pip install -U pytest coverage
+      echo ${PATH}
+      python --version
+      python -c 'import sys ; print(sys.executable)'
+      python -c 'import site ; print(site.getsitepackages())'
+      python -c 'import site ; print(site.getusersitepackages())'
+
+      python -m pip install -U --upgrade pip setuptools
+      python -m pip install -U pytest coverage
     displayName: 'Install Python tools'
 
   - script: |
@@ -145,10 +154,9 @@ jobs:
 
   - script: |
       set -e
-      cd ts/nni_manager
-      yarn test
-      cd ../nasui
-      CI=true yarn test
+      export CI=true
+      (cd ts/nni_manager && yarn test)
+      (cd ts/nasui && yarn test)
     displayName: 'TypeScript unit test'
 
   - script: |

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -143,21 +143,31 @@ jobs:
       python -c 'import sys ; print(sys.executable)'
       python -c 'import site ; print(site.getsitepackages())'
       python -c 'import site ; print(site.getusersitepackages())'
+      echo $USER
+      (cd ~ && pwd)
 
-      python -m pip install -U --upgrade pip setuptools
+      ls /Users/runner/hostedtoolcache/Python/3.8.6/x64
+      ls /Users/runner/.local
+
+      python -m pip install -U --upgrade pip setuptools wheel
       python -m pip install -U pytest coverage
     displayName: 'Install Python tools'
 
   - script: |
       python3 setup.py develop
+
+      echo 'vvv Find nnictl #1 vvv'
+      find /Users/runner/hostedtoolcache/Python/3.8.6/x64 -name nnictl
+      echo 'vvv Find nnictl #2 vvv'
+      find /Users/runner/.local -name nnictl
     displayName: 'Install NNI'
 
-  - script: |
-      set -e
-      export CI=true
-      (cd ts/nni_manager && yarn test)
-      (cd ts/nasui && yarn test)
-    displayName: 'TypeScript unit test'
+  #- script: |
+  #    set -e
+  #    export CI=true
+  #    (cd ts/nni_manager && yarn test)
+  #    (cd ts/nasui && yarn test)
+  #  displayName: 'TypeScript unit test'
 
   - script: |
       set -e

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -147,12 +147,12 @@ jobs:
       python3 setup.py develop
     displayName: 'Install NNI'
 
-  #- script: |
-  #    set -e
-  #    export CI=true
-  #    (cd ts/nni_manager && yarn test)
-  #    (cd ts/nasui && yarn test)
-  #  displayName: 'TypeScript unit test'
+  - script: |
+      set -e
+      export CI=true
+      (cd ts/nni_manager && yarn test)
+      (cd ts/nasui && yarn test)
+    displayName: 'TypeScript unit test'
 
   - script: |
       set -e


### PR DESCRIPTION
Python on macOS failed to find pytest for unknown reason.
I noticed it was using a somewhat strange environment which I don't know how it was installed or configured.
I tried another approach, azure task, to set Python version and luckily it works.
So basically this PR is switching from black magic to white magic 🪄