### PR TITLE
Fix 'NoneType' Error on jupyter notebooks

### DIFF
--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -98,7 +98,10 @@ def blackbox(cls, *args, **kwargs):
     """
     # get caller module name
     frm = inspect.stack()[1]
-    module_name = inspect.getmodule(frm[0]).__name__
+    if inspect.getmodule(frm[0]):
+        module_name = inspect.getmodule(frm[0]).__name__
+    else:
+        module_name = inspect.getsourcefile(frm[0])
     return _blackbox_cls(cls, module_name, 'args')(*args, **kwargs)
 
 
@@ -107,7 +110,10 @@ def blackbox_module(cls):
     Register a module. Use it as a decorator.
     """
     frm = inspect.stack()[1]
-    module_name = inspect.getmodule(frm[0]).__name__
+    if inspect.getmodule(frm[0]):
+        module_name = inspect.getmodule(frm[0]).__name__
+    else:
+        module_name = inspect.getsourcefile(frm[0])
     return _blackbox_cls(cls, module_name, 'args')
 
 
@@ -116,7 +122,10 @@ def register_trainer(cls):
     Register a trainer. Use it as a decorator.
     """
     frm = inspect.stack()[1]
-    module_name = inspect.getmodule(frm[0]).__name__
+    if inspect.getmodule(frm[0]):
+        module_name = inspect.getmodule(frm[0]).__name__
+    else:
+        module_name = inspect.getsourcefile(frm[0])
     return _blackbox_cls(cls, module_name, 'full')
 
 

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -2,6 +2,7 @@ import inspect
 import warnings
 from collections import defaultdict
 from typing import Any
+from pathlib import Path
 
 
 def import_(target: str, allow_none: bool = False) -> Any:
@@ -98,10 +99,7 @@ def blackbox(cls, *args, **kwargs):
     """
     # get caller module name
     frm = inspect.stack()[1]
-    if inspect.getmodule(frm[0]):
-        module_name = inspect.getmodule(frm[0]).__name__
-    else:
-        module_name = inspect.getsourcefile(frm[0])
+    module_name = inspect.getmodule(frm[0]).__name__
     return _blackbox_cls(cls, module_name, 'args')(*args, **kwargs)
 
 
@@ -110,10 +108,18 @@ def blackbox_module(cls):
     Register a module. Use it as a decorator.
     """
     frm = inspect.stack()[1]
-    if inspect.getmodule(frm[0]):
-        module_name = inspect.getmodule(frm[0]).__name__
-    else:
-        module_name = inspect.getsourcefile(frm[0])
+
+    assert (inspect.getmodule(frm[0]) is not None), ('unable to locate the definition of the given black box module, '
+                                                     'please define it explicitly in a .py file.')
+    module_name = inspect.getmodule(frm[0]).__name__
+
+    if module_name == '__main__':
+        main_file_path = Path(inspect.getsourcefile(frm[0]))
+        if main_file_path.parents[0] != Path('.'):
+            raise RuntimeError(f'you are using "{main_file_path}" to launch your experiment, '
+                               f'please launch the experiment under the directory where "{main_file_path.name}" is located.')
+        module_name = main_file_path.stem
+
     return _blackbox_cls(cls, module_name, 'args')
 
 
@@ -122,10 +128,9 @@ def register_trainer(cls):
     Register a trainer. Use it as a decorator.
     """
     frm = inspect.stack()[1]
-    if inspect.getmodule(frm[0]):
-        module_name = inspect.getmodule(frm[0]).__name__
-    else:
-        module_name = inspect.getsourcefile(frm[0])
+    assert (inspect.getmodule(frm[0]) is not None), ('unable to locate the definition of the given trainer, '
+                                                     'please define it explicitly in a .py file.')
+    module_name = inspect.getmodule(frm[0]).__name__
     return _blackbox_cls(cls, module_name, 'full')
 
 


### PR DESCRIPTION
Some objects don't return anything for `getmodule()`, e.g., jupyter notebook.
While I am using it on jupyter notebooks, the code throws an Error:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-13-720eba80f94f> in <module>()
     87 
     88 @register_trainer
---> 89 class Trainer(BaseTrainer):
     90     def __init__(self, model,
     91                  train_dataloader, val_dataloader, loss_fn, optimizer, device=torch.device('cpu'), trainer_kwargs={'max_epochs': 10}):

~/anaconda3/lib/python3.7/site-packages/nni/retiarii/utils.py in register_trainer(cls)
    117     """
    118     frm = inspect.stack()[1]
--> 119     module_name = inspect.getmodule(frm[0]).__name__
    120     return _blackbox_cls(cls, module_name, 'full')
    121 

AttributeError: 'NoneType' object has no attribute '__name__'
```
In this case, we can use `getsourcefile` to get the name of the current cell in the jupyter notebook, for example, `<ipython-input-14-f75f6173b0d5>` means the 14th cell and the subsequent programs can run normally.