### PR TITLE
Fix on log and metric issue on Windows when using pytorch with multithread

### DIFF
--- a/nni/runtime/log.py
+++ b/nni/runtime/log.py
@@ -88,7 +88,7 @@ def _init_logger_dispatcher() -> None:
 
 def _init_logger_trial() -> None:
     log_path = _prepare_log_dir(trial_env_vars.NNI_OUTPUT_DIR) / 'trial.log'
-    log_file = open(log_path, 'w')
+    log_file = open(log_path, 'a')
     _register_handler(StreamHandler(log_file), logging.INFO)
 
     if trial_env_vars.NNI_PLATFORM == 'local':

--- a/nni/runtime/platform/local.py
+++ b/nni/runtime/platform/local.py
@@ -13,7 +13,7 @@ from nni.utils import to_json
 _sysdir = trial_env_vars.NNI_SYS_DIR
 if not os.path.exists(os.path.join(_sysdir, '.nni')):
     os.makedirs(os.path.join(_sysdir, '.nni'))
-_metric_file = open(os.path.join(_sysdir, '.nni', 'metrics'), 'wb')
+_metric_file = open(os.path.join(_sysdir, '.nni', 'metrics'), 'ab')
 
 _outputdir = trial_env_vars.NNI_OUTPUT_DIR
 if not os.path.exists(_outputdir):


### PR DESCRIPTION
The problem with log and metric when using torch.utils.data.DataLoader with num_workers>0 on windows is known for a long time. I find that the log and metric file is whipped of its content whenever a DataLoader is enumerated. I reached out to pytorch for this, and they told me it is a issue with the multiprocessing library. It uses on default spawn mode in windows, in which
> unnecessary file descriptors and handles from the parent process will not be inherited (https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)

This cause the log and metric file which are opened at top level in `__init__.py` and `runtime/platform/local.py`. Thankfully there is a simple workaround on this, that is to change the file to 'a' open mode. I tested it on my local machine and it works. 