### PR TITLE
 fix buffer allocate and wrapper name confliction 

### DIFF
--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -146,8 +146,8 @@ class QAT_Quantizer(Quantizer):
         self.steps = 1
         modules_to_compress = self.get_modules_to_compress()
         for layer, config in modules_to_compress:
-            layer.module.register_buffer("zero_point", None)
-            layer.module.register_buffer("scale", None)
+            layer.module.register_buffer("zero_point", torch.Tensor([0.0]))
+            layer.module.register_buffer("scale", torch.Tensor([1.0]))
             if "output" in config.get("quant_types", []):
                 layer.module.register_buffer('ema_decay', torch.Tensor([0.99]))
                 layer.module.register_buffer('tracked_min_biased', torch.zeros(1))

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -455,7 +455,7 @@ class QuantizerModuleWrapper(torch.nn.Module):
         super().__init__()
         # origin layer information
         self.module = module
-        self.name = module_name
+        self.name = f"wrapper_{module_name}"
         self.type = module_type
         # config and pruner
         self.config = config

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -240,39 +240,39 @@ class CompressorTestCase(TestCase):
         # range not including 0
         eps = 1e-7
         weight = torch.tensor([[1, 2], [3, 5]]).float()
-        model.conv2.module.old_weight.data = weight
-        quantizer.quantize_weight(model.conv2)
-        assert math.isclose(model.conv2.module.scale, 5 / 255, abs_tol=eps)
-        assert model.conv2.module.zero_point == 0
+        model.wrapper_conv2.module.old_weight.data = weight
+        quantizer.quantize_weight(model.wrapper_conv2)
+        assert math.isclose(model.wrapper_conv2.module.scale, 5 / 255, abs_tol=eps)
+        assert model.wrapper_conv2.module.zero_point == 0
         # range including 0
         weight = torch.tensor([[-1, 2], [3, 5]]).float()
-        model.conv2.module.old_weight.data = weight
-        quantizer.quantize_weight(model.conv2)
-        assert math.isclose(model.conv2.module.scale, 6 / 255, abs_tol=eps)
-        assert model.conv2.module.zero_point in (42, 43)
+        model.wrapper_conv2.module.old_weight.data = weight
+        quantizer.quantize_weight(model.wrapper_conv2)
+        assert math.isclose(model.wrapper_conv2.module.scale, 6 / 255, abs_tol=eps)
+        assert model.wrapper_conv2.module.zero_point in (42, 43)
         # test value of weight and bias after quantization
         weight = torch.tensor([[1.1287, 2.3456], [3.7814, 5.9723]])
         weight_valid = torch.tensor([[1.1242, 2.3421], [3.7707, 5.9723]])
         bias = torch.tensor([2.3432, 3.4342, 1.3414, 5.2341])
         bias_valid = torch.tensor([2.3432, 3.4342, 1.3414, 5.2341])
-        model.conv2.module.old_weight.data = weight
-        model.conv2.module.bias.data = bias
-        quantizer.quantize_weight(model.conv2)
-        assert torch.all(torch.isclose(model.conv2.module.weight.data, weight_valid, rtol=1e-4))
-        assert torch.all(torch.isclose(model.conv2.module.bias.data, bias_valid, rtol=1e-7))
+        model.wrapper_conv2.module.old_weight.data = weight
+        model.wrapper_conv2.module.bias.data = bias
+        quantizer.quantize_weight(model.wrapper_conv2)
+        assert torch.all(torch.isclose(model.wrapper_conv2.module.weight.data, weight_valid, rtol=1e-4))
+        assert torch.all(torch.isclose(model.wrapper_conv2.module.bias.data, bias_valid, rtol=1e-7))
 
         # test ema
         eps = 1e-7
         x = torch.tensor([[-0.2, 0], [0.1, 0.2]])
-        out = model.relu(x)
-        assert math.isclose(model.relu.module.tracked_min_biased, 0, abs_tol=eps)
-        assert math.isclose(model.relu.module.tracked_max_biased, 0.002, abs_tol=eps)
+        out = model.wrapper_relu(x)
+        assert math.isclose(model.wrapper_relu.module.tracked_min_biased, 0, abs_tol=eps)
+        assert math.isclose(model.wrapper_relu.module.tracked_max_biased, 0.002, abs_tol=eps)
 
         quantizer.step_with_optimizer()
         x = torch.tensor([[0.2, 0.4], [0.6, 0.8]])
-        out = model.relu(x)
-        assert math.isclose(model.relu.module.tracked_min_biased, 0.002, abs_tol=eps)
-        assert math.isclose(model.relu.module.tracked_max_biased, 0.00998, abs_tol=eps)
+        out = model.wrapper_relu(x)
+        assert math.isclose(model.wrapper_relu.module.tracked_min_biased, 0.002, abs_tol=eps)
+        assert math.isclose(model.wrapper_relu.module.tracked_max_biased, 0.00998, abs_tol=eps)
 
     def test_torch_pruner_validation(self):
         # test bad configuraiton


### PR DESCRIPTION
#3119

register zero_point and scale with a real value Tensor rather not None, cause latter value will cause state dict load failure

avoid wrapper's name to be the same with module's name, cause it will cause some problems when load state dict

