### PR TITLE
fix example typos

### DIFF
--- a/examples/model_compress/pruning/basic_pruners_torch.py
+++ b/examples/model_compress/pruning/basic_pruners_torch.py
@@ -373,6 +373,6 @@ if __name__ == '__main__':
         print(params)
         args.sparsity = params['sparsity']
         args.pruner = params['pruner']
-        args.model = params['pruner']
+        args.model = params['model']
 
     main(args)

--- a/examples/model_compress/pruning/config.yml
+++ b/examples/model_compress/pruning/config.yml
@@ -15,4 +15,4 @@ trialCommand: python3 basic_pruners_torch.py --nni
 trialConcurrency: 1
 trialGpuNumber: 0
 tuner:
-  name: grid
+  name: GridSearch


### PR DESCRIPTION
fix two typos in `examples/model_compress/pruning`.