### PR TITLE
fix: Fix ruamel import

### DIFF
--- a/nni/experiment/config/base.py
+++ b/nni/experiment/config/base.py
@@ -6,7 +6,7 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Dict, Optional, Type, TypeVar
 
-from ruamel.yaml import yaml
+import ruamel.yaml as yaml
 
 from . import util
 
@@ -70,7 +70,7 @@ class ConfigBase:
         Load config from YAML (or JSON) file.
         Keys in YAML file can either be camelCase or snake_case.
         """
-        data = yaml.safe_load(open(path))
+        data = yaml.load(open(path), Loader=yaml.SafeLoader)
         if not isinstance(data, dict):
             raise ValueError(f'Content of config file {path} is not a dict/object')
         return cls(**data, _base_path=Path(path).parent)

--- a/nni/experiment/config/base.py
+++ b/nni/experiment/config/base.py
@@ -6,7 +6,7 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Dict, Optional, Type, TypeVar
 
-from ruamel import yaml
+from ruamel.yaml import yaml
 
 from . import util
 


### PR DESCRIPTION
This PR fixes the following error when the `ruamel.yaml` version is greater than 0.11.4:

```bash
ModuleNotFoundError: No module named 'ruamel'
```

It also makes the code consistent with other code that uses this module.

