### PR TITLE
Support show customized tuner/assessor name and get optimize_mode from tuner/advisor/assessor

### DIFF
--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -14,6 +14,9 @@ export const Command1 = (): any => {
         if (tuner.builtinTunerName !== undefined) {
             builtinName.push(tuner.builtinTunerName);
         }
+        if (tuner.className !== undefined) {
+            builtinName.push(tuner.className);
+        }
     }
 
     if (advisor !== undefined) {
@@ -30,6 +33,9 @@ export const Command1 = (): any => {
         title.push('Assessor');
         if (assessor.builtinAssessorName !== undefined) {
             builtinName.push(assessor.builtinAssessorName);
+        }
+        if (assessor.className !== undefined) {
+            builtinName.push(assessor.className);
         }
     }
 

--- a/ts/webui/src/components/overview/command/Command1.tsx
+++ b/ts/webui/src/components/overview/command/Command1.tsx
@@ -11,32 +11,17 @@ export const Command1 = (): any => {
     const builtinName: string[] = [];
     if (tuner !== undefined) {
         title.push('Tuner');
-        if (tuner.builtinTunerName !== undefined) {
-            builtinName.push(tuner.builtinTunerName);
-        }
-        if (tuner.className !== undefined) {
-            builtinName.push(tuner.className);
-        }
+        builtinName.push(tuner.builtinTunerName || tuner.className || 'unknown');
     }
 
     if (advisor !== undefined) {
         title.push('Advisor');
-        if (advisor.builtinAdvisorName !== undefined) {
-            builtinName.push(advisor.builtinAdvisorName);
-        }
-        if (advisor.className !== undefined) {
-            builtinName.push(advisor.className);
-        }
+        builtinName.push(advisor.builtinAdvisorName || advisor.className || 'unknown');
     }
 
     if (assessor !== undefined) {
         title.push('Assessor');
-        if (assessor.builtinAssessorName !== undefined) {
-            builtinName.push(assessor.builtinAssessorName);
-        }
-        if (assessor.className !== undefined) {
-            builtinName.push(assessor.className);
-        }
+        builtinName.push(assessor.builtinAssessorName || assessor.className || 'unknown');
     }
 
     return (

--- a/ts/webui/src/static/model/experiment.ts
+++ b/ts/webui/src/static/model/experiment.ts
@@ -128,7 +128,19 @@ class Experiment {
 
     get optimizeMode(): string {
         const tuner = this.profile.params.tuner;
-        return tuner && tuner.classArgs && tuner.classArgs.optimize_mode ? tuner.classArgs.optimize_mode : 'unknown';
+        const advisor = this.profile.params.advisor;
+        const assessor = this.profile.params.assessor;
+        const resultTuner =
+            tuner && tuner.classArgs && tuner.classArgs.optimize_mode ? tuner.classArgs.optimize_mode : undefined;
+        const resultAdvisor =
+            advisor && advisor.classArgs && advisor.classArgs.optimize_mode
+                ? advisor.classArgs.optimize_mode
+                : undefined;
+        const resultAssessor =
+            assessor && assessor.classArgs && assessor.classArgs.optimize_mode
+                ? assessor.classArgs.optimize_mode
+                : undefined;
+        return resultTuner || resultAdvisor || resultAssessor || 'unknown';
     }
 
     get trainingServicePlatform(): string {


### PR DESCRIPTION
- support `tuner/advisor/assessor` name field: `builtinXxxName || className`
- support get `optimize_mode` from `tuner/advisor/assessor`
-  webui will use `tuner` field if tuner and assessor both have `optimize_mode` field.
