### PR TITLE
[WIP] Enable optional Pod Spec for FrameworkController platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 /ts/nni_manager/metrics.json
 /ts/nni_manager/trial_jobs.json
 
-# tmp
-*.bak
-
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /ts/nni_manager/metrics.json
 /ts/nni_manager/trial_jobs.json
 
+# tmp
+*.bak
 
 # Logs
 logs

--- a/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
+++ b/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
@@ -26,4 +26,4 @@ frameworkcontrollerConfig:
   configPath: fc_template.yml
   storage: pvc
   pvc:
-    path: /tmp/data
+    path: {your path pvc mountPath here}

--- a/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
+++ b/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
@@ -25,5 +25,6 @@ trial:
 frameworkcontrollerConfig:
   configPath: fc_template.yml
   storage: pvc
+  namespace: "default"
   pvc:
-    path: {your path pvc mountPath here}
+    path: "/tmp/data"

--- a/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
+++ b/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
@@ -1,0 +1,29 @@
+authorName: default
+experimentName: example_mnist_pytorch
+trialConcurrency: 1
+maxExecDuration: 1h
+maxTrialNum: 10
+logLevel: trace
+nniManagerIp: 127.0.0.1
+#choice: local, remote, pai, kubeflow
+trainingServicePlatform: frameworkcontroller
+searchSpacePath: search_space.json
+#choice: true, false
+useAnnotation: false
+tuner:
+  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
+  builtinTunerName: TPE
+  classArgs:
+    #choice: maximize, minimize
+    optimize_mode: maximize
+assessor:
+  builtinAssessorName: Medianstop
+  classArgs:
+    optimize_mode: maximize
+trial:
+  codeDir: .
+frameworkcontrollerConfig:
+  configPath: fc_template.yml
+  storage: pvc
+  pvc:
+    path: /tmp/data

--- a/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
+++ b/examples/trials/mnist-pytorch/config_frameworkcontroller_custom.yml
@@ -4,7 +4,6 @@ trialConcurrency: 1
 maxExecDuration: 1h
 maxTrialNum: 10
 logLevel: trace
-nniManagerIp: 127.0.0.1
 #choice: local, remote, pai, kubeflow
 trainingServicePlatform: frameworkcontroller
 searchSpacePath: search_space.json
@@ -27,4 +26,4 @@ frameworkcontrollerConfig:
   storage: pvc
   namespace: "default"
   pvc:
-    path: "/tmp/data"
+    path: "/tmp/mount"

--- a/examples/trials/mnist-pytorch/fc_template.yml
+++ b/examples/trials/mnist-pytorch/fc_template.yml
@@ -1,7 +1,7 @@
 apiVersion: frameworkcontroller.microsoft.com/v1
 kind: Framework
 metadata:
-  name: tensorflowdistributedtrainingwithcpu
+  name: pytorchcpu
   namespace: default
 spec:
   executionType: Start
@@ -25,17 +25,16 @@ spec:
           restartPolicy: Never
           hostNetwork: false
           containers:
-          - name: tensorflow
-            image: frameworkcontroller/tensorflow-examples:cpu
-            workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
-            command: []
+          - name: mnist-pytorch
+            image: msranni/nni:latest
+            command: ["python3", "mnist.py"]
             ports:
             - containerPort: 4001
             volumeMounts:
             - name: frameworkbarrier-volume
               mountPath: /mnt/frameworkbarrier
             - name: data-volume
-              mountPath: /mnt/data
+              mountPath: /tmp/data
           serviceAccountName: frameworkbarrier
           initContainers:
           - name: frameworkbarrier
@@ -47,6 +46,8 @@ spec:
           - name: frameworkbarrier-volume
             emptyDir: {}
           - name: data-volume
+            persistentVolumeClaim:
+              claimName: nni-storage
   - name: worker
     taskNumber: 3
     frameworkAttemptCompletionPolicy:
@@ -62,17 +63,16 @@ spec:
           restartPolicy: Never
           hostNetwork: false
           containers:
-          - name: tensorflow
-            image: frameworkcontroller/tensorflow-examples:cpu
-            workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
-            command: []
+          - name: mnist-pytorch
+            image: msranni/nni:latest
+            command: ["python", "mnist.py"]
             ports:
             - containerPort: 5001
             volumeMounts:
             - name: frameworkbarrier-volume
               mountPath: /mnt/frameworkbarrier
             - name: data-volume
-              mountPath: /mnt/data
+              mountPath: /tmp/data
           serviceAccountName: frameworkbarrier
           initContainers:
           - name: frameworkbarrier

--- a/examples/trials/mnist-pytorch/fc_template.yml
+++ b/examples/trials/mnist-pytorch/fc_template.yml
@@ -9,47 +9,8 @@ spec:
     fancyRetryPolicy: true
     maxRetryCount: 2
   taskRoles:
-  - name: ps
-    taskNumber: 2
-    frameworkAttemptCompletionPolicy:
-      minFailedTaskCount: 1
-      minSucceededTaskCount: -1
-    task:
-      retryPolicy:
-        fancyRetryPolicy: false
-        maxRetryCount: 0
-      # Large timeout to force delete Pod as it may break the stateful batch.
-      podGracefulDeletionTimeoutSec: 1800
-      pod:
-        spec:
-          restartPolicy: Never
-          hostNetwork: false
-          containers:
-          - name: mnist-pytorch
-            image: msranni/nni:latest
-            command: ["python3", "mnist.py"]
-            ports:
-            - containerPort: 4001
-            volumeMounts:
-            - name: frameworkbarrier-volume
-              mountPath: /mnt/frameworkbarrier
-            - name: data-volume
-              mountPath: /tmp/data
-          serviceAccountName: frameworkbarrier
-          initContainers:
-          - name: frameworkbarrier
-            image: frameworkcontroller/frameworkbarrier
-            volumeMounts:
-            - name: frameworkbarrier-volume
-              mountPath: /mnt/frameworkbarrier
-          volumes:
-          - name: frameworkbarrier-volume
-            emptyDir: {}
-          - name: data-volume
-            persistentVolumeClaim:
-              claimName: nni-storage
   - name: worker
-    taskNumber: 3
+    taskNumber: 1
     frameworkAttemptCompletionPolicy:
       minFailedTaskCount: 1
       minSucceededTaskCount: 3
@@ -72,7 +33,7 @@ spec:
             - name: frameworkbarrier-volume
               mountPath: /mnt/frameworkbarrier
             - name: data-volume
-              mountPath: /tmp/data
+              mountPath: /tmp/mount
           serviceAccountName: frameworkbarrier
           initContainers:
           - name: frameworkbarrier

--- a/examples/trials/mnist-pytorch/fc_template.yml
+++ b/examples/trials/mnist-pytorch/fc_template.yml
@@ -1,0 +1,88 @@
+apiVersion: frameworkcontroller.microsoft.com/v1
+kind: Framework
+metadata:
+  name: tensorflowdistributedtrainingwithcpu
+  namespace: default
+spec:
+  executionType: Start
+  retryPolicy:
+    fancyRetryPolicy: true
+    maxRetryCount: 2
+  taskRoles:
+  - name: ps
+    taskNumber: 2
+    frameworkAttemptCompletionPolicy:
+      minFailedTaskCount: 1
+      minSucceededTaskCount: -1
+    task:
+      retryPolicy:
+        fancyRetryPolicy: false
+        maxRetryCount: 0
+      # Large timeout to force delete Pod as it may break the stateful batch.
+      podGracefulDeletionTimeoutSec: 1800
+      pod:
+        spec:
+          restartPolicy: Never
+          hostNetwork: false
+          containers:
+          - name: tensorflow
+            image: frameworkcontroller/tensorflow-examples:cpu
+            workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
+            command: []
+            ports:
+            - containerPort: 4001
+            volumeMounts:
+            - name: frameworkbarrier-volume
+              mountPath: /mnt/frameworkbarrier
+            - name: data-volume
+              mountPath: /mnt/data
+          serviceAccountName: frameworkbarrier
+          initContainers:
+          - name: frameworkbarrier
+            image: frameworkcontroller/frameworkbarrier
+            volumeMounts:
+            - name: frameworkbarrier-volume
+              mountPath: /mnt/frameworkbarrier
+          volumes:
+          - name: frameworkbarrier-volume
+            emptyDir: {}
+          - name: data-volume
+  - name: worker
+    taskNumber: 3
+    frameworkAttemptCompletionPolicy:
+      minFailedTaskCount: 1
+      minSucceededTaskCount: 3
+    task:
+      retryPolicy:
+        fancyRetryPolicy: false
+        maxRetryCount: 0
+      podGracefulDeletionTimeoutSec: 1800
+      pod:
+        spec:
+          restartPolicy: Never
+          hostNetwork: false
+          containers:
+          - name: tensorflow
+            image: frameworkcontroller/tensorflow-examples:cpu
+            workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
+            command: []
+            ports:
+            - containerPort: 5001
+            volumeMounts:
+            - name: frameworkbarrier-volume
+              mountPath: /mnt/frameworkbarrier
+            - name: data-volume
+              mountPath: /mnt/data
+          serviceAccountName: frameworkbarrier
+          initContainers:
+          - name: frameworkbarrier
+            image: frameworkcontroller/frameworkbarrier
+            volumeMounts:
+            - name: frameworkbarrier-volume
+              mountPath: /mnt/frameworkbarrier
+          volumes:
+          - name: frameworkbarrier-volume
+            emptyDir: {}
+          - name: data-volume
+            persistentVolumeClaim:
+              claimName: nni-storage

--- a/nni/tools/nnictl/config_schema.py
+++ b/nni/tools/nnictl/config_schema.py
@@ -394,14 +394,16 @@ frameworkcontroller_config_schema = {
         'nfs': {
             'server': setType('server', str),
             'path': setType('path', str)
-        }
+        },
+        Optional('namespace'): setType('namespace', str),
     }, {Optional('configPath'): setType('configPath', str),
         Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
         Optional('serviceAccountName'): setType('serviceAccountName', str),
         Optional('configPath'): setType('configPath', str),
         'pvc': {'path': setType('server', str)},
+        Optional('namespace'): setType('namespace', str),
     }, {
-        Optional('storage'): setChoice('storage', 'nfs', 'azureStorage'),
+        Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
         Optional('serviceAccountName'): setType('serviceAccountName', str),
         'keyVault': {
             'vaultName': And(Regex('([0-9]|[a-z]|[A-Z]|-){1,127}'),
@@ -415,7 +417,8 @@ frameworkcontroller_config_schema = {
             'azureShare': And(Regex('([0-9]|[a-z]|[A-Z]|-){3,63}'),
                               error='ERROR: azureShare format error, azureShare support using (0-9|a-z|A-Z|-)')
         },
-        Optional('uploadRetryCount'): setNumberRange('uploadRetryCount', int, 1, 99999)
+        Optional('uploadRetryCount'): setNumberRange('uploadRetryCount', int, 1, 99999),
+        Optional('namespace'): setType('namespace', str),
     })
 }
 

--- a/nni/tools/nnictl/config_schema.py
+++ b/nni/tools/nnictl/config_schema.py
@@ -370,7 +370,7 @@ kubeflow_config_schema = {
 frameworkcontroller_trial_schema = {
     'trial': {
         'codeDir':  setPathCheck('codeDir'),
-        'taskRoles': [{
+        Optional('taskRoles'): [{
             'name': setType('name', str),
             'taskNum': setType('taskNum', int),
             'frameworkAttemptCompletionPolicy': {
@@ -395,11 +395,11 @@ frameworkcontroller_config_schema = {
             'server': setType('server', str),
             'path': setType('path', str)
         }
-    }, {Optional('configPath'): setType('configPath', str), {
-            Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
-            Optional('serviceAccountName'): setType('serviceAccountName', str),
-            Optional('configPath'): setType('configPath', str),
-            'pvc': {'path': setType('server', str)},
+    }, {Optional('configPath'): setType('configPath', str),
+        Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
+        Optional('serviceAccountName'): setType('serviceAccountName', str),
+        Optional('configPath'): setType('configPath', str),
+        'pvc': {'path': setType('server', str)},
     }, {
         Optional('storage'): setChoice('storage', 'nfs', 'azureStorage'),
         Optional('serviceAccountName'): setType('serviceAccountName', str),

--- a/nni/tools/nnictl/config_schema.py
+++ b/nni/tools/nnictl/config_schema.py
@@ -4,11 +4,17 @@
 import json
 import logging
 import os
+
 import netifaces
-from schema import Schema, And, Optional, Regex, Or, SchemaError
-from nni.tools.package_utils import create_validator_instance, get_all_builtin_names, get_registered_algo_meta
-from .constants import SCHEMA_TYPE_ERROR, SCHEMA_RANGE_ERROR, SCHEMA_PATH_ERROR
+from nni.tools.package_utils import (
+    create_validator_instance,
+    get_all_builtin_names,
+    get_registered_algo_meta,
+)
+from schema import And, Optional, Or, Regex, Schema, SchemaError
+
 from .common_utils import get_yml_content, print_warning
+from .constants import SCHEMA_PATH_ERROR, SCHEMA_RANGE_ERROR, SCHEMA_TYPE_ERROR
 
 
 def setType(key, valueType):
@@ -171,9 +177,9 @@ pai_yarn_trial_schema = {
         Optional('virtualCluster'): setType('virtualCluster', str),
         Optional('nasMode'): setChoice('nasMode', 'classic_mode', 'enas_mode', 'oneshot_mode', 'darts_mode'),
         Optional('portList'): [{
-            "label": setType('label', str),
-            "beginAt": setType('beginAt', int),
-            "portNumber": setType('portNumber', int)
+            'label': setType('label', str),
+            'beginAt': setType('beginAt', int),
+            'portNumber': setType('portNumber', int)
         }]
     }
 }
@@ -383,12 +389,17 @@ frameworkcontroller_trial_schema = {
 
 frameworkcontroller_config_schema = {
     'frameworkcontrollerConfig': Or({
-        Optional('storage'): setChoice('storage', 'nfs', 'azureStorage'),
+        Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
         Optional('serviceAccountName'): setType('serviceAccountName', str),
         'nfs': {
             'server': setType('server', str),
             'path': setType('path', str)
         }
+    }, {Optional('configPath'): setType('configPath', str), {
+            Optional('storage'): setChoice('storage', 'nfs', 'azureStorage', 'pvc'),
+            Optional('serviceAccountName'): setType('serviceAccountName', str),
+            Optional('configPath'): setType('configPath', str),
+            'pvc': {'path': setType('server', str)},
     }, {
         Optional('storage'): setChoice('storage', 'nfs', 'azureStorage'),
         Optional('serviceAccountName'): setType('serviceAccountName', str),
@@ -576,7 +587,7 @@ class NNIConfigSchema:
                 and not experiment_config.get('nniManagerIp') \
                 and 'eth0' not in netifaces.interfaces():
             raise SchemaError('This machine does not contain eth0 network device, please set nniManagerIp in config file!')
-    
+
     def validate_hybrid_platforms(self, experiment_config):
         required_config_name_map = {
             'remote': 'machineList',
@@ -588,4 +599,4 @@ class NNIConfigSchema:
                 config_name = required_config_name_map.get(platform)
                 if config_name and not experiment_config.get(config_name):
                     raise SchemaError('Need to set {0} for {1} in hybrid mode!'.format(config_name, platform))
-                
+

--- a/nni/tools/nnictl/launcher_utils.py
+++ b/nni/tools/nnictl/launcher_utils.py
@@ -100,6 +100,11 @@ def parse_path(experiment_config, config_path):
     if experiment_config['trial'].get('paiConfigPath'):
         parse_relative_path(root_path, experiment_config['trial'], 'paiConfigPath')
 
+    # For frameworkcontroller a custom configuration path may be specified
+    if experiment_config.get('frameworkcontrollerConfig'):
+        if experiment_config['frameworkcontrollerConfig'].get('configPath'):
+            parse_relative_path(root_path, experiment_config['frameworkcontrollerConfig'], 'configPath')
+
 def set_default_values(experiment_config):
     if experiment_config.get('maxExecDuration') is None:
         experiment_config['maxExecDuration'] = '999d'

--- a/ts/nni_manager/rest_server/restValidationSchemas.ts
+++ b/ts/nni_manager/rest_server/restValidationSchemas.ts
@@ -63,14 +63,14 @@ export namespace ValidationSchemas {
                     command: joi.string().min(1).required()
                 }),
                 ps: joi.object({
-                        replicas: joi.number().min(1).required(),
-                        image: joi.string().min(1),
-                        privateRegistryAuthPath: joi.string().min(1),
-                        outputDir: joi.string(),
-                        cpuNum: joi.number().min(1),
-                        memoryMB: joi.number().min(100),
-                        gpuNum: joi.number().min(0).required(),
-                        command: joi.string().min(1).required()
+                    replicas: joi.number().min(1).required(),
+                    image: joi.string().min(1),
+                    privateRegistryAuthPath: joi.string().min(1),
+                    outputDir: joi.string(),
+                    cpuNum: joi.number().min(1),
+                    memoryMB: joi.number().min(100),
+                    gpuNum: joi.number().min(0).required(),
+                    command: joi.string().min(1).required()
                 }),
                 master: joi.object({
                     replicas: joi.number().min(1).required(),
@@ -168,7 +168,8 @@ export namespace ValidationSchemas {
                     accountName: joi.string().regex(/^([0-9]|[a-z]|[A-Z]|-){3,31}$/),
                     azureShare: joi.string().regex(/^([0-9]|[a-z]|[A-Z]|-){3,63}$/)
                 }),
-                uploadRetryCount: joi.number().min(1)
+                uploadRetryCount: joi.number().min(1),
+                namespace: joi.string().min(1)
             }),
             dlts_config: joi.object({ // eslint-disable-line @typescript-eslint/camelcase
                 dashboard: joi.string().min(1),

--- a/ts/nni_manager/rest_server/restValidationSchemas.ts
+++ b/ts/nni_manager/rest_server/restValidationSchemas.ts
@@ -152,6 +152,10 @@ export namespace ValidationSchemas {
             frameworkcontroller_config: joi.object({ // eslint-disable-line @typescript-eslint/camelcase
                 storage: joi.string().min(1),
                 serviceAccountName: joi.string().min(1),
+                pvc: joi.object({
+                    path: joi.string().min(1).required()
+                }),
+                configPath: joi.string().min(1),
                 nfs: joi.object({
                     server: joi.string().min(1).required(),
                     path: joi.string().min(1).required()
@@ -168,10 +172,10 @@ export namespace ValidationSchemas {
             }),
             dlts_config: joi.object({ // eslint-disable-line @typescript-eslint/camelcase
                 dashboard: joi.string().min(1),
-              
+
                 cluster: joi.string().min(1),
                 team: joi.string().min(1),
-              
+
                 email: joi.string().min(1),
                 password: joi.string().min(1)
             }),

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerApiClient.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerApiClient.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as fs from 'fs';
-import { GeneralK8sClient, KubernetesCRDClient } from '../kubernetesApiClient';
+import {GeneralK8sClient, KubernetesCRDClient} from '../kubernetesApiClient';
 
 /**
  * FrameworkController ClientV1
@@ -13,14 +13,16 @@ class FrameworkControllerClientV1 extends KubernetesCRDClient {
     /**
      * constructor, to initialize frameworkcontroller CRD definition
      */
-    public constructor() {
+    public namespace: string;
+    public constructor(namespace?: string) {
         super();
+        this.namespace = namespace ? namespace : "default"
         this.crdSchema = JSON.parse(fs.readFileSync('./config/frameworkcontroller/frameworkcontrollerjob-crd-v1.json', 'utf8'));
         this.client.addCustomResourceDefinition(this.crdSchema);
     }
 
     protected get operator(): any {
-        return this.client.apis['frameworkcontroller.microsoft.com'].v1.namespaces('default').frameworks;
+        return this.client.apis['frameworkcontroller.microsoft.com'].v1.namespaces(this.namespace).frameworks;
     }
 
     public get containerName(): string {
@@ -35,9 +37,9 @@ class FrameworkControllerClientFactory {
     /**
      * Factory method to generate operator client
      */
-    public static createClient(): KubernetesCRDClient {
-        return new FrameworkControllerClientV1();
+    public static createClient(namespace?: string): KubernetesCRDClient {
+        return new FrameworkControllerClientV1(namespace);
     }
 }
 
-export { FrameworkControllerClientFactory, GeneralK8sClient };
+export {FrameworkControllerClientFactory, GeneralK8sClient};

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
@@ -10,6 +10,7 @@ import {
     KubernetesStorageKind, KubernetesTrialConfig, KubernetesTrialConfigTemplate, NFSConfig, StorageConfig, KubernetesClusterConfigPVC,
     PVCConfig,
 } from '../kubernetesConfig';
+import {config} from 'rx';
 
 export class FrameworkAttemptCompletionPolicy {
     public readonly minFailedTaskCount: number;
@@ -50,7 +51,7 @@ export class FrameworkControllerTrialConfig extends KubernetesTrialConfig {
 export class FrameworkControllerClusterConfig extends KubernetesClusterConfig {
     public readonly serviceAccountName: string;
     constructor(apiVersion: string, serviceAccountName: string, configPath?: string, namespace?: string) {
-        super(apiVersion, undefined, namespace) ;
+        super(apiVersion, undefined, namespace);
         this.serviceAccountName = serviceAccountName;
     }
 }
@@ -82,15 +83,18 @@ export class FrameworkControllerClusterConfigPVC extends KubernetesClusterConfig
 
 export class FrameworkControllerClusterConfigNFS extends KubernetesClusterConfigNFS {
     public readonly serviceAccountName: string;
+    public readonly configPath?: string;
     constructor(
         serviceAccountName: string,
         apiVersion: string,
         nfs: NFSConfig,
         storage?: KubernetesStorageKind,
-        namespace?: string
+        namespace?: string,
+        configPath?: string
     ) {
         super(apiVersion, nfs, storage, namespace);
         this.serviceAccountName = serviceAccountName;
+        this.configPath = configPath
     }
 
     public static getInstance(jsonObject: object): FrameworkControllerClusterConfigNFS {
@@ -109,6 +113,7 @@ export class FrameworkControllerClusterConfigNFS extends KubernetesClusterConfig
 
 export class FrameworkControllerClusterConfigAzure extends KubernetesClusterConfigAzure {
     public readonly serviceAccountName: string;
+    public readonly configPath?: string;
 
     constructor(
         serviceAccountName: string,
@@ -117,10 +122,12 @@ export class FrameworkControllerClusterConfigAzure extends KubernetesClusterConf
         azureStorage: AzureStorage,
         storage?: KubernetesStorageKind,
         uploadRetryCount?: number,
-        namespace?: string
+        namespace?: string,
+        configPath?: string
     ) {
         super(apiVersion, keyVault, azureStorage, storage, uploadRetryCount, namespace);
         this.serviceAccountName = serviceAccountName;
+        this.configPath = configPath
     }
 
     public static getInstance(jsonObject: object): FrameworkControllerClusterConfigAzure {

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
@@ -5,7 +5,8 @@
 
 import * as assert from 'assert';
 
-import { AzureStorage, KeyVaultConfig, KubernetesClusterConfig, KubernetesClusterConfigAzure, KubernetesClusterConfigNFS,
+import {
+    AzureStorage, KeyVaultConfig, KubernetesClusterConfig, KubernetesClusterConfigAzure, KubernetesClusterConfigNFS,
     KubernetesStorageKind, KubernetesTrialConfig, KubernetesTrialConfigTemplate, NFSConfig, StorageConfig, KubernetesClusterConfigPVC,
     PVCConfig,
 } from '../kubernetesConfig';
@@ -27,8 +28,8 @@ export class FrameworkControllerTrialConfigTemplate extends KubernetesTrialConfi
     public readonly name: string;
     public readonly taskNum: number;
     constructor(taskNum: number, command: string, gpuNum: number,
-                cpuNum: number, memoryMB: number, image: string,
-                frameworkAttemptCompletionPolicy: FrameworkAttemptCompletionPolicy, privateRegistryFilePath?: string | undefined) {
+        cpuNum: number, memoryMB: number, image: string,
+        frameworkAttemptCompletionPolicy: FrameworkAttemptCompletionPolicy, privateRegistryFilePath?: string | undefined) {
         super(command, gpuNum, cpuNum, memoryMB, image, privateRegistryFilePath);
         this.frameworkAttemptCompletionPolicy = frameworkAttemptCompletionPolicy;
         this.name = name;
@@ -48,19 +49,18 @@ export class FrameworkControllerTrialConfig extends KubernetesTrialConfig {
 
 export class FrameworkControllerClusterConfig extends KubernetesClusterConfig {
     public readonly serviceAccountName: string;
-    public readonly configPath?: string;
-    constructor(apiVersion: string, serviceAccountName: string, configPath?: string) {
-        super(apiVersion);
+    constructor(apiVersion: string, serviceAccountName: string, configPath?: string, namespace?: string) {
+        super(apiVersion, undefined, namespace) ;
         this.serviceAccountName = serviceAccountName;
-        this.configPath = configPath;
     }
 }
 
 export class FrameworkControllerClusterConfigPVC extends KubernetesClusterConfigPVC {
     public readonly serviceAccountName: string;
     public readonly configPath: string;
-    constructor(serviceAccountName: string, apiVersion: string, pvc: PVCConfig, configPath: string, storage?: KubernetesStorageKind) {
-        super(apiVersion, pvc, storage);
+    constructor(serviceAccountName: string, apiVersion: string, pvc: PVCConfig, configPath: string,
+        storage?: KubernetesStorageKind, namespace?: string) {
+        super(apiVersion, pvc, storage, namespace);
         this.serviceAccountName = serviceAccountName;
         this.configPath = configPath
     }
@@ -74,7 +74,8 @@ export class FrameworkControllerClusterConfigPVC extends KubernetesClusterConfig
             kubernetesClusterConfigObjectPVC.apiVersion,
             kubernetesClusterConfigObjectPVC.pvc,
             kubernetesClusterConfigObjectPVC.configPath,
-            kubernetesClusterConfigObjectPVC.storage
+            kubernetesClusterConfigObjectPVC.storage,
+            kubernetesClusterConfigObjectPVC.namespace
         );
     }
 }
@@ -82,24 +83,26 @@ export class FrameworkControllerClusterConfigPVC extends KubernetesClusterConfig
 export class FrameworkControllerClusterConfigNFS extends KubernetesClusterConfigNFS {
     public readonly serviceAccountName: string;
     constructor(
-            serviceAccountName: string,
-            apiVersion: string,
-            nfs: NFSConfig,
-            storage?: KubernetesStorageKind
-        ) {
-        super(apiVersion, nfs, storage);
+        serviceAccountName: string,
+        apiVersion: string,
+        nfs: NFSConfig,
+        storage?: KubernetesStorageKind,
+        namespace?: string
+    ) {
+        super(apiVersion, nfs, storage, namespace);
         this.serviceAccountName = serviceAccountName;
     }
 
     public static getInstance(jsonObject: object): FrameworkControllerClusterConfigNFS {
-        const kubeflowClusterConfigObjectNFS: FrameworkControllerClusterConfigNFS = <FrameworkControllerClusterConfigNFS>jsonObject;
-        assert (kubeflowClusterConfigObjectNFS !== undefined);
+        const kubernetesClusterConfigObjectNFS: FrameworkControllerClusterConfigNFS = <FrameworkControllerClusterConfigNFS>jsonObject;
+        assert(kubernetesClusterConfigObjectNFS !== undefined);
 
         return new FrameworkControllerClusterConfigNFS(
-            kubeflowClusterConfigObjectNFS.serviceAccountName,
-            kubeflowClusterConfigObjectNFS.apiVersion,
-            kubeflowClusterConfigObjectNFS.nfs,
-            kubeflowClusterConfigObjectNFS.storage
+            kubernetesClusterConfigObjectNFS.serviceAccountName,
+            kubernetesClusterConfigObjectNFS.apiVersion,
+            kubernetesClusterConfigObjectNFS.nfs,
+            kubernetesClusterConfigObjectNFS.storage,
+            kubernetesClusterConfigObjectNFS.namespace
         );
     }
 }
@@ -108,25 +111,29 @@ export class FrameworkControllerClusterConfigAzure extends KubernetesClusterConf
     public readonly serviceAccountName: string;
 
     constructor(
-            serviceAccountName: string,
-            apiVersion: string,
-            keyVault: KeyVaultConfig,
-            azureStorage: AzureStorage,
-            storage?: KubernetesStorageKind
-        ) {
-        super(apiVersion, keyVault, azureStorage, storage);
+        serviceAccountName: string,
+        apiVersion: string,
+        keyVault: KeyVaultConfig,
+        azureStorage: AzureStorage,
+        storage?: KubernetesStorageKind,
+        uploadRetryCount?: number,
+        namespace?: string
+    ) {
+        super(apiVersion, keyVault, azureStorage, storage, uploadRetryCount, namespace);
         this.serviceAccountName = serviceAccountName;
     }
 
     public static getInstance(jsonObject: object): FrameworkControllerClusterConfigAzure {
-        const kubeflowClusterConfigObjectAzure: FrameworkControllerClusterConfigAzure = <FrameworkControllerClusterConfigAzure>jsonObject;
+        const kubernetesClusterConfigObjectAzure: FrameworkControllerClusterConfigAzure = <FrameworkControllerClusterConfigAzure>jsonObject;
 
         return new FrameworkControllerClusterConfigAzure(
-            kubeflowClusterConfigObjectAzure.serviceAccountName,
-            kubeflowClusterConfigObjectAzure.apiVersion,
-            kubeflowClusterConfigObjectAzure.keyVault,
-            kubeflowClusterConfigObjectAzure.azureStorage,
-            kubeflowClusterConfigObjectAzure.storage
+            kubernetesClusterConfigObjectAzure.serviceAccountName,
+            kubernetesClusterConfigObjectAzure.apiVersion,
+            kubernetesClusterConfigObjectAzure.keyVault,
+            kubernetesClusterConfigObjectAzure.azureStorage,
+            kubernetesClusterConfigObjectAzure.storage,
+            kubernetesClusterConfigObjectAzure.uploadRetryCount,
+            kubernetesClusterConfigObjectAzure.namespace
         );
     }
 }
@@ -134,22 +141,22 @@ export class FrameworkControllerClusterConfigAzure extends KubernetesClusterConf
 export class FrameworkControllerClusterConfigFactory {
 
     public static generateFrameworkControllerClusterConfig(jsonObject: object): FrameworkControllerClusterConfig {
-         const storageConfig: StorageConfig = <StorageConfig>jsonObject;
-         if (storageConfig === undefined) {
+        const storageConfig: StorageConfig = <StorageConfig>jsonObject;
+        if (storageConfig === undefined) {
             throw new Error('Invalid json object as a StorageConfig instance');
         }
         if (storageConfig.storage !== undefined && storageConfig.storage === 'azureStorage') {
             return FrameworkControllerClusterConfigAzure.getInstance(jsonObject);
         } else if (storageConfig.storage === undefined || storageConfig.storage === 'nfs') {
             return FrameworkControllerClusterConfigNFS.getInstance(jsonObject);
-        } else if ( storageConfig.storage === undefined || storageConfig.storage === 'pvc') {
+        } else if (storageConfig.storage !== undefined && storageConfig.storage === 'pvc') {
             return FrameworkControllerClusterConfigPVC.getInstance(jsonObject);
         }
-    throw new Error(`Invalid json object ${jsonObject}`);
-  }
+        throw new Error(`Invalid json object ${jsonObject}`);
+    }
 }
 
 export type FrameworkControllerJobStatus =
-  'AttemptRunning' | 'Completed' | 'AttemptCreationPending' | 'AttemptCreationRequested' | 'AttemptPreparing' | 'AttemptCompleted';
+    'AttemptRunning' | 'Completed' | 'AttemptCreationPending' | 'AttemptCreationRequested' | 'AttemptPreparing' | 'AttemptCompleted';
 
 export type FrameworkControllerJobCompleteStatus = 'Succeeded' | 'Failed';

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerConfig.ts
@@ -10,7 +10,6 @@ import {
     KubernetesStorageKind, KubernetesTrialConfig, KubernetesTrialConfigTemplate, NFSConfig, StorageConfig, KubernetesClusterConfigPVC,
     PVCConfig,
 } from '../kubernetesConfig';
-import {config} from 'rx';
 
 export class FrameworkAttemptCompletionPolicy {
     public readonly minFailedTaskCount: number;

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
@@ -301,7 +301,7 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
             const fcClusterConfigNFS: FrameworkControllerClusterConfigNFS = <FrameworkControllerClusterConfigNFS>this.fcClusterConfig;
             const nfsConfig: NFSConfig = fcClusterConfigNFS.nfs;
             return `nfs://${nfsConfig.server}:${destDirectory}`;
-        } else if (this.fcClusterConfig.storage === 'pvc' || this.fcClusterConfig.storage === undefined) {
+        } else if (this.fcClusterConfig.storage === 'pvc') {
             await cpp.exec(`mkdir -p ${this.trialLocalNFSTempFolder}/${destDirectory}`);
             await cpp.exec(`cp -r ${srcDirectory}/* ${this.trialLocalNFSTempFolder}/${destDirectory}/.`);
             return `${this.trialLocalNFSTempFolder}/${destDirectory}`;

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
@@ -140,13 +140,16 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
         const trialLocalTempFolder: string = path.join(getExperimentRootDir(), 'trials-local', trialJobId);
         let frameworkcontrollerJobName: string = `nniexp${this.experimentId}trial${trialJobId}`.toLowerCase();
 
+        // Create frameworkcontroller job based on generated frameworkcontroller job resource config
+        let frameworkcontrollerJobConfig = JSON.parse(JSON.stringify(this.fcTemplate));
+
         if (this.fcTemplate !== undefined) {
             // add a custom name extension to the job name and apply it to the custom template
             frameworkcontrollerJobName += "xx" + this.fcTemplate.metadata.name;
             // Process custom task roles commands
             configTaskRoles.map((x: any, i: number) => {
                 const scriptName = path.join(trialWorkingFolder, "run_" + x.name + ".sh")
-                this.fcTemplate.spec.taskRoles[i].task.pod.spec.containers[0].command = ["sh", scriptName]
+                frameworkcontrollerJobConfig.spec.taskRoles[i].task.pod.spec.containers[0].command = ["sh", scriptName]
             })
         }
 
@@ -173,12 +176,9 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
         // Set trial job detail until create frameworkcontroller job successfully
         this.trialJobsMap.set(trialJobId, trialJobDetail);
 
-        // Create frameworkcontroller job based on generated frameworkcontroller job resource config
-        let frameworkcontrollerJobConfig: any = {};
-
         if (this.fcTemplate !== undefined) {
             frameworkcontrollerJobConfig = {
-                ...this.fcTemplate,
+                ...frameworkcontrollerJobConfig,
                 metadata: {...this.fcTemplate.metadata, name: frameworkcontrollerJobName}
             };
         } else {

--- a/ts/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
@@ -202,8 +202,8 @@ class KubeflowTrainingService extends KubernetesTrainingService implements Kuber
             const azureKubeflowClusterConfig: KubeflowClusterConfigAzure = <KubeflowClusterConfigAzure>this.kubeflowClusterConfig;
             return await this.uploadFolderToAzureStorage(srcDirectory, destDirectory, azureKubeflowClusterConfig.uploadRetryCount);
         } else if (this.kubeflowClusterConfig.storage === 'nfs' || this.kubeflowClusterConfig.storage === undefined) {
-            await cpp.exec(`mkdir -p ${this.trialLocalNFSTempFolder}/${destDirectory}`);
-            await cpp.exec(`cp -r ${srcDirectory}/* ${this.trialLocalNFSTempFolder}/${destDirectory}/.`);
+            await cpp.exec(`mkdir -p ${this.trialLocalTempFolder}/${destDirectory}`);
+            await cpp.exec(`cp -r ${srcDirectory}/* ${this.trialLocalTempFolder}/${destDirectory}/.`);
             const nfsKubeflowClusterConfig: KubeflowClusterConfigNFS = <KubeflowClusterConfigNFS>this.kubeflowClusterConfig;
             const nfsConfig: NFSConfig = nfsKubeflowClusterConfig.nfs;
             return `nfs://${nfsConfig.server}:${destDirectory}`;
@@ -426,7 +426,7 @@ class KubeflowTrainingService extends KubernetesTrainingService implements Kuber
             }]);
         }
         // The config spec for container field
-        const containersSpecMap: Map<string, object> = new Map<string, object>(); 
+        const containersSpecMap: Map<string, object> = new Map<string, object>();
         containersSpecMap.set('containers', [
         {
                 // Kubeflow tensorflow operator requires that containers' name must be tensorflow

--- a/ts/nni_manager/training_service/kubernetes/kubernetesApiClient.ts
+++ b/ts/nni_manager/training_service/kubernetes/kubernetesApiClient.ts
@@ -4,8 +4,8 @@
 'use strict';
 
 // eslint-disable-next-line @typescript-eslint/camelcase
-import { Client1_10, config } from 'kubernetes-client';
-import { getLogger, Logger } from '../../common/log';
+import {Client1_10, config} from 'kubernetes-client';
+import {getLogger, Logger} from '../../common/log';
 
 /**
  * Generic Kubernetes client, target version >= 1.9
@@ -16,12 +16,15 @@ class GeneralK8sClient {
     protected namespace: string = 'default';
 
     constructor() {
-        this.client = new Client1_10({ config: config.fromKubeconfig(), version: '1.9'});
+        this.client = new Client1_10({config: config.fromKubeconfig(), version: '1.9'});
         this.client.loadSpec();
     }
 
     public set setNamespace(namespace: string) {
         this.namespace = namespace;
+    }
+    public get getNamespace(): string {
+        return this.namespace;
     }
 
     private matchStorageClass(response: any): string {
@@ -32,7 +35,7 @@ class GeneralK8sClient {
             new RegExp("\\b" + "efs" + "\\b")
         ]
         const templateLen = adlSupportedProvisioners.length,
-              responseLen = response.items.length
+            responseLen = response.items.length
         let i = 0,
             j = 0;
         for (; i < responseLen; i++) {
@@ -66,7 +69,7 @@ class GeneralK8sClient {
     public async createDeployment(deploymentManifest: any): Promise<string> {
         let result: Promise<string>;
         const response: any = await this.client.apis.apps.v1.namespaces(this.namespace)
-          .deployments.post({ body: deploymentManifest })
+            .deployments.post({body: deploymentManifest})
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(response.body.metadata.uid);
         } else {
@@ -79,7 +82,7 @@ class GeneralK8sClient {
         let result: Promise<boolean>;
         // TODO: change this hard coded deployment name after demo
         const response: any = await this.client.apis.apps.v1.namespaces(this.namespace)
-          .deployment(deploymentName).delete();
+            .deployment(deploymentName).delete();
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(true);
         } else {
@@ -91,7 +94,7 @@ class GeneralK8sClient {
     public async createConfigMap(configMapManifest: any): Promise<boolean> {
         let result: Promise<boolean>;
         const response: any = await this.client.api.v1.namespaces(this.namespace)
-          .configmaps.post({body: configMapManifest});
+            .configmaps.post({body: configMapManifest});
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(true);
         } else {
@@ -104,7 +107,7 @@ class GeneralK8sClient {
     public async createPersistentVolumeClaim(pvcManifest: any): Promise<boolean> {
         let result: Promise<boolean>;
         const response: any = await this.client.api.v1.namespaces(this.namespace)
-          .persistentvolumeclaims.post({body: pvcManifest});
+            .persistentvolumeclaims.post({body: pvcManifest});
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(true);
         } else {
@@ -116,7 +119,7 @@ class GeneralK8sClient {
     public async createSecret(secretManifest: any): Promise<boolean> {
         let result: Promise<boolean>;
         const response: any = await this.client.api.v1.namespaces(this.namespace)
-          .secrets.post({body: secretManifest});
+            .secrets.post({body: secretManifest});
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(true);
         } else {
@@ -136,7 +139,7 @@ abstract class KubernetesCRDClient {
     protected crdSchema: any;
 
     constructor() {
-        this.client = new Client1_10({ config: config.fromKubeconfig() });
+        this.client = new Client1_10({config: config.fromKubeconfig()});
         this.client.loadSpec();
     }
 
@@ -181,7 +184,7 @@ abstract class KubernetesCRDClient {
     public async getKubernetesJob(kubeflowJobName: string): Promise<any> {
         let result: Promise<any>;
         const response: any = await this.operator(kubeflowJobName)
-          .get();
+            .get();
         if (response.statusCode && (response.statusCode >= 200 && response.statusCode <= 299)) {
             result = Promise.resolve(response.body);
         } else {
@@ -195,16 +198,16 @@ abstract class KubernetesCRDClient {
         let result: Promise<boolean>;
         // construct match query from labels for deleting tfjob
         const matchQuery: string = Array.from(labels.keys())
-                                     .map((labelKey: string) => `${labelKey}=${labels.get(labelKey)}`)
-                                     .join(',');
+            .map((labelKey: string) => `${labelKey}=${labels.get(labelKey)}`)
+            .join(',');
         try {
             const deleteResult: any = await this.operator()
-              .delete({
-                 qs: {
-                      labelSelector: matchQuery,
-                      propagationPolicy: 'Background'
-                     }
-            });
+                .delete({
+                    qs: {
+                        labelSelector: matchQuery,
+                        propagationPolicy: 'Background'
+                    }
+                });
             if (deleteResult.statusCode && deleteResult.statusCode >= 200 && deleteResult.statusCode <= 299) {
                 result = Promise.resolve(true);
             } else {
@@ -219,4 +222,4 @@ abstract class KubernetesCRDClient {
     }
 }
 
-export { KubernetesCRDClient, GeneralK8sClient };
+export {KubernetesCRDClient, GeneralK8sClient};

--- a/ts/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/kubernetesTrainingService.ts
@@ -309,6 +309,18 @@ abstract class KubernetesTrainingService {
 
         return Promise.resolve();
     }
+    protected async createPVCStorage(pvcPath: string): Promise<void> {
+        try {
+            await cpp.exec(`sudo ln -s ${pvcPath} ${this.trialLocalNFSTempFolder}`);
+        } catch (error) {
+            const linkError: string = `Linking ${pvcPath} to ${this.trialLocalNFSTempFolder} failed, error is ${error}`;
+            this.log.error(linkError);
+
+            return Promise.reject(linkError);
+        }
+
+        return Promise.resolve();
+    }
 
     protected async createRegistrySecret(filePath: string | undefined): Promise<string | undefined> {
         if(filePath === undefined || filePath === '') {
@@ -337,7 +349,7 @@ abstract class KubernetesTrainingService {
         );
         return registrySecretName;
     }
-    
+
     /**
      * upload local directory to azureStorage
      * @param srcDirectory the source directory of local folder
@@ -349,7 +361,7 @@ abstract class KubernetesTrainingService {
             throw new Error('azureStorageClient is not initialized');
         }
         let retryCount: number = 1;
-        if(uploadRetryCount) {
+        if (uploadRetryCount) {
             retryCount = uploadRetryCount;
         }
         let uploadSuccess: boolean = false;
@@ -358,7 +370,7 @@ abstract class KubernetesTrainingService {
             do {
                 uploadSuccess = await AzureStorageClientUtility.uploadDirectory(
                     this.azureStorageClient,
-                    `${destDirectory}`, 
+                    `${destDirectory}`,
                     this.azureStorageShare,
                     `${srcDirectory}`);
                 if (!uploadSuccess) {


### PR DESCRIPTION
As discussed in #3350, this PR introduces: 
- The option to specify a custom framework controller config for framework controller mode
- A minimum working setup for the mnist-pytorch example (nni config and framework controller config)
- Required changes to the related python parser / webserver logic

In addition, the following changes have been applied:
- Option to specify a k8s namespace for the trials to run 

Currently, the following components have not yet been considered (thus the WIP state):
- documentation for the code and examples
- unit tests covering the changes