### PR TITLE
detached tuner process under windows

### DIFF
--- a/nni/experiment/experiment.py
+++ b/nni/experiment/experiment.py
@@ -169,7 +169,7 @@ class Experiment:
             while True:
                 time.sleep(10)
                 status = self.get_status()
-                if status == 'STOPPED':
+                if status == 'DONE' or status == 'STOPPED':
                     return True
                 if status == 'ERROR':
                     return False

--- a/ts/nni_manager/common/utils.ts
+++ b/ts/nni_manager/common/utils.ts
@@ -344,16 +344,19 @@ function getTunerProc(command: string, stdio: StdioOptions, newCwd: string, newE
     let cmd: string = command;
     let arg: string[] = [];
     let newShell: boolean = true;
+    let isDetached: boolean = false;
     if (process.platform === "win32") {
         cmd = command.split(" ", 1)[0];
         arg = command.substr(cmd.length + 1).split(" ");
         newShell = false;
+        isDetached = true;
     }
     const tunerProc: ChildProcess = spawn(cmd, arg, {
         stdio,
         cwd: newCwd,
         env: newEnv,
-        shell: newShell
+        shell: newShell,
+        detached: isDetached
     });
     return tunerProc;
 }


### PR DESCRIPTION
Fix dispatcher exit before rest main process clean up. This issue due to CTRL BREAK or CTRL C is sent to all console processes that are attached to the console in Windows.