### PR TITLE
modify the config bug about Automatic Model Pruning using NNI Tuners

### DIFF
--- a/docs/en_US/Compression/AutoPruningUsingTuners.rst
+++ b/docs/en_US/Compression/AutoPruningUsingTuners.rst
@@ -64,7 +64,7 @@ Then, define a ``config`` file in YAML to automatically tuning model, pruning al
     trialConcurrency: 1
     trialGpuNumber: 0
     tuner:
-      name: grid
+      name: GridSearch
 
 The full example can be found :githublink:`here <examples/model_compress/pruning/config.yml>`
 

--- a/docs/zh_CN/Compression/AutoPruningUsingTuners.rst
+++ b/docs/zh_CN/Compression/AutoPruningUsingTuners.rst
@@ -64,7 +64,7 @@ op_type 'Conv2d' 表示在 PyTorch 框架下定义在 :githublink:`default_layer
     trialConcurrency: 1
     trialGpuNumber: 0
     tuner:
-      name: GridSearch
+      name: grid
 
 完整实验代码在 :githublink:`这里 <examples/model_compress/pruning/config.yml>`
 

--- a/docs/zh_CN/Compression/AutoPruningUsingTuners.rst
+++ b/docs/zh_CN/Compression/AutoPruningUsingTuners.rst
@@ -64,7 +64,7 @@ op_type 'Conv2d' 表示在 PyTorch 框架下定义在 :githublink:`default_layer
     trialConcurrency: 1
     trialGpuNumber: 0
     tuner:
-      name: grid
+      name: GridSearch
 
 完整实验代码在 :githublink:`这里 <examples/model_compress/pruning/config.yml>`
 

--- a/examples/model_compress/pruning/basic_pruners_torch.py
+++ b/examples/model_compress/pruning/basic_pruners_torch.py
@@ -373,6 +373,6 @@ if __name__ == '__main__':
         print(params)
         args.sparsity = params['sparsity']
         args.pruner = params['pruner']
-        args.model = params['pruner']
+        args.model = params['model']
 
     main(args)

--- a/examples/model_compress/pruning/config.yml
+++ b/examples/model_compress/pruning/config.yml
@@ -15,4 +15,4 @@ trialCommand: python3 basic_pruners_torch.py --nni
 trialConcurrency: 1
 trialGpuNumber: 0
 tuner:
-  name: grid
+  name: GridSearch


### PR DESCRIPTION
The bug is about config error, and the specific modification location is as follows:
    1. Modify the code in "nni/examples/model_compress/pruning/basic_pruners_torch.py" , 378 line ：args.model = params['model']
    2. Modify the code in "nni/examples/model_compress/pruning/config.yml", 18 line ：name: GridSearch