### PR TITLE
WebUI dispatcher log / nnimanager log wrap

### DIFF
--- a/ts/webui/src/components/public-child/MonacoEditor.tsx
+++ b/ts/webui/src/components/public-child/MonacoEditor.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Spinner } from '@fluentui/react';
-import { DRAWEROPTION } from '../../static/const';
 import MonacoEditor from 'react-monaco-editor';
 
 interface MonacoEditorProps {
@@ -10,18 +9,9 @@ interface MonacoEditorProps {
 }
 
 class MonacoHTML extends React.Component<MonacoEditorProps, {}> {
-    public _isMonacoMount!: boolean;
 
     constructor(props: MonacoEditorProps) {
         super(props);
-    }
-
-    componentDidMount(): void {
-        this._isMonacoMount = true;
-    }
-
-    componentWillUnmount(): void {
-        this._isMonacoMount = false;
     }
 
     render(): React.ReactNode {
@@ -40,11 +30,27 @@ class MonacoHTML extends React.Component<MonacoEditorProps, {}> {
                             height={height}
                             language='json'
                             value={content}
-                            options={DRAWEROPTION}
+                            options={{
+                                minimap: { enabled: false },
+                                readOnly: true,
+                                automaticLayout: true,
+                                wordWrap: 'on'
+                            }}
                         />
                     </Spinner>
                 ) : (
-                    <MonacoEditor width='100%' height={height} language='json' value={content} options={DRAWEROPTION} />
+                    <MonacoEditor
+                            width='100%'
+                            height={height}
+                            language='json'
+                            value={content}
+                            options={{
+                                minimap: { enabled: false },
+                                readOnly: true,
+                                automaticLayout: true,
+                                wordWrap: 'on'
+                            }}
+                        />
                 )}
             </React.Fragment>
         );

--- a/ts/webui/src/components/public-child/MonacoEditor.tsx
+++ b/ts/webui/src/components/public-child/MonacoEditor.tsx
@@ -9,7 +9,6 @@ interface MonacoEditorProps {
 }
 
 class MonacoHTML extends React.Component<MonacoEditorProps, {}> {
-
     constructor(props: MonacoEditorProps) {
         super(props);
     }
@@ -40,17 +39,17 @@ class MonacoHTML extends React.Component<MonacoEditorProps, {}> {
                     </Spinner>
                 ) : (
                     <MonacoEditor
-                            width='100%'
-                            height={height}
-                            language='json'
-                            value={content}
-                            options={{
-                                minimap: { enabled: false },
-                                readOnly: true,
-                                automaticLayout: true,
-                                wordWrap: 'on'
-                            }}
-                        />
+                        width='100%'
+                        height={height}
+                        language='json'
+                        value={content}
+                        options={{
+                            minimap: { enabled: false },
+                            readOnly: true,
+                            automaticLayout: true,
+                            wordWrap: 'on'
+                        }}
+                    />
                 )}
             </React.Fragment>
         );


### PR DESCRIPTION
- this variable `_isMonacoMount` is no use, so delete related code;
- when I put `wordWrap: 'on'` in object `DRAWEROPTION`, met this error, as picture:
   ![image](https://user-images.githubusercontent.com/61399850/111744462-3e984200-88c6-11eb-860b-2679e6cfc322.png)
- For fix this question, must write this options in `MonacoEditor` directly.
- wrap:   
   ![image](https://user-images.githubusercontent.com/61399850/111744696-98007100-88c6-11eb-8c0d-ca0c25ed68b1.png)
