### PR TITLE
Fix crash in dispatcher after 1 to 10 hours when using BOHB tuner

### DIFF
--- a/nni/algorithms/hpo/bohb_advisor/config_generator.py
+++ b/nni/algorithms/hpo/bohb_advisor/config_generator.py
@@ -310,6 +310,7 @@ class CG_BOHB:
         train_losses = np.array(self.losses[budget])
 
         n_good = max(self.min_points_in_model, (self.top_n_percent * train_configs.shape[0])//100)
+        n_bad = max(self.min_points_in_model, ((100-self.top_n_percent)*train_configs.shape[0])//100)
 
         # Refit KDE for the current budget
         idx = np.argsort(train_losses)

--- a/nni/algorithms/hpo/bohb_advisor/config_generator.py
+++ b/nni/algorithms/hpo/bohb_advisor/config_generator.py
@@ -310,7 +310,6 @@ class CG_BOHB:
         train_losses = np.array(self.losses[budget])
 
         n_good = max(self.min_points_in_model, (self.top_n_percent * train_configs.shape[0])//100)
-        n_bad = max(self.min_points_in_model, ((100-self.top_n_percent)*train_configs.shape[0])//100)
 
         # Refit KDE for the current budget
         idx = np.argsort(train_losses)


### PR DESCRIPTION
## Issue

The BOHB tuner will eventually crash after 1 to 10 hours of operation.

When this crash occurs:
* No more jobs are processed by the dispatcher;
* Progress halts until NNI is manually stopped/resumed on the command line;
* The trial it crashed on is marked as "FAILED" which invalidates what could have been a good result.

See exception below. The problem is that in rare circumstances, `n_good+n_bad` is one beyond the end of the array which crashes the dispatcher with this error:

```
IndexError: index 181 is out of bounds for axis 0 with size 181
```

A clean and elegant fix is to remove `n_good+n_bad` so it slices to the end of the array by default, but no further. Added a couple of comments to make it clear what is occurring.

## Testing

* Pre fix: regular dispatcher crashes after 1 to 10 hours of operation.
* Post fix: two instances ran for 12 hours with no issues. Will continue to monitor over the next week.

## Test System

* NNI v2.0.
* Windows 10 x64
* Python 3.7.5 (not that it makes much difference).

## Exception

Stack trace of error:
```
[2021-01-29 17:03:47] ERROR (nni.runtime.msg_dispatcher_base/Thread-27) index 180 is out of bounds for axis 0 with size 180
Traceback (most recent call last):
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 121, in process_command_thread
    self.process_command(command, data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 147, in process_command
    command_handlers[command](data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\bohb_advisor.py", line 622, in handle_report_metric_data
    self.cg.new_result(loss=reward, budget=data['sequence'], parameters=_parameters, update_model=True)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\config_generator.py", line 319, in new_result
    train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:n_good+n_bad]])
IndexError: index 180 is out of bounds for axis 0 with size 180
[2021-01-29 17:03:47] ERROR (nni.runtime.msg_dispatcher_base/Thread-21) index 181 is out of bounds for axis 0 with size 181
Traceback (most recent call last):
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 121, in process_command_thread
    self.process_command(command, data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\runtime\msg_dispatcher_base.py", line 147, in process_command
    command_handlers[command](data)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\bohb_advisor.py", line 622, in handle_report_metric_data
    self.cg.new_result(loss=reward, budget=data['sequence'], parameters=_parameters, update_model=True)
  File "S:\PhiResearchV2\bin\Python375\lib\site-packages\nni\algorithms\hpo\bohb_advisor\config_generator.py", line 319, in new_result
    train_data_bad = self.impute_conditional_data(train_configs[idx[n_good:n_good+n_bad]])
IndexError: index 181 is out of bounds for axis 0 with size 181
```
