### PR TITLE
fix the issue: text is not displayed completely when searching in the search space/config/log monaco editor

### DIFF
--- a/ts/webui/src/components/Overview.tsx
+++ b/ts/webui/src/components/Overview.tsx
@@ -79,7 +79,7 @@ class Overview extends React.Component<{}, OverviewState> {
                     const minActive = metricGraphMode === 'min' ? 'active' : '';
                     return (
                         <div className='overview'>
-                            <div className='wrapper'>
+                            <div className='overviewWrapper'>
                                 {/* exp params */}
                                 <div className='overviewBasicInfo'>
                                     <TitleContext.Provider value={{ text: 'Experiment', icon: 'AutoRacing' }}>

--- a/ts/webui/src/static/style/overview/overview.scss
+++ b/ts/webui/src/static/style/overview/overview.scss
@@ -2,7 +2,7 @@ $boxPadding: 24px;
 $boxBorderRadius: 5px;
 $boxGapPadding: 10px;
 
-.wrapper {
+.overviewWrapper {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
     grid-auto-rows: 102px;


### PR DESCRIPTION
customer raised issue: https://github.com/microsoft/nni/issues/3484

bug reason: own code uses same className with monaco editor. they all use `wrapper`.