### PR TITLE
Add model export for QAT

### DIFF
--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -111,6 +111,9 @@ def get_bits_length(config, quant_type):
         return config["quant_bits"].get(quant_type)
 
 def del_simulated_attr(module):
+    """
+    delete redundant parameters in quantize module
+    """
     if hasattr(module, 'old_weight'):
         delattr(module, 'old_weight')
     if hasattr(module, 'ema_decay'):
@@ -310,12 +313,12 @@ class QAT_Quantizer(Quantizer):
 
     def export_model(self, model_path, calibration_path=None):
         """
-        Export pruned model weights, masks and onnx model(optional)
+        Export quantized model weights and calibration parameters(optional)
 
         Parameters
         ----------
         model_path : str
-            path to save pruned model state_dict
+            path to save quantized model weight
         calibration_path : str
             (optional) path to save quantize parameters after calibration
         """

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -379,6 +379,10 @@ class DoReFaQuantizer(Quantizer):
 
     def __init__(self, model, config_list, optimizer=None):
         super().__init__(model, config_list, optimizer)
+        modules_to_compress = self.get_modules_to_compress()
+        for layer, config in modules_to_compress:
+            if "weight" in config.get("quant_types", []):
+                layer.module.register_buffer('weight_bit', torch.zeros(1))
 
     def del_simulated_attr(self, module):
         """

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -21,6 +21,27 @@ def _setattr(model, name, module):
         model = getattr(model, name)
     setattr(model, name_list[-1], module)
 
+def _delsimulatedattr(module):
+    if hasattr(module, 'old_weight'):
+        delattr(module, 'old_weight')
+    if hasattr(module, 'ema_decay'):
+        delattr(module, 'ema_decay')
+    if hasattr(module, 'tracked_min_biased'):
+        delattr(module, 'tracked_min_biased')
+    if hasattr(module, 'tracked_max_biased'):
+        delattr(module, 'tracked_max_biased')
+    if hasattr(module, 'tracked_min'):
+        delattr(module, 'tracked_min')
+    if hasattr(module, 'tracked_max'):
+        delattr(module, 'tracked_max')
+    if hasattr(module, 'scale'):
+        delattr(module, 'scale')
+    if hasattr(module, 'zero_point'):
+        delattr(module, 'zero_point')
+    if hasattr(module, 'weight_bit'):
+        delattr(module, 'weight_bit')
+    if hasattr(module, 'activation_bit'):
+        delattr(module, 'activation_bit')
 
 class Compressor:
     """
@@ -572,6 +593,19 @@ class Quantizer(Compressor):
                 assert quant_type in config['quant_bits'], 'bits length for %s must be specified in quant_bits dict' % quant_type
 
         return QuantizerModuleWrapper(layer.module, layer.name, layer.type, config, self)
+
+    def export_model(self, model_path, calibration_path=None):
+        """
+        Export pruned model weights, masks and onnx model(optional)
+
+        Parameters
+        ----------
+        model_path : str
+            path to save pruned model state_dict
+        calibration_path : str
+            (optional) path to save quantize parameters after calibration
+        """
+        raise NotImplementedError('Quantizer must overload export_model()')
 
     def step_with_optimizer(self):
         pass

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -574,12 +574,12 @@ class Quantizer(Compressor):
 
     def export_model(self, model_path, calibration_path=None):
         """
-        Export pruned model weights, masks and onnx model(optional)
+        Export quantized model weights and calibration parameters
 
         Parameters
         ----------
         model_path : str
-            path to save pruned model state_dict
+            path to save quantized model weight
         calibration_path : str
             (optional) path to save quantize parameters after calibration
         """

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -572,7 +572,8 @@ class Quantizer(Compressor):
 
         return QuantizerModuleWrapper(layer.module, layer.name, layer.type, config, self)
 
-    def export_model_save(self, model, model_path, calibration_config=None, calibration_path=None, onnx_path=None, input_shape=None, device=None):
+    def export_model_save(self, model, model_path, calibration_config=None, calibration_path=None, onnx_path=None, \
+        input_shape=None, device=None):
         """
         This method helps save pytorch model, calibration config, onnx model in quantizer.
 

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -21,28 +21,6 @@ def _setattr(model, name, module):
         model = getattr(model, name)
     setattr(model, name_list[-1], module)
 
-def _delsimulatedattr(module):
-    if hasattr(module, 'old_weight'):
-        delattr(module, 'old_weight')
-    if hasattr(module, 'ema_decay'):
-        delattr(module, 'ema_decay')
-    if hasattr(module, 'tracked_min_biased'):
-        delattr(module, 'tracked_min_biased')
-    if hasattr(module, 'tracked_max_biased'):
-        delattr(module, 'tracked_max_biased')
-    if hasattr(module, 'tracked_min'):
-        delattr(module, 'tracked_min')
-    if hasattr(module, 'tracked_max'):
-        delattr(module, 'tracked_max')
-    if hasattr(module, 'scale'):
-        delattr(module, 'scale')
-    if hasattr(module, 'zero_point'):
-        delattr(module, 'zero_point')
-    if hasattr(module, 'weight_bit'):
-        delattr(module, 'weight_bit')
-    if hasattr(module, 'activation_bit'):
-        delattr(module, 'activation_bit')
-
 class Compressor:
     """
     Abstract base PyTorch compressor

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -582,6 +582,13 @@ class Quantizer(Compressor):
             path to save quantized model weight
         calibration_path : str
             (optional) path to save quantize parameters after calibration
+        onnx_path : str
+            (optional) path to save onnx model
+        input_shape : list or tuple
+            input shape to onnx model
+        device : torch.device
+            device of the model, used to place the dummy input tensor for exporting onnx file.
+            the tensor is placed on cpu if ```device``` is None
         """
         raise NotImplementedError('Quantizer must overload export_model()')
 

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -572,7 +572,7 @@ class Quantizer(Compressor):
 
         return QuantizerModuleWrapper(layer.module, layer.name, layer.type, config, self)
 
-    def export_model(self, model_path, calibration_path=None):
+    def export_model(self, model_path, calibration_path=None, onnx_path=None, input_shape=None, device=None):
         """
         Export quantized model weights and calibration parameters
 


### PR DESCRIPTION
Add `export_model` function for quantization algorithm QAT. Users can save quantized weight and calibration parameters to specific path. What' s more, this function will be a prerequisite for #3356 (Support mixed-precision quantization speed up by using tensorrt).