### PR TITLE
Cast quniform and qloguniform values to be float

### DIFF
--- a/nni/algorithms/hpo/hyperopt_tuner.py
+++ b/nni/algorithms/hpo/hyperopt_tuner.py
@@ -80,7 +80,7 @@ def json2parameter(in_x, parameter, name=NodeType.ROOT):
                 }
             else:
                 if _type in ['quniform', 'qloguniform']:
-                    out_y = np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1], dtype=np.float32)
+                    out_y = float(np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1])
                 elif _type == 'randint':
                     out_y = parameter[name] + in_x[NodeType.VALUE][0]
                 else:

--- a/nni/algorithms/hpo/hyperopt_tuner.py
+++ b/nni/algorithms/hpo/hyperopt_tuner.py
@@ -80,7 +80,7 @@ def json2parameter(in_x, parameter, name=NodeType.ROOT):
                 }
             else:
                 if _type in ['quniform', 'qloguniform']:
-                    out_y = float(np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1])
+                    out_y = float(np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1]))
                 elif _type == 'randint':
                     out_y = parameter[name] + in_x[NodeType.VALUE][0]
                 else:

--- a/nni/algorithms/hpo/hyperopt_tuner.py
+++ b/nni/algorithms/hpo/hyperopt_tuner.py
@@ -80,7 +80,7 @@ def json2parameter(in_x, parameter, name=NodeType.ROOT):
                 }
             else:
                 if _type in ['quniform', 'qloguniform']:
-                    out_y = np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1])
+                    out_y = np.clip(parameter[name], in_x[NodeType.VALUE][0], in_x[NodeType.VALUE][1], dtype=np.float32)
                 elif _type == 'randint':
                     out_y = parameter[name] + in_x[NodeType.VALUE][0]
                 else:


### PR DESCRIPTION
Hyperopt returns values in np.float64 for quniform and qloguniform which causes deduplication at line 280 "if total_params in self.total_data.values():" to fail. They need to be cast to native float.