### PR TITLE
Convert config files in examples to v2 schema

### DIFF
--- a/examples/trials/auto-gbdt/config.yml
+++ b/examples/trials/auto-gbdt/config.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_auto-gbdt
+maxExperimentDuration: 10h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 10h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: minimize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: minimize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/auto-gbdt/config_metis.yml
+++ b/examples/trials/auto-gbdt/config_metis.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_auto-gbdt-metis
+maxExperimentDuration: 10h
+maxTrialNumber: 10
+searchSpaceFile: search_space_metis.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 10h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space_metis.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: MetisTuner
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: minimize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: minimize}
+  name: MetisTuner
+useAnnotation: false

--- a/examples/trials/auto-gbdt/config_pai.yml
+++ b/examples/trials/auto-gbdt/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_auto-gbdt
-trialConcurrency: 1
-maxExecDuration: 10h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: minimize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 10h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 main.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: minimize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/benchmarking/config_hyperband.yml
+++ b/examples/trials/benchmarking/config_hyperband.yml
@@ -1,27 +1,14 @@
-authorName: default
-experimentName: example_mnist_hyperband
-trialConcurrency: 2
-maxExecDuration: 100h
-maxTrialNum: 10000
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 advisor:
-  #choice: Hyperband, BOHB
-  builtinAdvisorName: Hyperband
-  classArgs:
-    #R: the maximum trial budget (could be the number of mini-batches or epochs) can be
-    #   allocated to a trial. Each trial should use trial budget to control how long it runs.
-    R: 60
-    #eta: proportion of discarded trials
-    eta: 3
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    #choice: serial, parallelism
-    exec_mode: serial
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {R: 60, eta: 3, exec_mode: serial, optimize_mode: maximize}
+  name: Hyperband
+debug: false
+experimentName: example_mnist_hyperband
+maxExperimentDuration: 100h
+maxTrialNumber: 10000
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
+trialConcurrency: 2
+trialGpuNumber: 0
+useAnnotation: false

--- a/examples/trials/cifar10_pytorch/config.yml
+++ b/examples/trials/cifar10_pytorch/config.yml
@@ -1,23 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_pytorch_cifar10
+maxExperimentDuration: 100h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 2, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 4
-maxExecDuration: 100h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 1
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 1
-localConfig:
-  maxTrialNumPerGpu:  2
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/cifar10_pytorch/config_pai.yml
+++ b/examples/trials/cifar10_pytorch/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_pytorch_cifar10
-trialConcurrency: 1
-maxExecDuration: 100h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 1
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 100h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 main.py
+trialConcurrency: 1
+trialGpuNumber: 1
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/efficientnet/config_local.yml
+++ b/examples/trials/efficientnet/config_local.yml
@@ -1,18 +1,16 @@
-authorName: unknown
+debug: false
 experimentName: example_efficient_net
+maxExperimentDuration: 99999d
+maxTrialNumber: 100
+searchSpaceFile: search_net.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: EfficientNet-PyTorch
+trialCommand: python main.py /data/imagenet -j 12 -a efficientnet --batch-size 48
+  --lr 0.048 --wd 1e-5 --epochs 5 --request-from-nni
 trialConcurrency: 4
-maxExecDuration: 99999d
-maxTrialNum: 100
-trainingServicePlatform: local
-searchSpacePath: search_net.json
-useAnnotation: false
+trialGpuNumber: 1
 tuner:
-  codeDir: .
-  classFileName: tuner.py
-  className: FixedProductTuner
-  classArgs:
-    product: 2
-trial:
-  codeDir: EfficientNet-PyTorch
-  command: python main.py /data/imagenet -j 12 -a efficientnet --batch-size 48 --lr 0.048 --wd 1e-5 --epochs 5 --request-from-nni
-  gpuNum: 1
+  classArgs: {product: 2}
+  classDirectory: !!python/object/apply:pathlib.PosixPath []
+  className: tuner.FixedProductTuner
+useAnnotation: false

--- a/examples/trials/ga_squad/config.yml
+++ b/examples/trials/ga_squad/config.yml
@@ -1,19 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_ga_squad
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 trial.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  codeDir: ../../tuners/ga_customer_tuner
-  classFileName: customer_tuner.py
-  className: CustomerTuner
-  classArgs:
-    optimize_mode: maximize
-trial:
-  command: python3 trial.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [.., .., tuners, ga_customer_tuner]
+  className: customer_tuner.CustomerTuner
+useAnnotation: false

--- a/examples/trials/ga_squad/config_pai.yml
+++ b/examples/trials/ga_squad/config_pai.yml
@@ -1,35 +1,18 @@
-authorName: default
+debug: false
 experimentName: example_ga_squad
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-#choice: true, false
-useAnnotation: false
-#Your nni_manager ip
+maxExperimentDuration: 1h
+maxTrialNumber: 10
 nniManagerIp: 10.10.10.10
+trainingService: {containerStorageMountPoint: /mnt/data/user, dockerImage: msranni/nni:latest,
+  host: 10.10.10.10, localStorageMountPoint: /home/user/mnt, platform: openpai, reuseMode: false,
+  storageConfigName: confignfs-data, token: token, trialCpuNumber: 1, trialMemorySize: 32869,
+  username: username}
+trialCodeDirectory: .
+trialCommand: chmod +x ./download.sh && ./download.sh && python3 trial.py
+trialConcurrency: 1
+trialGpuNumber: 0
 tuner:
-  codeDir: ../../tuners/ga_customer_tuner
-  classFileName: customer_tuner.py
-  className: CustomerTuner
-  classArgs:
-    optimize_mode: maximize
-trial:
-  command: chmod +x ./download.sh && ./download.sh && python3 trial.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 32869
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: /home/user/mnt
-  containerNFSMountPath: /mnt/data/user
-  paiStorageConfigName: confignfs-data
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
-  host: 10.10.10.10
+  classArgs: {optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [.., .., tuners, ga_customer_tuner]
+  className: customer_tuner.CustomerTuner
+useAnnotation: false

--- a/examples/trials/kaggle-tgs-salt/config.yml
+++ b/examples/trials/kaggle-tgs-salt/config.yml
@@ -1,20 +1,13 @@
-authorName: default
+debug: false
 experimentName: example_tgs
+maxExperimentDuration: 10h
+maxTrialNumber: 10
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 train.py
 trialConcurrency: 2
-maxExecDuration: 10h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-#choice: true, false
-useAnnotation: true
+trialGpuNumber: 1
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 train.py
-  codeDir: .
-  gpuNum: 1
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-advisor/config_bohb.yml
+++ b/examples/trials/mnist-advisor/config_bohb.yml
@@ -1,23 +1,14 @@
-authorName: default
-experimentName: example_mnist_bohb
-trialConcurrency: 1
-maxExecDuration: 10h
-maxTrialNum: 1000
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 advisor:
-  #choice: Hyperband, BOHB
-  #(BOHB should be installed through nnictl)
-  builtinAdvisorName: BOHB
-  classArgs:
-    max_budget: 27
-    min_budget: 1
-    eta: 3
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {eta: 3, max_budget: 27, min_budget: 1, optimize_mode: maximize}
+  name: BOHB
+debug: false
+experimentName: example_mnist_bohb
+maxExperimentDuration: 10h
+maxTrialNumber: 1000
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+useAnnotation: false

--- a/examples/trials/mnist-advisor/config_hyperband.yml
+++ b/examples/trials/mnist-advisor/config_hyperband.yml
@@ -1,27 +1,14 @@
-authorName: default
-experimentName: example_mnist_hyperband
-trialConcurrency: 2
-maxExecDuration: 100h
-maxTrialNum: 10000
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 advisor:
-  #choice: Hyperband, BOHB
-  builtinAdvisorName: Hyperband
-  classArgs:
-    #R: the maximum trial budget (could be the number of mini-batches or epochs) can be
-    #   allocated to a trial. Each trial should use trial budget to control how long it runs.
-    R: 100
-    #eta: proportion of discarded trials
-    eta: 3
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    #choice: serial, parallelism
-    exec_mode: parallelism
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {R: 100, eta: 3, exec_mode: parallelism, optimize_mode: maximize}
+  name: Hyperband
+debug: false
+experimentName: example_mnist_hyperband
+maxExperimentDuration: 100h
+maxTrialNumber: 10000
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 2
+trialGpuNumber: 0
+useAnnotation: false

--- a/examples/trials/mnist-advisor/config_pai.yml
+++ b/examples/trials/mnist-advisor/config_pai.yml
@@ -1,41 +1,17 @@
-authorName: default
-experimentName: example_mnist_hyperband
-maxExecDuration: 1h
-maxTrialNum: 10000
-trialConcurrency: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 advisor:
-  #choice: Hyperband, BOHB
-  #(BOHB should be installed through nnictl)
-  builtinAdvisorName: Hyperband
-  classArgs:
-    #R: the maximum trial budget
-    R: 100
-    #eta: proportion of discarded trials
-    eta: 3
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    #choice: serial, parallelism
-    exec_mode: parallelism
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: /home/user/mnt
-  containerNFSMountPath: /mnt/data/user
-  paiStorageConfigName: confignfs-data
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
-  host: 10.10.10.10
+  classArgs: {R: 100, eta: 3, exec_mode: parallelism, optimize_mode: maximize}
+  name: Hyperband
+debug: false
+experimentName: example_mnist_hyperband
+maxExperimentDuration: 1h
+maxTrialNumber: 10000
+searchSpaceFile: search_space.json
+trainingService: {containerStorageMountPoint: /mnt/data/user, dockerImage: msranni/nni:latest,
+  host: 10.10.10.10, localStorageMountPoint: /home/user/mnt, platform: openpai, reuseMode: false,
+  storageConfigName: confignfs-data, token: token, trialCpuNumber: 1, trialMemorySize: 8196,
+  username: username}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 10
+trialGpuNumber: 0
+useAnnotation: false

--- a/examples/trials/mnist-annotation/config.yml
+++ b/examples/trials/mnist-annotation/config.yml
@@ -1,20 +1,13 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-#choice: true, false
-useAnnotation: true
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-annotation/config_gpu.yml
+++ b/examples/trials/mnist-annotation/config_gpu.yml
@@ -1,20 +1,13 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 4
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-#choice: true, false
-useAnnotation: true
+trialGpuNumber: 1
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 1
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-annotation/config_kubeflow.yml
+++ b/examples/trials/mnist-annotation/config_kubeflow.yml
@@ -1,31 +1,23 @@
-authorName: default
+debug: false
 experimentName: example_dist
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 1
-#choice: local, remote, pai, kubeflow
-trainingServicePlatform: kubeflow
-#choice: true, false
-useAnnotation: true
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  codeDir: .
-  worker:
-    replicas: 1
-    command: python3 mnist.py
-    gpuNum: 0
-    cpuNum: 1
-    memoryMB: 8192
-    image: msranni/nni:latest
-kubeflowConfig:
-  operator: tf-operator
+maxExperimentDuration: 1h
+maxTrialNumber: 1
+trainingService:
   apiVersion: v1alpha2
-  storage: nfs
-  nfs:
-    server: 10.10.10.10
-    path: /var/nfs/general
+  operator: tf-operator
+  platform: kubeflow
+  storage: {path: /var/nfs/general, server: 10.10.10.10, storage: nfs}
+  worker:
+    command: python3 mnist.py
+    cpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    dockerImage: msranni/nni:latest
+    gpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    memorySize: 8192
+    replicas: 1
+trialCodeDirectory: .
+trialCommand: !!python/object:dataclasses._MISSING_TYPE {}
+trialConcurrency: 1
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-annotation/config_pai.yml
+++ b/examples/trials/mnist-annotation/config_pai.yml
@@ -1,34 +1,16 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+trainingService: {containerStorageMountPoint: /mnt/data/user, dockerImage: msranni/nni:latest,
+  host: 10.10.10.10, localStorageMountPoint: /home/user/mnt, platform: openpai, reuseMode: false,
+  storageConfigName: confignfs-data, token: token, trialCpuNumber: 1, trialMemorySize: 8196,
+  username: username}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-#choice: true, false
-useAnnotation: true
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: /home/user/mnt
-  containerNFSMountPath: /mnt/data/user
-  paiStorageConfigName: confignfs-data
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
-  host: 10.10.10.10
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-annotation/config_remote.yml
+++ b/examples/trials/mnist-annotation/config_remote.yml
@@ -1,33 +1,22 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+trainingService:
+  machineList:
+  - {host: 10.1.1.1, maxTrialNumberPerGpu: 1, password: bob123, port: 22, useActiveGpu: false,
+    user: bob}
+  - {host: 10.1.1.2, maxTrialNumberPerGpu: 1, password: bob123, port: 22, useActiveGpu: false,
+    user: bob}
+  - {host: 10.1.1.3, maxTrialNumberPerGpu: 1, password: bob123, port: 22, useActiveGpu: false,
+    user: bob}
+  platform: remote
+  reuseMode: false
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: remote
-#choice: true, false
-useAnnotation: true
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-#machineList can be empty if the platform is local
-machineList:
-  - ip: 10.1.1.1
-    username: bob
-    passwd: bob123
-    #port can be skip if using default ssh port 22
-    #port: 22
-  - ip: 10.1.1.2
-    username: bob
-    passwd: bob123
-  - ip: 10.1.1.3
-    username: bob
-    passwd: bob123
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: true

--- a/examples/trials/mnist-batch-tune-keras/config.yml
+++ b/examples/trials/mnist-batch-tune-keras/config.yml
@@ -1,18 +1,12 @@
-authorName: default
+debug: false
 experimentName: example_mnist-keras
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist-keras.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
+trialGpuNumber: 0
+tuner: {name: BatchTuner}
 useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: BatchTuner
-trial:
-  command: python3 mnist-keras.py
-  codeDir: .
-  gpuNum: 0

--- a/examples/trials/mnist-batch-tune-keras/config_pai.yml
+++ b/examples/trials/mnist-batch-tune-keras/config_pai.yml
@@ -1,32 +1,23 @@
-authorName: default
+debug: false
 experimentName: example_mnist-keras
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: BatchTuner
-trial:
-  command: python3 mnist-keras.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 mnist-keras.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner: {name: BatchTuner}
+useAnnotation: false

--- a/examples/trials/mnist-distributed/config_kubeflow.yml
+++ b/examples/trials/mnist-distributed/config_kubeflow.yml
@@ -1,45 +1,37 @@
-authorName: default
-experimentName: example_mnist
-trialConcurrency: 2
-maxExecDuration: 1h
-maxTrialNum: 20
-#choice: local, remote, pai, kubeflow
-trainingServicePlatform: kubeflow
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
 assessor:
-  builtinAssessorName: Medianstop
-  classArgs:
-    optimize_mode: maximize
-trial:
-  codeDir: .
-  worker:
-    replicas: 2
-    command: python3 dist_mnist.py
-    gpuNum: 1
-    cpuNum: 1
-    memoryMB: 8196
-    image: msranni/nni:latest
-  ps:
-    replicas: 1
-    command: python3 dist_mnist.py
-    gpuNum: 0
-    cpuNum: 1
-    memoryMB: 8196
-    image: msranni/nni:latest
-kubeflowConfig:
-  operator: tf-operator
+  classArgs: {optimize_mode: maximize}
+  name: Medianstop
+debug: false
+experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 20
+searchSpaceFile: search_space.json
+trainingService:
   apiVersion: v1alpha2
-  storage: nfs
-  nfs:
-    # Your NFS server IP, like 10.10.10.10
-    server: {your_nfs_server_ip}
-    # Your NFS server export path, like /var/nfs/nni
-    path: {your_nfs_server_export_path}
+  operator: tf-operator
+  parameterServer:
+    command: python3 dist_mnist.py
+    cpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    dockerImage: msranni/nni:latest
+    gpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    memorySize: 8196
+    replicas: 1
+  platform: kubeflow
+  storage:
+    path: {your_nfs_server_export_path: null}
+    server: {your_nfs_server_ip: null}
+    storage: nfs
+  worker:
+    command: python3 dist_mnist.py
+    cpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    dockerImage: msranni/nni:latest
+    gpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    memorySize: 8196
+    replicas: 2
+trialCodeDirectory: .
+trialCommand: !!python/object:dataclasses._MISSING_TYPE {}
+trialConcurrency: 2
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-keras/config.yml
+++ b/examples/trials/mnist-keras/config.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist-keras
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist-keras.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist-keras.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-keras/config_pai.yml
+++ b/examples/trials/mnist-keras/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_mnist-keras
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist-keras.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 mnist-keras.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-nested-search-space/config.yml
+++ b/examples/trials/mnist-nested-search-space/config.yml
@@ -1,20 +1,14 @@
-authorName: default
+debug: false
 experimentName: mnist-nested-search-space
+maxExperimentDuration: 1h
+maxTrialNumber: 100
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 2
-maxExecDuration: 1h
-maxTrialNum: 100
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pbt-tuner-pytorch/config.yml
+++ b/examples/trials/mnist-pbt-tuner-pytorch/config.yml
@@ -1,22 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist_pbt_tuner_pytorch
+maxExperimentDuration: 2h
+maxTrialNumber: 100
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 3
-maxExecDuration: 2h
-maxTrialNum: 100
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 1
 tuner:
-#  codeDir: ~/nni/src/sdk/pynni/nni/pbt_tuner
-#  classFileName: pbt_tuner.py
-#  className: PBTTuner
-  builtinTunerName: PBTTuner
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 1
+  classArgs: {optimize_mode: maximize}
+  name: PBTTuner
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config.yml
+++ b/examples/trials/mnist-pytorch/config.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist_pytorch
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config_aml.yml
+++ b/examples/trials/mnist-pytorch/config_aml.yml
@@ -1,25 +1,15 @@
-authorName: default
+debug: false
 experimentName: example_mnist_pytorch
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {computeTarget: '${replace_to_your_computeTarget}', dockerImage: msranni/nni,
+  platform: aml, resourceGroup: '${replace_to_your_resourceGroup}', subscriptionId: '${replace_to_your_subscriptionId}',
+  workspaceName: '${replace_to_your_workspaceName}'}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-trainingServicePlatform: aml
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  image: msranni/nni
-amlConfig:
-  subscriptionId: ${replace_to_your_subscriptionId}
-  resourceGroup: ${replace_to_your_resourceGroup}
-  workspaceName: ${replace_to_your_workspaceName}
-  computeTarget: ${replace_to_your_computeTarget}
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config_assessor.yml
+++ b/examples/trials/mnist-pytorch/config_assessor.yml
@@ -1,27 +1,17 @@
-authorName: default
-experimentName: example_mnist_pytorch
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 50
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
 assessor:
-  #choice: Medianstop, Curvefitting
-  builtinAssessorName: Curvefitting
-  classArgs:
-    epoch_num: 20
-    threshold: 0.9
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {epoch_num: 20, threshold: 0.9}
+  name: Curvefitting
+debug: false
+experimentName: example_mnist_pytorch
+maxExperimentDuration: 1h
+maxTrialNumber: 50
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config_kubeflow.yml
+++ b/examples/trials/mnist-pytorch/config_kubeflow.yml
@@ -1,32 +1,24 @@
-authorName: default
+debug: false
 experimentName: example_dist_pytorch
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 1
-#choice: local, remote, pai, kubeflow
-trainingServicePlatform: kubeflow
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  codeDir: .
-  worker:
-    replicas: 1
-    command: python3 mnist.py
-    gpuNum: 0
-    cpuNum: 1
-    memoryMB: 8192
-    image: msranni/nni:latest
-kubeflowConfig:
-  operator: tf-operator
+maxExperimentDuration: 1h
+maxTrialNumber: 1
+searchSpaceFile: search_space.json
+trainingService:
   apiVersion: v1alpha2
-  storage: nfs
-  nfs:
-    server: 10.10.10.10
-    path: /var/nfs/general
+  operator: tf-operator
+  platform: kubeflow
+  storage: {path: /var/nfs/general, server: 10.10.10.10, storage: nfs}
+  worker:
+    command: python3 mnist.py
+    cpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    dockerImage: msranni/nni:latest
+    gpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    memorySize: 8192
+    replicas: 1
+trialCodeDirectory: .
+trialCommand: !!python/object:dataclasses._MISSING_TYPE {}
+trialConcurrency: 1
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config_pai.yml
+++ b/examples/trials/mnist-pytorch/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_mnist_pytorch
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-pytorch/config_windows.yml
+++ b/examples/trials/mnist-pytorch/config_windows.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist_pytorch
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config.yml
+++ b/examples/trials/mnist-tfv1/config.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config_aml.yml
+++ b/examples/trials/mnist-tfv1/config_aml.yml
@@ -1,25 +1,15 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {computeTarget: '${replace_to_your_computeTarget}', dockerImage: msranni/nni,
+  platform: aml, resourceGroup: '${replace_to_your_resourceGroup}', subscriptionId: '${replace_to_your_subscriptionId}',
+  workspaceName: '${replace_to_your_workspaceName}'}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-trainingServicePlatform: aml
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  image: msranni/nni
-amlConfig:
-  subscriptionId: ${replace_to_your_subscriptionId}
-  resourceGroup: ${replace_to_your_resourceGroup}
-  workspaceName: ${replace_to_your_workspaceName}
-  computeTarget: ${replace_to_your_computeTarget}
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config_assessor.yml
+++ b/examples/trials/mnist-tfv1/config_assessor.yml
@@ -1,27 +1,17 @@
-authorName: default
-experimentName: example_mnist
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 50
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
 assessor:
-  #choice: Medianstop, Curvefitting
-  builtinAssessorName: Curvefitting
-  classArgs:
-    epoch_num: 20
-    threshold: 0.9
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {epoch_num: 20, threshold: 0.9}
+  name: Curvefitting
+debug: false
+experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 50
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config_kubeflow.yml
+++ b/examples/trials/mnist-tfv1/config_kubeflow.yml
@@ -1,32 +1,24 @@
-authorName: default
+debug: false
 experimentName: example_dist
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 1
-#choice: local, remote, pai, kubeflow
-trainingServicePlatform: kubeflow
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  codeDir: .
-  worker:
-    replicas: 1
-    command: python3 mnist.py
-    gpuNum: 0
-    cpuNum: 1
-    memoryMB: 8192
-    image: msranni/nni:latest
-kubeflowConfig:
-  operator: tf-operator
+maxExperimentDuration: 1h
+maxTrialNumber: 1
+searchSpaceFile: search_space.json
+trainingService:
   apiVersion: v1alpha2
-  storage: nfs
-  nfs:
-    server: 10.10.10.10
-    path: /var/nfs/general
+  operator: tf-operator
+  platform: kubeflow
+  storage: {path: /var/nfs/general, server: 10.10.10.10, storage: nfs}
+  worker:
+    command: python3 mnist.py
+    cpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    dockerImage: msranni/nni:latest
+    gpuNumber: !!python/object:dataclasses._MISSING_TYPE {}
+    memorySize: 8192
+    replicas: 1
+trialCodeDirectory: .
+trialCommand: !!python/object:dataclasses._MISSING_TYPE {}
+trialConcurrency: 1
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config_pai.yml
+++ b/examples/trials/mnist-tfv1/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_mnist
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv1/config_windows.yml
+++ b/examples/trials/mnist-tfv1/config_windows.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv2/config.yml
+++ b/examples/trials/mnist-tfv2/config.yml
@@ -1,17 +1,14 @@
-authorName: NNI Example
+debug: false
 experimentName: MNIST TF v2.x
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-trainingServicePlatform: local  # choices: local, remote, pai
-searchSpacePath: search_space.json
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-    builtinTunerName: TPE   # choices: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner,
-                            #          GPTuner, SMAC (SMAC should be installed through nnictl)
-    classArgs:
-        optimize_mode: maximize  # choices: maximize, minimize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv2/config_assessor.yml
+++ b/examples/trials/mnist-tfv2/config_assessor.yml
@@ -1,27 +1,17 @@
-authorName: NNI Example
-experimentName: MNIST TF v2.x with assessor
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 50
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
 assessor:
-  #choice: Medianstop, Curvefitting
-  builtinAssessorName: Curvefitting
-  classArgs:
-    epoch_num: 20
-    threshold: 0.9
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {epoch_num: 20, threshold: 0.9}
+  name: Curvefitting
+debug: false
+experimentName: MNIST TF v2.x with assessor
+maxExperimentDuration: 1h
+maxTrialNumber: 50
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv2/config_remote.yml
+++ b/examples/trials/mnist-tfv2/config_remote.yml
@@ -1,32 +1,21 @@
-authorName: default
+debug: false
 experimentName: example_mnist
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService:
+  machineList:
+  - {host: '${replace_to_your_remote_machine_ip}', maxTrialNumberPerGpu: 1, port: 22,
+    sshKeyFile: '${replace_to_your_remote_machine_sshKeyPath}', trialPrepareCommand: 'export
+      PATH=${replace_to_python_environment_path_in_your_remote_machine}:$PATH', useActiveGpu: false,
+    user: '${replace_to_your_remote_machine_username}'}
+  platform: remote
+  reuseMode: false
+trialCodeDirectory: .
+trialCommand: python3 mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: remote
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 mnist.py
-  codeDir: .
-  gpuNum: 0
-#machineList can be empty if the platform is local
-machineList:
-  - ip: ${replace_to_your_remote_machine_ip}
-    username: ${replace_to_your_remote_machine_username}
-    sshKeyPath: ${replace_to_your_remote_machine_sshKeyPath}
-    # Pre-command will be executed before the remote machine executes other commands.
-    # Below is an example of specifying python environment.
-    # If you want to execute multiple commands, please use "&&" to connect them.
-    # preCommand: source ${replace_to_absolute_path_recommended_here}/bin/activate
-    # preCommand: source ${replace_to_conda_path}/bin/activate ${replace_to_conda_env_name}
-    preCommand: export PATH=${replace_to_python_environment_path_in_your_remote_machine}:$PATH
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/mnist-tfv2/config_windows.yml
+++ b/examples/trials/mnist-tfv2/config_windows.yml
@@ -1,21 +1,14 @@
-authorName: NNI Example
+debug: false
 experimentName: MNIST TF v2.x
+maxExperimentDuration: 1h
+maxTrialNumber: 10
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python mnist.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner, GPTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python mnist.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/network_morphism/FashionMNIST/config.yml
+++ b/examples/trials/network_morphism/FashionMNIST/config.yml
@@ -1,29 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_FashionMNIST-network-morphism
+maxExperimentDuration: 48h
+maxTrialNumber: 200
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 FashionMNIST_keras.py
 trialConcurrency: 4
-maxExecDuration: 48h
-maxTrialNum: 200
-#choice: local, remote, pai
-trainingServicePlatform: local
-#searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 1
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, NetworkMorphism
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: NetworkMorphism
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    #for now, this tuner only supports cv domain
-    task: cv
-    #input image width
-    input_width: 28
-    #input image channel
-    input_channel: 1
-    #number of classes
-    n_output_node: 10
-trial:
-  command: python3 FashionMNIST_keras.py
-  codeDir: .
-  gpuNum: 1
+  classArgs: {input_channel: 1, input_width: 28, n_output_node: 10, optimize_mode: maximize,
+    task: cv}
+  name: NetworkMorphism
+useAnnotation: false

--- a/examples/trials/network_morphism/FashionMNIST/config_pai.yml
+++ b/examples/trials/network_morphism/FashionMNIST/config_pai.yml
@@ -1,42 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_FashionMNIST-network-morphism
-trialConcurrency: 1
-maxExecDuration: 24h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, NetworkMorphism
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: NetworkMorphism
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    # for now, this tuner only supports cv domain
-    task: cv
-    #input image width
-    input_width: 28
-    #input image channel
-    input_channel: 1
-    #number of classes
-    n_output_node: 10
-trial:
-  command: python3 FashionMNIST_keras.py
-  codeDir: .
-  gpuNum: 1
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 24h
+maxTrialNumber: 10
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 FashionMNIST_keras.py
+trialConcurrency: 1
+trialGpuNumber: 1
+tuner:
+  classArgs: {input_channel: 1, input_width: 28, n_output_node: 10, optimize_mode: maximize,
+    task: cv}
+  name: NetworkMorphism
+useAnnotation: false

--- a/examples/trials/network_morphism/cifar10/config.yml
+++ b/examples/trials/network_morphism/cifar10/config.yml
@@ -1,29 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_cifar10-network-morphism
+maxExperimentDuration: 48h
+maxTrialNumber: 200
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 cifar10_keras.py
 trialConcurrency: 4
-maxExecDuration: 48h
-maxTrialNum: 200
-#choice: local, remote, pai
-trainingServicePlatform: local
-#searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 1
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, NetworkMorphism
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: NetworkMorphism
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    #for now, this tuner only supports cv domain
-    task: cv
-    #input image width
-    input_width: 32
-    #input image channel
-    input_channel: 3
-    #number of classes
-    n_output_node: 10
-trial:
-  command: python3 cifar10_keras.py
-  codeDir: .
-  gpuNum: 1
+  classArgs: {input_channel: 3, input_width: 32, n_output_node: 10, optimize_mode: maximize,
+    task: cv}
+  name: NetworkMorphism
+useAnnotation: false

--- a/examples/trials/network_morphism/cifar10/config_pai.yml
+++ b/examples/trials/network_morphism/cifar10/config_pai.yml
@@ -1,42 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_cifar10-network-morphism
-trialConcurrency: 1
-maxExecDuration: 24h
-maxTrialNum: 10
-#choice: local, remote, pai
-trainingServicePlatform: pai
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, NetworkMorphism
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: NetworkMorphism
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-    # for now, this tuner only supports cv domain
-    task: cv
-    #input image width
-    input_width: 32
-    #input image channel
-    input_channel: 3
-    #number of classes
-    n_output_node: 10
-trial:
-  command: python3 cifar10_keras.py
-  codeDir: .
-  gpuNum: 1
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 24h
+maxTrialNumber: 10
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 cifar10_keras.py
+trialConcurrency: 1
+trialGpuNumber: 1
+tuner:
+  classArgs: {input_channel: 3, input_width: 32, n_output_node: 10, optimize_mode: maximize,
+    task: cv}
+  name: NetworkMorphism
+useAnnotation: false

--- a/examples/trials/sklearn/classification/config.yml
+++ b/examples/trials/sklearn/classification/config.yml
@@ -1,20 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_sklearn-classification
+maxExperimentDuration: 1h
+maxTrialNumber: 100
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 100
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/sklearn/classification/config_pai.yml
+++ b/examples/trials/sklearn/classification/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_sklearn
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 100
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner,MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 100
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 main.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/sklearn/regression/config.yml
+++ b/examples/trials/sklearn/regression/config.yml
@@ -1,20 +1,14 @@
-authorName: default
+debug: false
 experimentName: example_sklearn-regression
+maxExperimentDuration: 1h
+maxTrialNumber: 30
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 30
-#choice: local, remote
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/sklearn/regression/config_pai.yml
+++ b/examples/trials/sklearn/regression/config_pai.yml
@@ -1,35 +1,25 @@
-authorName: default
+debug: false
 experimentName: example_sklearn
-trialConcurrency: 1
-maxExecDuration: 1h
-maxTrialNum: 100
-#choice: local, remote, pai
-trainingServicePlatform: pai
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
-tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
-  cpuNum: 1
-  memoryMB: 8196
-  #The docker image to run nni job on pai
-  image: msranni/nni:latest
-  nniManagerNFSMountPath: {replace_to_your_nfs_mount_path}
-  containerNFSMountPath: {replace_to_your_container_mount_path}
-  paiStorageConfigName: {replace_to_your_storage_config_name}
-paiConfig:
-  #The username to login pai
-  userName: username
-  #The token to login pai
-  token: token
-  #The host of restful server of pai
+maxExperimentDuration: 1h
+maxTrialNumber: 100
+searchSpaceFile: search_space.json
+trainingService:
+  containerStorageMountPoint: {replace_to_your_container_mount_path: null}
+  dockerImage: msranni/nni:latest
   host: 10.10.10.10
+  localStorageMountPoint: {replace_to_your_nfs_mount_path: null}
+  platform: openpai
+  reuseMode: false
+  storageConfigName: {replace_to_your_storage_config_name: null}
+  token: token
+  trialCpuNumber: 1
+  trialMemorySize: 8196
+  username: username
+trialCodeDirectory: .
+trialCommand: python3 main.py
+trialConcurrency: 1
+trialGpuNumber: 0
+tuner:
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K128M64PNN/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K128M64PNN/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: BatchMatMul_B960N128K128M64PNN_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=batch_matmul B=960 N=128 K=128 M=64 P=NN ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=batch_matmul B=960 N=128 K=128 M=64 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K128M64PTN/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K128M64PTN/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: BatchMatMul_B960N128K128M64PTN_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=batch_matmul B=960 N=128 K=128 M=64 P=TN ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=batch_matmul B=960 N=128 K=128 M=64 P=TN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K64M128PNT/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/bmm/B960N128K64M128PNT/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: BatchMatMul_B960N128K64M128PNT_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=batch_matmul B=960 N=128 K=64 M=128 P=NT ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=batch_matmul B=960 N=128 K=64 M=128 P=NT ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/conv/N512C3HW227F64K11ST4PD0/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/conv/N512C3HW227F64K11ST4PD0/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: Conv_N512C3HW227F64K11ST4PD0_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=convfwd_direct N=512 C=3 H=227 W=227 F=64 K=11 ST=4 PD=0 ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=convfwd_direct N=512 C=3 H=227 W=227 F=64 K=11 ST=4 PD=0 ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/conv/N512C64HW27F192K5ST1PD2/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/conv/N512C64HW27F192K5ST1PD2/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: Conv_N512C64HW27F192K5ST1PD2_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=convfwd_direct N=512 C=64 H=27 W=27 F=192 K=5 ST=1 PD=2 ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=convfwd_direct N=512 C=64 H=27 W=27 F=192 K=5 ST=1 PD=2 ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_gbfs.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_gbfs.yml
@@ -1,23 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M1024_GBFS
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
 trialConcurrency: 5
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: gbfs.py
-  className: G_BFS
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    num_samples: 5
-trial:
-  command: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {num_samples: 5, optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: gbfs.G_BFS
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_na2c.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_na2c.yml
@@ -1,22 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M1024_NA2C
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
 trialConcurrency: 6
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: na2c.py
-  className: N_A2C
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-trial:
-  command: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: na2c.N_A2C
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M1024/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M1024_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=matmul N=512 K=1024 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_gbfs.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_gbfs.yml
@@ -1,23 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M4096_GBFS
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
 trialConcurrency: 5
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: gbfs.py
-  className: G_BFS
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    num_samples: 5
-trial:
-  command: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {num_samples: 5, optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: gbfs.G_BFS
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_na2c.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_na2c.yml
@@ -1,22 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M4096_NA2C
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
 trialConcurrency: 6
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: na2c.py
-  className: N_A2C
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-trial:
-  command: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: na2c.N_A2C
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K1024M4096/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K1024M4096_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=matmul N=512 K=1024 M=4096 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_gbfs.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_gbfs.yml
@@ -1,23 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K4096M1024_GBFS
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
 trialConcurrency: 5
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: gbfs.py
-  className: G_BFS
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    num_samples: 5
-trial:
-  command: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {num_samples: 5, optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: gbfs.G_BFS
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_na2c.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_na2c.yml
@@ -1,22 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K4096M1024_NA2C
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
 trialConcurrency: 6
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: na2c.py
-  className: N_A2C
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-trial:
-  command: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: na2c.N_A2C
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_opevo.yml
+++ b/examples/trials/systems_auto_tuning/opevo/src/experiments/mm/N512K4096M1024/config_opevo.yml
@@ -1,25 +1,14 @@
-authorName: default
+debug: false
 experimentName: MatMul_N512K4096M1024_OPEVO
+maxExperimentDuration: 24h
+maxTrialNumber: 512
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: /root
+trialCommand: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
 trialConcurrency: 8
-maxExecDuration: 24h
-maxTrialNum: 512
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 tuner:
-  codeDir: /root/algorithms/
-  classFileName: opevo.py
-  className: OpEvo
-  # Any parameter need to pass to your tuner class __init__ constructor
-  # can be specified in this optional classArgs field, for example 
-  classArgs:
-    optimize_mode: maximize
-    parents_size: 8
-    offspring_size: 8
-    mutate_rate: 0.5
-trial:
-  command: OP=matmul N=512 K=4096 M=1024 P=NN ./run.sh
-  codeDir: /root
-  # gpuNum: 0
+  classArgs: {mutate_rate: 0.5, offspring_size: 8, optimize_mode: maximize, parents_size: 8}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [/, root, algorithms]
+  className: opevo.OpEvo
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_smac.yml
+++ b/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_smac.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: auto_rocksdb_SMAC
+maxExperimentDuration: 12h
+maxTrialNumber: 256
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 12h
-maxTrialNum: 256
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: SMAC
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: SMAC
+useAnnotation: false

--- a/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_tpe.yml
+++ b/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_tpe.yml
@@ -1,21 +1,14 @@
-authorName: default
+debug: false
 experimentName: auto_rocksdb_TPE
+maxExperimentDuration: 12h
+maxTrialNumber: 256
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 main.py
 trialConcurrency: 1
-maxExecDuration: 12h
-maxTrialNum: 256
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+trialGpuNumber: 0
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
-  classArgs:
-    #choice: maximize, minimize
-    optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+  classArgs: {optimize_mode: maximize}
+  name: TPE
+useAnnotation: false

--- a/examples/trials/weight_sharing/ga_squad/config_remote.yml
+++ b/examples/trials/weight_sharing/ga_squad/config_remote.yml
@@ -1,31 +1,23 @@
-authorName: default
+debug: false
 experimentName: ga_squad_weight_sharing
+maxExperimentDuration: 1h
+maxTrialNumber: 200
+trainingService:
+  machineList:
+  - {host: remote-ip-0, maxTrialNumberPerGpu: 1, password: screencast, port: 8022,
+    useActiveGpu: false, user: root}
+  - {host: remote-ip-1, maxTrialNumberPerGpu: 1, password: screencast, port: 8022,
+    useActiveGpu: false, user: root}
+  platform: remote
+  reuseMode: false
+trialCodeDirectory: .
+trialCommand: python3 trial.py --input_file /mnt/nfs/nni/train-v1.1.json --dev_file
+  /mnt/nfs/nni/dev-v1.1.json --max_epoch 1 --embedding_file /mnt/nfs/nni/glove.6B.300d.txt
 trialConcurrency: 2
-maxExecDuration: 1h
-maxTrialNum: 200
-#choice: local, remote, pai
-trainingServicePlatform: remote
-#choice: true, false
-useAnnotation: false
-multiThread: true
+trialGpuNumber: 1
 tuner:
-  codeDir: ../../../tuners/weight_sharing/ga_customer_tuner
-  classFileName: customer_tuner.py
-  className: CustomerTuner
-  classArgs:
-    optimize_mode: maximize
-    population_size: 32
-    save_dir_root: /mnt/nfs/nni/ga_squad
-trial:
-  command: python3 trial.py --input_file /mnt/nfs/nni/train-v1.1.json --dev_file /mnt/nfs/nni/dev-v1.1.json --max_epoch 1 --embedding_file /mnt/nfs/nni/glove.6B.300d.txt
-  codeDir: .
-  gpuNum: 1
-machineList:
-  - ip: remote-ip-0
-    port: 8022
-    username: root
-    passwd: screencast
-  - ip: remote-ip-1
-    port: 8022
-    username: root
-    passwd: screencast
+  classArgs: {optimize_mode: maximize, population_size: 32, save_dir_root: /mnt/nfs/nni/ga_squad}
+  classDirectory: !!python/object/apply:pathlib.PosixPath [.., .., .., tuners, weight_sharing,
+    ga_customer_tuner]
+  className: customer_tuner.CustomerTuner
+useAnnotation: false

--- a/examples/tuners/mnist_keras_customized_advisor/config.yml
+++ b/examples/tuners/mnist_keras_customized_advisor/config.yml
@@ -1,20 +1,15 @@
-authorName: default
-experimentName: example_customized_advisor
-trialConcurrency: 4
-maxExecDuration: 1h
-maxTrialNum: 200
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
 advisor:
-  codeDir: .
-  classFileName: dummy_advisor.py
-  className: DummyAdvisor
-  classArgs:
-    k: 3
-trial:
-  command: python3 mnist_keras.py --epochs 100 --num_train 600 --num_test 100
-  codeDir: .
-  gpuNum: 0
+  classArgs: {k: 3}
+  classDirectory: !!python/object/apply:pathlib.PosixPath []
+  className: dummy_advisor.DummyAdvisor
+debug: false
+experimentName: example_customized_advisor
+maxExperimentDuration: 1h
+maxTrialNumber: 200
+searchSpaceFile: search_space.json
+trainingService: {maxTrialNumberPerGpu: 1, platform: local}
+trialCodeDirectory: .
+trialCommand: python3 mnist_keras.py --epochs 100 --num_train 600 --num_test 100
+trialConcurrency: 4
+trialGpuNumber: 0
+useAnnotation: false


### PR DESCRIPTION
YAML files not (yet) covered:
- [ ] `examples/experiment_config.yml` What's this?
- [ ] `examples/model_compress/*` 
- [ ] `examples/nas/*`
- [ ] `examples/trials/efficientnet/config_pai.yml` Seems like pai-yarn config?
- [ ] `examples/trials/mnist-distributed-pytorch/config_kubeflow.yml` Is "storage" field optional?
- [ ] `examples/trials/mnist-tfv1/config_dlts.yml` Is DLTS still supported?
- [ ] `examples/trials/cifar10_pytorch/config_adl.yml` Not fully understood v1 schema yet
- [ ] `examples/trials/mnist-pytorch/config_adl.yml` Not fully understood v1 schema yet
- [ ] `examples/trials/mnist-pytorch/config_frameworkcontroller.yml` Bug in my translation script
- [ ] `examples/trials/mnist-tfv1/config_frameworkcontroller.yml` Bug in my translation script
- [ ] `examples/trials/mnist-tfv1/config_hybrid.yml` Bug in my translation script
