### PR TITLE
fix /version not handle error

### DIFF
--- a/ts/nni_manager/rest_server/restHandler.ts
+++ b/ts/nni_manager/rest_server/restHandler.ts
@@ -98,8 +98,11 @@ class NNIRestHandler {
 
     private version(router: Router): void {
         router.get('/version', async (req: Request, res: Response) => {
-            const version = await getVersion();
-            res.send(version);
+            getVersion().then((version) => {
+                res.send(version)
+            }).catch((err: Error) => {
+                this.handleError(err, res);
+            });
         });
     }
 


### PR DESCRIPTION
previous:
```
(node:6506) UnhandledPromiseRejectionWarning: Error: Cannot find module '/home/xxx/nni/ts/nni_manager/dist/package.json'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Promise.resolve.then (/home/xxx/nni/ts/nni_manager/dist/common/utils.js:276:34)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:6506) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:6506) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

now:
```
[12/4/2020, 6:38:07 PM] ERROR [ { Error: Cannot find module '/home/xxx/nni/ts/nni_manager/dist/package.json'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
      at Function.Module._load (internal/modules/cjs/loader.js:562:25)
      at Module.require (internal/modules/cjs/loader.js:692:17)
      at require (internal/modules/cjs/helpers.js:25:18)
      at Promise.resolve.then (/home/xxx/nni/ts/nni_manager/dist/common/utils.js:276:34) code: 'MODULE_NOT_FOUND' } ]
```

```
async function getVersion(): Promise<string> {
    const deferred: Deferred<string> = new Deferred<string>();
    import(path.join(__dirname, '..', 'package.json')).then((pkg) => {
        deferred.resolve(pkg.version);
    }).catch((error) => {
        deferred.reject(error);
    });
    return deferred.promise;
}
```

**Need Discuss**
`develop` in Linux use `symlink`, and use `__dirname` in `getVersion()`.
`package.json` is in `/home/xxx/nni/ts/nni_manager` not `/home/xxx/nni/ts/nni_manager/dist`. Do we need make a copy of `package.json` in `dist`?