### PR TITLE
Fix nni.experiment bug

### DIFF
--- a/nni/experiment/pipe.py
+++ b/nni/experiment/pipe.py
@@ -52,7 +52,7 @@ else:
 
         def connect(self) -> BufferedIOBase:
             conn, _ = self._socket.accept()
-            self.file = conn.makefile('w+b')
+            self.file = conn.makefile('rwb')
             return self.file
 
         def close(self) -> None:


### PR DESCRIPTION
The open mode of `socket.makefile()` is different from `open()`. "w+" is written as "rw" here.