### PR TITLE
Adding back the missing softmax in DARTS and support deduplication

### DIFF
--- a/nni/retiarii/trainer/pytorch/proxyless.py
+++ b/nni/retiarii/trainer/pytorch/proxyless.py
@@ -157,6 +157,7 @@ class ProxylessTrainer(BaseOneShotTrainer):
             module.to(self.device)
 
         self.optimizer = optimizer
+        # we do not support deduplicate control parameters with same label (like DARTS) yet.
         self.ctrl_optim = torch.optim.Adam([m.alpha for _, m in self.nas_modules], arc_learning_rate,
                                            weight_decay=0, betas=(0, 0.999), eps=1e-8)
         self._init_dataloader()


### PR DESCRIPTION
I somehow missed the softmax part in DARTS, causing it to converge really slowly.

Also adding back the deduplication part (share the same architecture weight across all modules with the same label) for DARTS. Note that for ProxylessNAS this feature is not supported yet (neither in v1.x).