### PR TITLE
Bug fix for Cream NAS

### DIFF
--- a/examples/nas/cream/lib/models/structures/supernet.py
+++ b/examples/nas/cream/lib/models/structures/supernet.py
@@ -131,12 +131,12 @@ class SuperNet(nn.Module):
                 yield param
 
         if not meta:
-            for layer, layer_arch in zip(self.blocks, architecture):
-                for blocks, arch in zip(layer, layer_arch):
-                    if arch == -1:
+            for choice_blocks, choice_name in zip(self.blocks, architecture):
+                choice_sample = architecture[choice_name]
+                for block, arch in zip(choice_blocks, choice_sample):
+                    if not arch:
                         continue
-                    for name, param in blocks[arch].named_parameters(
-                            recurse=True):
+                    for name, param in block.named_parameters(recurse=True):
                         yield param
 
 

--- a/nni/algorithms/nas/pytorch/cream/trainer.py
+++ b/nni/algorithms/nas/pytorch/cream/trainer.py
@@ -165,7 +165,7 @@ class CreamSupernetTrainer(Trainer):
                 (val_prec1,
                  prec1,
                  flops,
-                 self.current_teacher_arch,
+                 self.current_student_arch,
                  training_data,
                  torch.nn.functional.softmax(
                      features,
@@ -174,8 +174,6 @@ class CreamSupernetTrainer(Trainer):
                 self.prioritized_board, reverse=True)
 
         if len(self.prioritized_board) > self.pool_size:
-            self.prioritized_board = sorted(
-                self.prioritized_board, reverse=True)
             del self.prioritized_board[-1]
 
     # only update student network weights


### PR DESCRIPTION
Two bugs may be fixed for the NAS (Cream of the Crop):
1) in "nni/nni/algorithms/nas/pytorch/cream/trainer.py", line 168: 
I think the prioritized board should be updated with the newest student network, not the teacher. Otherwise, the prioritized board will be filled with the same teacher?

2) in "nni/examples/nas/cream/lib/models/structures/supernet.py", line 126:
In the class method rand_parameters(self, ...), when yielding parameters of the block in mutable, the passed architecture is the dictionary with the type Dict[str, np.array], of which the key is mutable.key, and the value is a one-hot vector. In the original function, the traversed blocks is already a block in the mutable, which can not be indexed by the arch. Therefore, the class method is modified by using (block, arch) to find the sampled block in the mutable.