### PR TITLE
fix aml outputs and python process not killed

### DIFF
--- a/ts/nni_manager/training_service/reusable/environments/amlEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/amlEnvironmentService.ts
@@ -91,16 +91,13 @@ export class AMLEnvironmentService extends EnvironmentService {
                 case 'COMPLETED':
                 case 'SUCCEEDED':
                     environment.setStatus('SUCCEEDED');
-                    this.stopEnvironment(environment);
                     break;
                 case 'FAILED':
                     environment.setStatus('FAILED');
-                    this.stopEnvironment(environment);
                     return Promise.reject(`AML: job ${environment.envId} is failed!`);
                 case 'STOPPED':
                 case 'STOPPING':
                     environment.setStatus('USER_CANCELED');
-                    this.stopEnvironment(environment);
                     break;
                 default:
                     environment.setStatus('UNKNOWN');

--- a/ts/nni_manager/training_service/reusable/environments/amlEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/amlEnvironmentService.ts
@@ -91,13 +91,16 @@ export class AMLEnvironmentService extends EnvironmentService {
                 case 'COMPLETED':
                 case 'SUCCEEDED':
                     environment.setStatus('SUCCEEDED');
+                    this.stopEnvironment(environment);
                     break;
                 case 'FAILED':
                     environment.setStatus('FAILED');
+                    this.stopEnvironment(environment);
                     return Promise.reject(`AML: job ${environment.envId} is failed!`);
                 case 'STOPPED':
                 case 'STOPPING':
                     environment.setStatus('USER_CANCELED');
+                    this.stopEnvironment(environment);
                     break;
                 default:
                     environment.setStatus('UNKNOWN');
@@ -114,7 +117,7 @@ export class AMLEnvironmentService extends EnvironmentService {
         }
         const amlEnvironment: AMLEnvironmentInformation = environment as AMLEnvironmentInformation;
         const environmentLocalTempFolder = path.join(this.experimentRootDir, this.experimentId, "environment-temp");
-        environment.command = `import os\nos.system('${amlEnvironment.command}')`;
+        environment.command = `import os\nos.system('mv envs outputs/envs && cd outputs && ${amlEnvironment.command}')`;
         environment.useActiveGpu = this.amlClusterConfig.useActiveGpu;
         environment.maxTrialNumberPerGpu = this.amlClusterConfig.maxTrialNumPerGpu;
         await fs.promises.writeFile(path.join(environmentLocalTempFolder, 'nni_script.py'), amlEnvironment.command, { encoding: 'utf8' });

--- a/ts/nni_manager/training_service/reusable/environments/localEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/localEnvironmentService.ts
@@ -111,6 +111,10 @@ ${environment.command} --job_pid_file ${environment.runnerWorkingFolder}/pid \
     }
 
     public async stopEnvironment(environment: EnvironmentInformation): Promise<void> {
+        if (environment.isAlive === false) {
+            return Promise.resolve();
+        }
+
         const jobpidPath: string = `${environment.runnerWorkingFolder}/pid`;
         const pid: string = await fs.promises.readFile(jobpidPath, 'utf8');
         tkill(Number(pid), 'SIGKILL');

--- a/ts/nni_manager/training_service/reusable/environments/openPaiEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/openPaiEnvironmentService.ts
@@ -219,6 +219,9 @@ export class OpenPaiEnvironmentService extends EnvironmentService {
     public async stopEnvironment(environment: EnvironmentInformation): Promise<void> {
         const deferred: Deferred<void> = new Deferred<void>();
 
+        if (environment.isAlive === false) {
+            return deferred.promise;
+        }
         if (this.paiClusterConfig === undefined) {
             return Promise.reject(new Error('PAI Cluster config is not initialized'));
         }

--- a/ts/nni_manager/training_service/reusable/environments/openPaiEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/openPaiEnvironmentService.ts
@@ -220,7 +220,7 @@ export class OpenPaiEnvironmentService extends EnvironmentService {
         const deferred: Deferred<void> = new Deferred<void>();
 
         if (environment.isAlive === false) {
-            return deferred.promise;
+            return Promise.resolve();
         }
         if (this.paiClusterConfig === undefined) {
             return Promise.reject(new Error('PAI Cluster config is not initialized'));

--- a/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
@@ -289,6 +289,10 @@ ${environment.command} --job_pid_file ${environment.runnerWorkingFolder}/pid \
     }
 
     public async stopEnvironment(environment: EnvironmentInformation): Promise<void> {
+        if (environment.isAlive === false) {
+            return Promise.resolve();
+        }
+
         const executor = await this.getExecutor(environment.id);
 
         if (environment.status === 'UNKNOWN') {

--- a/ts/nni_manager/training_service/reusable/trialDispatcher.ts
+++ b/ts/nni_manager/training_service/reusable/trialDispatcher.ts
@@ -310,14 +310,12 @@ class TrialDispatcher implements TrainingService {
 
         for (let index = 0; index < environments.length; index++) {
             const environment = environments[index];
-            if (environment.isAlive === true) {
-                this.log.info(`stopping environment ${environment.id}...`);
-                if (environment.environmentService === undefined) {
-                    throw new Error(`${environment.id} do not have environmentService!`);
-                }
-                await environment.environmentService.stopEnvironment(environment);
-                this.log.info(`stopped environment ${environment.id}.`);
+            this.log.info(`stopping environment ${environment.id}...`);
+            if (environment.environmentService === undefined) {
+                throw new Error(`${environment.id} do not have environmentService!`);
             }
+            await environment.environmentService.stopEnvironment(environment);
+            this.log.info(`stopped environment ${environment.id}.`);
         }
         this.commandEmitter.off("command", this.handleCommand);
         for (const commandChannel of this.commandChannelSet) {


### PR DESCRIPTION
1. only files in `./outputs` or `./logs` dir, aml will upload them to run history
2. if aml environment status is not in `['WAITING', 'RUNNING', 'UNKNOWN']`, `environment.isAlive == false`, and environment will not be stopped when `cleanup`, but the python process handled `amlUtil` is still alive.