### PR TITLE
FLAML tuner integration

### DIFF
--- a/dependencies/required_extra.txt
+++ b/dependencies/required_extra.txt
@@ -11,3 +11,7 @@ statsmodels==0.12.0
 
 # PPOTuner
 gym
+
+# BlendSearch
+FLAML
+optuna

--- a/nni/runtime/default_config/registered_algorithms.yml
+++ b/nni/runtime/default_config/registered_algorithms.yml
@@ -76,3 +76,6 @@ tuners:
   classArgsValidator: nni.algorithms.hpo.regularized_evolution_tuner.EvolutionClassArgsValidator
   className: nni.algorithms.hpo.regularized_evolution_tuner.RegularizedEvolutionTuner
   source: nni
+- builtinName: BlendSearch
+  className: flaml.searcher.blendsearch.BlendSearchTuner
+  source: nni


### PR DESCRIPTION
Adds new tuner "BlendSearch" from [FLAML](https://github.com/microsoft/FLAML) as an optional tuner.