### PR TITLE
Make standalone mode warning more obvious

### DIFF
--- a/nni/runtime/platform/standalone.py
+++ b/nni/runtime/platform/standalone.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import colorama
 import logging
+import warnings
 import json_tricks
 
 __all__ = [
@@ -16,7 +18,16 @@ _logger = logging.getLogger('nni')
 
 
 def get_next_parameter():
-    _logger.warning('Requesting parameter without NNI framework, returning empty dict')
+    warning_message = ''.join([
+        colorama.Style.BRIGHT,
+        colorama.Fore.RED,
+        'Running NNI code without runtime. ',
+        'Check following tutorial if you are new to NNI: ',
+        colorama.Fore.YELLOW,
+        'https://nni.readthedocs.io/en/stable/Tutorial/QuickStart.html#id1',
+        colorama.Style.RESET_ALL
+    ])
+    warnings.warn(warning_message, RuntimeWarning)
     return {
         'parameter_id': None,
         'parameters': {}

--- a/nni/runtime/platform/standalone.py
+++ b/nni/runtime/platform/standalone.py
@@ -22,7 +22,7 @@ def get_next_parameter():
         colorama.Style.BRIGHT,
         colorama.Fore.RED,
         'Running NNI code without runtime. ',
-        'Check following tutorial if you are new to NNI: ',
+        'Check the following tutorial if you are new to NNI: ',
         colorama.Fore.YELLOW,
         'https://nni.readthedocs.io/en/stable/Tutorial/QuickStart.html#id1',
         colorama.Style.RESET_ALL


### PR DESCRIPTION
Bug bash guide: run the trial code of an HPO example, like `examples/trials/mnist-pytorch/mnist.py`; it should print a striking warning with a link to quick start tutorial.
