### PR TITLE
[Retiarii] Use ValueChoice inline in a serializable instance

### DIFF
--- a/docs/en_US/NAS/retiarii/Tutorial.rst
+++ b/docs/en_US/NAS/retiarii/Tutorial.rst
@@ -83,7 +83,7 @@ For easy usability and also backward compatibility, we provide some APIs for use
     # invoked in `forward` function, choose one from the three
     out = self.input_switch([tensor1, tensor2, tensor3])
 
-* ``nn.ValueChoice``. It is for choosing one value from some candidate values. It can only be used as input argument of the modules in ``nn.modules`` and ``@blackbox_module`` decorated user-defined modules. *Note that it has not been officially supported.*
+* ``nn.ValueChoice``. It is for choosing one value from some candidate values. It can only be used as input argument of the modules in ``nn.modules`` and ``@blackbox_module`` decorated user-defined modules.
 
   .. code-block:: python
 

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -152,6 +152,14 @@ class Model:
         }
         return ret
 
+    def get_nodes(self) -> List['Node']:
+        """
+        Traverse through all the nodes.
+        """
+        for graph in self.graphs.values():
+            for node in graph.nodes:
+                yield node
+
     def get_nodes_by_label(self, label: str) -> List['Node']:
         """
         Traverse all the nodes to find the matched node(s) with the given name.

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -6,7 +6,7 @@ import abc
 import copy
 import json
 from enum import Enum
-from typing import (Any, Dict, List, Optional, Tuple, Union, overload)
+from typing import (Any, Dict, Iterable, List, Optional, Tuple, Union, overload)
 
 from .operation import Cell, Operation, _IOPseudoOperation
 from .utils import get_full_class_name, import_, uid
@@ -152,7 +152,7 @@ class Model:
         }
         return ret
 
-    def get_nodes(self) -> List['Node']:
+    def get_nodes(self) -> Iterable['Node']:
         """
         Traverse through all the nodes.
         """

--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -273,7 +273,7 @@ class ValueChoice(Translatable, nn.Module):
         warnings.warn('You should not run forward of this module directly.')
         return self.candidates[0]
 
-    def __translate__(self):
+    def _translate(self):
         # Will function as a value when used in serializer.
         return self.candidates[0]
 

--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -5,7 +5,7 @@ import warnings
 import torch
 import torch.nn as nn
 
-from ...utils import uid, add_record, del_record
+from ...utils import uid, add_record, del_record, Translatable
 
 
 __all__ = ['LayerChoice', 'InputChoice', 'ValueChoice', 'Placeholder', 'ChosenInputs']
@@ -189,7 +189,7 @@ class InputChoice(nn.Module):
         return candidate_inputs[0]
 
 
-class ValueChoice(nn.Module):
+class ValueChoice(Translatable, nn.Module):
     """
     ValueChoice is to choose one from ``candidates``.
 
@@ -235,6 +235,10 @@ class ValueChoice(nn.Module):
 
     def forward(self):
         warnings.warn('You should not run forward of this module directly.')
+        return self.candidates[0]
+
+    def __translate__(self):
+        # Will function as a value when used in serializer.
         return self.candidates[0]
 
 

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -97,7 +97,7 @@ class Translatable(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __translate__(self) -> Any:
+    def _translate(self) -> Any:
         pass
 
 
@@ -116,10 +116,10 @@ def _blackbox_cls(cls):
             args = list(args)
             for i, value in enumerate(args):
                 if isinstance(value, Translatable):
-                    args[i] = value.__translate__()
+                    args[i] = value._translate()
             for i, value in kwargs.items():
                 if isinstance(value, Translatable):
-                    kwargs[i] = value.__translate__()
+                    kwargs[i] = value._translate()
 
             add_record(id(self), full_args)  # for compatibility. Will remove soon.
 

--- a/test/ut/retiarii/test_highlevel_apis.py
+++ b/test/ut/retiarii/test_highlevel_apis.py
@@ -10,7 +10,7 @@ from nni.retiarii.codegen import model_to_pytorch_script
 from nni.retiarii.nn.pytorch.mutator import process_inline_mutation
 
 
-class EnuemrateSampler(Sampler):
+class EnumerateSampler(Sampler):
     def __init__(self):
         self.index = 0
 
@@ -70,7 +70,7 @@ class TestHighLevelAPI(unittest.TestCase):
         model = self._convert_to_ir(Net())
         mutators = process_inline_mutation(model)
         self.assertEqual(len(mutators), 1)
-        mutator = mutators[0].bind_sampler(EnuemrateSampler())
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
         model1 = mutator.apply(model)
         model2 = mutator.apply(model)
         self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 3, 3)).size(),
@@ -94,7 +94,7 @@ class TestHighLevelAPI(unittest.TestCase):
         model = self._convert_to_ir(Net())
         mutators = process_inline_mutation(model)
         self.assertEqual(len(mutators), 1)
-        mutator = mutators[0].bind_sampler(EnuemrateSampler())
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
         model1 = mutator.apply(model)
         model2 = mutator.apply(model)
         self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 3, 3)).size(),
@@ -119,7 +119,7 @@ class TestHighLevelAPI(unittest.TestCase):
             model = self._convert_to_ir(Net(reduction))
             mutators = process_inline_mutation(model)
             self.assertEqual(len(mutators), 1)
-            mutator = mutators[0].bind_sampler(EnuemrateSampler())
+            mutator = mutators[0].bind_sampler(EnumerateSampler())
             model = mutator.apply(model)
             result = self._get_converted_pytorch_model(model)(torch.randn(1, 3, 3, 3))
             if reduction == 'none':
@@ -144,13 +144,94 @@ class TestHighLevelAPI(unittest.TestCase):
         model = self._convert_to_ir(Net())
         mutators = process_inline_mutation(model)
         self.assertEqual(len(mutators), 1)
-        mutator = mutators[0].bind_sampler(EnuemrateSampler())
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
         model1 = mutator.apply(model)
         model2 = mutator.apply(model)
         self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 3, 3)).size(),
                          torch.Size([1, 3, 3, 3]))
         self.assertEqual(self._get_converted_pytorch_model(model2)(torch.randn(1, 3, 3, 3)).size(),
                          torch.Size([1, 5, 3, 3]))
+
+    def test_value_choice_as_parameter(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 5, kernel_size=nn.ValueChoice([3, 5]))
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = self._convert_to_ir(Net())
+        mutators = process_inline_mutation(model)
+        self.assertEqual(len(mutators), 1)
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
+        model1 = mutator.apply(model)
+        model2 = mutator.apply(model)
+        self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 5, 3, 3]))
+        self.assertEqual(self._get_converted_pytorch_model(model2)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 5, 1, 1]))
+
+    def test_value_choice_as_parameter(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 5, kernel_size=nn.ValueChoice([3, 5]))
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = self._convert_to_ir(Net())
+        mutators = process_inline_mutation(model)
+        self.assertEqual(len(mutators), 1)
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
+        model1 = mutator.apply(model)
+        model2 = mutator.apply(model)
+        self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 5, 3, 3]))
+        self.assertEqual(self._get_converted_pytorch_model(model2)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 5, 1, 1]))
+
+    def test_value_choice_as_parameter(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, nn.ValueChoice([6, 8]), kernel_size=nn.ValueChoice([3, 5]))
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = self._convert_to_ir(Net())
+        mutators = process_inline_mutation(model)
+        self.assertEqual(len(mutators), 2)
+        mutators[0].bind_sampler(EnumerateSampler())
+        mutators[1].bind_sampler(EnumerateSampler())
+        input = torch.randn(1, 3, 5, 5)
+        self.assertEqual(self._get_converted_pytorch_model(mutators[1].apply(mutators[0].apply(model)))(input).size(),
+                         torch.Size([1, 6, 3, 3]))
+        self.assertEqual(self._get_converted_pytorch_model(mutators[1].apply(mutators[0].apply(model)))(input).size(),
+                         torch.Size([1, 8, 1, 1]))
+
+    def test_value_choice_as_parameter_shared(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = nn.Conv2d(3, nn.ValueChoice([6, 8], label='shared'), 1)
+                self.conv2 = nn.Conv2d(3, nn.ValueChoice([6, 8], label='shared'), 1)
+
+            def forward(self, x):
+                return self.conv1(x) + self.conv2(x)
+
+        model = self._convert_to_ir(Net())
+        mutators = process_inline_mutation(model)
+        self.assertEqual(len(mutators), 1)
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
+        model1 = mutator.apply(model)
+        model2 = mutator.apply(model)
+        self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 6, 5, 5]))
+        self.assertEqual(self._get_converted_pytorch_model(model2)(torch.randn(1, 3, 5, 5)).size(),
+                         torch.Size([1, 8, 5, 5]))
 
     def test_value_choice_in_functional(self):
         class Net(nn.Module):
@@ -164,7 +245,7 @@ class TestHighLevelAPI(unittest.TestCase):
         model = self._convert_to_ir(Net())
         mutators = process_inline_mutation(model)
         self.assertEqual(len(mutators), 1)
-        mutator = mutators[0].bind_sampler(EnuemrateSampler())
+        mutator = mutators[0].bind_sampler(EnumerateSampler())
         model1 = mutator.apply(model)
         model2 = mutator.apply(model)
         self.assertEqual(self._get_converted_pytorch_model(model1)(torch.randn(1, 3, 3, 3)).size(), torch.Size([1, 3, 3, 3]))


### PR DESCRIPTION
# Goal

```python
self.conv = nn.Conv2d(3, 32, kernel_size=nn.ValueChoice([3, 5, 7]))
```

# Work items

- [x] Serializer support
- [x] Graphgen support
- [x] Mutator support
- [x] Test
