### PR TITLE
Fixed typo on line 75 of nni/nas/pytorch/mutables.py

### DIFF
--- a/nni/nas/pytorch/mutables.py
+++ b/nni/nas/pytorch/mutables.py
@@ -72,7 +72,7 @@ class Mutable(nn.Module):
         """
         After the search space is parsed, it will be the module name of the mutable.
         """
-        return self._name if hasattr(self, "_name") else "_key"
+        return self._name if hasattr(self, "_name") else self._key
 
     @name.setter
     def name(self, name):


### PR DESCRIPTION
### Description
This Pull Request fixes a typo on` line 75 of nni/nas/pytorch/mutables.py`.

While I was reading the source code, I wondered whether this is a typo, as shown below:

```
nni/nas/pytorch/mutables.py, line 75

@property
71    def name(self):
72        """
73        After the search space is parsed, it will be the module name of the mutable.
74        """
75        return self._name if hasattr(self, "_name") else "_key"
```

Should `"_key"` be `self._key `because this method is supposed to return a key/name of a mutable?

The Issue seems to be very minor but it improves the readability of the Code and fixes a typo on` line 75 of nni/nas/pytorch/mutables.py `issue in Python 3 which happens to be a standard.

I'm a First-Time Contributor to Microsoft Open-Source so it would be helpful for me understanding how PR workflow works and help me step up in future contributions as well.

Fixes: #3515 

@ultmaster @liuzhe-lz Can you review this PR and let me know?