### PR TITLE
fix bug of `Add/Remove` modal

### DIFF
--- a/ts/webui/src/components/modals/ChangeColumnComponent.tsx
+++ b/ts/webui/src/components/modals/ChangeColumnComponent.tsx
@@ -12,6 +12,7 @@ interface ChangeColumnProps {
     onSelectedChange: (val: string[]) => void;
     onHideDialog: () => void;
     minSelected?: number;
+    whichComponent: string; // which component use this component
 }
 
 interface SimpleColumn {
@@ -57,10 +58,14 @@ class ChangeColumnComponent extends React.Component<ChangeColumnProps, ChangeCol
 
     saveUserSelectColumn = (): void => {
         const { currentSelected } = this.state;
-        const { allColumns, onSelectedChange } = this.props;
+        const { allColumns, onSelectedChange, whichComponent } = this.props;
         const selectedColumns = allColumns.map(column => column.key).filter(key => currentSelected.includes(key));
-        localStorage.setItem('columns', JSON.stringify(selectedColumns));
         onSelectedChange(selectedColumns);
+        if (whichComponent === 'table') {
+            localStorage.setItem('columns', JSON.stringify(selectedColumns));
+        } else {
+            localStorage.setItem('paraColumns', JSON.stringify(selectedColumns));
+        }
         this.hideDialog();
     };
 

--- a/ts/webui/src/components/trial-detail/Para.tsx
+++ b/ts/webui/src/components/trial-detail/Para.tsx
@@ -114,7 +114,7 @@ class Para extends React.Component<ParaProps, ParaState> {
                             { key: '0.01', text: 'Top 1%' },
                             { key: '0.05', text: 'Top 5%' },
                             { key: '0.2', text: 'Top 20%' },
-                            { key: '1', text: 'Topxx 100%' }
+                            { key: '1', text: 'Top 100%' }
                         ]}
                         styles={{ dropdown: { width: 120 } }}
                         className='para-filter-percent'

--- a/ts/webui/src/components/trial-detail/Para.tsx
+++ b/ts/webui/src/components/trial-detail/Para.tsx
@@ -51,7 +51,11 @@ class Para extends React.Component<ParaProps, ParaState> {
             noChart: true,
             customizeColumnsDialogVisible: false,
             availableDimensions: [],
-            chosenDimensions: []
+            chosenDimensions:
+                localStorage.getItem('paraColumns') !== null
+                    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                      JSON.parse(localStorage.getItem('paraColumns')!)
+                    : []
         };
     }
 
@@ -110,7 +114,7 @@ class Para extends React.Component<ParaProps, ParaState> {
                             { key: '0.01', text: 'Top 1%' },
                             { key: '0.05', text: 'Top 5%' },
                             { key: '0.2', text: 'Top 20%' },
-                            { key: '1', text: 'Top 100%' }
+                            { key: '1', text: 'Topxx 100%' }
                         ]}
                         styles={{ dropdown: { width: 120 } }}
                         className='para-filter-percent'
@@ -130,6 +134,7 @@ class Para extends React.Component<ParaProps, ParaState> {
                             this.setState({ customizeColumnsDialogVisible: false });
                         }}
                         minSelected={2}
+                        whichComponent='para'
                     />
                 )}
                 <div className='parcoords' style={this.chartMulineStyle} ref={this.paraRef} />

--- a/ts/webui/src/components/trial-detail/TableList.tsx
+++ b/ts/webui/src/components/trial-detail/TableList.tsx
@@ -571,6 +571,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
                         onHideDialog={(): void => {
                             this.setState({ customizeColumnsDialogVisible: false });
                         }}
+                        whichComponent='table'
                     />
                 )}
                 {/* Clone a trial and customize a set of new parameters */}


### PR DESCRIPTION
description: 

-  this bug is from v2.1
-  when using parameter graph's `Add/Remove axes` together with table's `Add/Remove columns`, it will be confused.
-  bug’s reason: they all use the component `ChangeColumnComponent` and it store localstorage by same key
-  bug fix by `add key to make different modal`
-  use localstorage to store user hyper-parameter yAxis setting