### PR TITLE
Update ssh2 version and fix minor bugs

### DIFF
--- a/ts/nni_manager/package.json
+++ b/ts/nni_manager/package.json
@@ -22,7 +22,7 @@
     "python-shell": "^2.0.1",
     "rx": "^4.1.0",
     "sqlite3": "5.0.0",
-    "ssh2": "^0.6.1",
+    "ssh2": "^0.8.9",
     "stream-buffers": "^3.0.2",
     "tail-stream": "^0.3.4",
     "tar": "^6.0.2",

--- a/ts/nni_manager/training_service/common/containerJobData.ts
+++ b/ts/nni_manager/training_service/common/containerJobData.ts
@@ -7,7 +7,7 @@ export const CONTAINER_INSTALL_NNI_SHELL_FORMAT: string =
 `#!/bin/bash
 if python3 -c 'import nni' > /dev/null 2>&1; then
   # nni module is already installed, skip
-  return
+  :
 else
   # Install nni
   python3 -m pip install --user --upgrade nni

--- a/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
@@ -129,6 +129,7 @@ export class RemoteEnvironmentService extends EnvironmentService {
 
         // Create root working directory after executor is ready
         const nniRootDir: string = executor.joinPath(executor.getTempPath(), 'nni');
+        await executor.createFolder(nniRootDir);
         await executor.createFolder(executor.getRemoteExperimentRootDir(getExperimentId()));
 
         // the directory to store temp scripts in remote machine

--- a/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
+++ b/ts/nni_manager/training_service/reusable/environments/remoteEnvironmentService.ts
@@ -128,8 +128,7 @@ export class RemoteEnvironmentService extends EnvironmentService {
         this.log.debug(`initializing ${executor.name}`);
 
         // Create root working directory after executor is ready
-        const nniRootDir: string = executor.joinPath(executor.getTempPath(), 'nni');
-        await executor.createFolder(nniRootDir);
+        const nniRootDir: string = executor.joinPath(executor.getTempPath(), 'nni-experiments');
         await executor.createFolder(executor.getRemoteExperimentRootDir(getExperimentId()));
 
         // the directory to store temp scripts in remote machine

--- a/ts/nni_manager/yarn.lock
+++ b/ts/nni_manager/yarn.lock
@@ -773,7 +773,7 @@ base64url@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
 
-bcrypt-pbkdf@^1.0.0:
+bcrypt-pbkdf@^1.0.0, bcrypt-pbkdf@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   dependencies:
@@ -5018,19 +5018,21 @@ sqlite3@5.0.0:
   optionalDependencies:
     node-gyp "3.x"
 
-ssh2-streams@~0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.2.1.tgz#9c9c9964be60e9644575af328677f64b1e5cbd79"
+ssh2-streams@~0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.4.10.tgz#48ef7e8a0e39d8f2921c30521d56dacb31d23a34"
+  integrity sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==
   dependencies:
     asn1 "~0.2.0"
-    semver "^5.1.0"
+    bcrypt-pbkdf "^1.0.2"
     streamsearch "~0.1.2"
 
-ssh2@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.6.1.tgz#5dde1a7394bb978b1f9c2f014affee2f5493bd40"
+ssh2@^0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.8.9.tgz#54da3a6c4ba3daf0d8477a538a481326091815f3"
+  integrity sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==
   dependencies:
-    ssh2-streams "~0.2.0"
+    ssh2-streams "~0.4.10"
 
 sshpk@^1.7.0:
   version "1.14.2"


### PR DESCRIPTION
Current version is too old to support default key format generated by openssh 8.4