### PR TITLE
[2.0a2] fix bugs of experiment managerment page on webui

### DIFF
--- a/ts/webui/src/App.scss
+++ b/ts/webui/src/App.scss
@@ -36,7 +36,6 @@
 
     /* nav bar: 56 + marginTop: 24 */
     margin-top: 80px;
-    margin-bottom: 30px;
 }
 
 .bottomDiv {

--- a/ts/webui/src/components/NavCon.tsx
+++ b/ts/webui/src/components/NavCon.tsx
@@ -145,7 +145,7 @@ class NavCon extends React.Component<NavProps, NavState> {
                             <CommandBarButton iconProps={infoIconAbout} text='About' menuProps={aboutProps} />
                             <Link to='/experiment' className='experiment'>
                                 <div className='expNavTitle'>
-                                    <span>All experiment</span>
+                                    <span>All experiments</span>
                                     {ChevronRightMed}
                                 </div>
                             </Link>

--- a/ts/webui/src/components/TrialsDetail.tsx
+++ b/ts/webui/src/components/TrialsDetail.tsx
@@ -82,7 +82,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                             </Pivot>
                         </div>
                         {/* trial table list */}
-                        <div style={{ backgroundColor: '#fff', marginTop: 10 }}>
+                        <div className='detailTable' style={{ marginTop: 10 }}>
                             <TableList
                                 tableSource={source}
                                 trialsUpdateBroadcast={this.context.trialsUpdateBroadcast}

--- a/ts/webui/src/components/managementExp/ExperimentManager.tsx
+++ b/ts/webui/src/components/managementExp/ExperimentManager.tsx
@@ -84,7 +84,8 @@ class Experiment extends React.Component<{}, ExpListState> {
                     </div>
                 ) : null}
                 <Stack className='contentBox expBackground'>
-                    <Stack className='content' styles={{ root: { minHeight: window.innerHeight - 56 - 48 } }}>
+                    {/* 56px: navBarHeight; 48: marginTop & Bottom */}
+                    <Stack className='content' styles={{ root: { minHeight: window.innerHeight - 104 } }}>
                         <Stack className='experimentList'>
                             <TitleContext.Provider value={{ text: 'All experiments', icon: 'CustomList' }}>
                                 <Title />

--- a/ts/webui/src/components/managementExp/ExperimentManager.tsx
+++ b/ts/webui/src/components/managementExp/ExperimentManager.tsx
@@ -93,7 +93,7 @@ class Experiment extends React.Component<{}, ExpListState> {
                                 <div className='search'>
                                     <SearchBox
                                         className='search-input'
-                                        placeholder='Search the experiment by name and ID'
+                                        placeholder='Search the experiment by name or ID'
                                         onEscape={this.setOriginSource.bind(this)}
                                         onClear={this.setOriginSource.bind(this)}
                                         onChange={this.searchNameAndId.bind(this)}
@@ -131,6 +131,7 @@ class Experiment extends React.Component<{}, ExpListState> {
                                 compact={true}
                                 selectionMode={0} // close selector function
                                 className='table'
+                                onActiveItemChanged={this.something}
                             />
                         </Stack>
                     </Stack>
@@ -256,6 +257,15 @@ class Experiment extends React.Component<{}, ExpListState> {
         }
     ];
 
+    private something = (item?: any, _index?: number, _ev?: React.FocusEvent<HTMLElement>): void => {
+        if (item.status !== 'STOPPED' && item.port !== undefined) {
+            const hostname = window.location.hostname;
+            const protocol = window.location.protocol;
+            const webuiPortal = `${protocol}//${hostname}:${item.port}/oview`;
+            window.open(webuiPortal);
+        }
+    };
+
     private clickFilter(_e: any): void {
         const { hideFilter } = this.state;
         if (!hideFilter === true) {
@@ -282,10 +292,11 @@ class Experiment extends React.Component<{}, ExpListState> {
             if (newValue === '') {
                 this.setOriginSource();
             } else {
+                const searchInput = newValue.trim();
                 let result = originExperimentList.filter(
                     item =>
-                        item.experimentName.toLowerCase().includes(newValue.toLowerCase()) ||
-                        item.id.toLowerCase().includes(newValue.toLowerCase())
+                        item.experimentName.toLowerCase().includes(searchInput.toLowerCase()) ||
+                        item.id.toLowerCase().includes(searchInput.toLowerCase())
                 );
                 result = this.commonSelectString(result, '');
                 const sortedResult = getSortedSource(result, sortInfo);
@@ -295,7 +306,7 @@ class Experiment extends React.Component<{}, ExpListState> {
                 }));
             }
             this.setState(() => ({
-                searchInputVal: newValue
+                searchInputVal: newValue.trim()
             }));
         }
     }
@@ -419,7 +430,9 @@ class Experiment extends React.Component<{}, ExpListState> {
 
     // reset
     private setSearchSource(): void {
-        const { sortInfo, searchInputVal, originExperimentList } = this.state;
+        const { sortInfo, originExperimentList } = this.state;
+        let { searchInputVal } = this.state;
+        searchInputVal = searchInputVal.trim();
         // hert re-search data for fix this status: filter first -> searchBox search result null -> close filter
         const result = originExperimentList.filter(
             item =>

--- a/ts/webui/src/components/managementExp/ExperimentManager.tsx
+++ b/ts/webui/src/components/managementExp/ExperimentManager.tsx
@@ -132,7 +132,7 @@ class Experiment extends React.Component<{}, ExpListState> {
                                 compact={true}
                                 selectionMode={0} // close selector function
                                 className='table'
-                                onActiveItemChanged={this.something}
+                                onActiveItemChanged={this.experimentClicked}
                             />
                         </Stack>
                     </Stack>
@@ -258,7 +258,7 @@ class Experiment extends React.Component<{}, ExpListState> {
         }
     ];
 
-    private something = (item?: any, _index?: number, _ev?: React.FocusEvent<HTMLElement>): void => {
+    private experimentClicked = (item?: any, _index?: number, _ev?: React.FocusEvent<HTMLElement>): void => {
         if (item.status !== 'STOPPED' && item.port !== undefined) {
             const hostname = window.location.hostname;
             const protocol = window.location.protocol;

--- a/ts/webui/src/components/managementExp/ExperimentManager.tsx
+++ b/ts/webui/src/components/managementExp/ExperimentManager.tsx
@@ -84,7 +84,7 @@ class Experiment extends React.Component<{}, ExpListState> {
                     </div>
                 ) : null}
                 <Stack className='contentBox expBackground'>
-                    <Stack className='content'>
+                    <Stack className='content' styles={{ root: { minHeight: window.innerHeight - 56 - 48 } }}>
                         <Stack className='experimentList'>
                             <TitleContext.Provider value={{ text: 'All experiments', icon: 'CustomList' }}>
                                 <Title />

--- a/ts/webui/src/components/managementExp/ExperimentManager.tsx
+++ b/ts/webui/src/components/managementExp/ExperimentManager.tsx
@@ -9,6 +9,8 @@ import { MAXSCREENCOLUMNWIDHT, MINSCREENCOLUMNWIDHT } from './experimentConst';
 import { Hearder } from './Header';
 import NameColumn from './TrialIdColumn';
 import FilterBtns from './FilterBtns';
+import { TitleContext } from '../overview/TitleContext';
+import { Title } from '../overview/Title';
 import '../../App.scss';
 import '../../static/style/nav/nav.scss';
 import '../../static/style/experiment/experiment.scss';
@@ -84,6 +86,9 @@ class Experiment extends React.Component<{}, ExpListState> {
                 <Stack className='contentBox expBackground'>
                     <Stack className='content'>
                         <Stack className='experimentList'>
+                            <TitleContext.Provider value={{ text: 'All experiments', icon: 'CustomList' }}>
+                                <Title />
+                            </TitleContext.Provider>
                             <Stack className='box' horizontal>
                                 <div className='search'>
                                     <SearchBox

--- a/ts/webui/src/components/managementExp/TrialIdColumn.tsx
+++ b/ts/webui/src/components/managementExp/TrialIdColumn.tsx
@@ -19,9 +19,14 @@ class TrialIdColumn extends React.Component<TrialIdColumnProps, {}> {
         return (
             <div className='succeed-padding ellipsis'>
                 {status === 'STOPPED' ? (
-                    <div>{id}</div>
+                    <div className='idColor'>{id}</div>
                 ) : (
-                    <a href={webuiPortal} className='link' target='_blank' rel='noopener noreferrer'>
+                    <a
+                        href={webuiPortal}
+                        className='link toAnotherExp idColor'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    >
                         {id}
                     </a>
                 )}

--- a/ts/webui/src/static/style/experiment/experiment.scss
+++ b/ts/webui/src/static/style/experiment/experiment.scss
@@ -1,16 +1,20 @@
+$pageMargin: 24px;
+
 .expBackground {
 	background: #f2f2f2;
 	height: 100%;
 
 	.content {
-		margin-top: 24px;
+		/* TODO: here is 32 rather than $pageMargin is because experiment page `content` position */
+		margin-top: 32px;
+		margin-bottom: $pageMargin;
 		background: #fff;
 	}
 }
 
 .experimentList {
 	min-height: 99%;
-	padding:  24px 42px;
+	padding: $pageMargin 42px;
 
 	.box {
 		margin-top: 20px;

--- a/ts/webui/src/static/style/experiment/experiment.scss
+++ b/ts/webui/src/static/style/experiment/experiment.scss
@@ -7,11 +7,14 @@
 }
 
 .experimentList {
-	padding: 42px;
+	padding:  24px 42px;
 
 	.box {
+		margin-top: 20px;
+
 		.search {
 			width: 90%;
+
 			&-input {
 				width: 330px;
 			}
@@ -51,14 +54,22 @@
 		margin-left: 10px;
 	}
 
-	.tagContainer {
-		width: 100%;
+	.idColor {
+		color: #615f5d !important;
+	}
 
-		.tag {
-			font-weight: 500;
-			background: #f2f2f2;
-			margin: 0 4px;
-			padding: 0 6px;
+	.toAnotherExp {
+
+		&:hover {
+			color: #333231 !important;
 		}
+
+		&:hover {
+			color:  #615f5d !important;
+		}
+	}
+
+	.ms-DetailsRow:focus {
+		background: #e1dfdd;
 	}
 }

--- a/ts/webui/src/static/style/experiment/experiment.scss
+++ b/ts/webui/src/static/style/experiment/experiment.scss
@@ -1,12 +1,15 @@
 .expBackground {
 	background: #f2f2f2;
 	height: 100%;
+
 	.content {
+		margin-top: 24px;
 		background: #fff;
 	}
 }
 
 .experimentList {
+	min-height: 99%;
 	padding:  24px 42px;
 
 	.box {

--- a/ts/webui/src/static/style/experiment/experiment.scss
+++ b/ts/webui/src/static/style/experiment/experiment.scss
@@ -13,7 +13,6 @@ $pageMargin: 24px;
 }
 
 .experimentList {
-	min-height: 99%;
 	padding: $pageMargin 42px;
 
 	.box {

--- a/ts/webui/src/static/style/trialsDetail.scss
+++ b/ts/webui/src/static/style/trialsDetail.scss
@@ -52,7 +52,6 @@
 }
 
 .detailTable {
-    margin-top: 10px;
     margin-bottom: 24px;
     background: #fff;
 }

--- a/ts/webui/src/static/style/trialsDetail.scss
+++ b/ts/webui/src/static/style/trialsDetail.scss
@@ -51,6 +51,12 @@
     }
 }
 
+.detailTable {
+    margin-top: 10px;
+    margin-bottom: 24px;
+    background: #fff;
+}
+
 .detailTabs {
     padding-left: 6px;
     padding-right: 18px;


### PR DESCRIPTION
1. nav: `All experiment` -> `All experiments`
2. 添加子标题：icon All experiments，如图所示： 

![image](https://user-images.githubusercontent.com/61399850/103075053-cf33ee80-4605-11eb-8bed-0b3a91403df2.png)

3. row hover 以及 focus 时背景颜色

![image](https://user-images.githubusercontent.com/61399850/103083384-4160ff00-4617-11eb-9815-cf6d6a997755.png)

4. ID 超链接 hover 时的颜色（#615f5d，#333231）

![image](https://user-images.githubusercontent.com/61399850/103083473-7705e800-4617-11eb-8aaa-754cdfa90b9c.png)

5. experiment page 距离 nav 调整为 `24px`，跟其他两个页面 (oview, detail) 保持一致
6. 尽管实验条目不多，依然保持满屏

![image](https://user-images.githubusercontent.com/61399850/103116831-c9401b00-46a2-11eb-840f-8e4b727ea13e.png)

当有很多条实验时，保持如下展示：

![13 77 78 63_9999_experiment](https://user-images.githubusercontent.com/61399850/103117703-a3b51080-46a6-11eb-93f0-7435571d7d15.png)

7. add `trim()` for search name `or`(use `or` rather than `and`) ID input

![image](https://user-images.githubusercontent.com/61399850/103125434-0a95f200-46c6-11eb-8753-0f0c96672b32.png)

8. 单机 `行` 弹出此实验的 WebUI