### PR TITLE
[Retiarii] Pure-python execution engine

### DIFF
--- a/docs/en_US/NAS/retiarii/Advanced.rst
+++ b/docs/en_US/NAS/retiarii/Advanced.rst
@@ -1,7 +1,17 @@
 Advanced Tutorial
 =================
 
-This document includes two parts. The first part explains the design decision of ``@basic_unit`` and ``serializer``. The second part is the tutorial of how to write a model space with mutators.
+Pure-python execution engine (experimental)
+-------------------------------------------
+
+If you are experiencing issues with TorchScript, or the generated model code by Retiarii, there is another execution engine called Pure-python execution engine which doesn't need the code-graph conversion. This should generally not affect models and strategies in most cases, but customized mutation might not be supported.
+
+This will come as the default execution engine in future version of Retiarii.
+
+Two steps are needed to enable this engine now.
+
+1. Add ``@nni.retiarii.model_wrapper`` decorator outside the whole PyTorch model.
+2. Add ``config.execution_engine = 'py'`` to ``RetiariiExeConfig``.
 
 ``@basic_unit`` and ``serializer``
 ----------------------------------

--- a/nni/retiarii/__init__.py
+++ b/nni/retiarii/__init__.py
@@ -5,4 +5,4 @@ from .operation import Operation
 from .graph import *
 from .execution import *
 from .mutator import *
-from .serializer import basic_unit, json_dump, json_dumps, json_load, json_loads, serialize, serialize_cls
+from .serializer import basic_unit, json_dump, json_dumps, json_load, json_loads, serialize, serialize_cls, model_wrapper

--- a/nni/retiarii/execution/api.py
+++ b/nni/retiarii/execution/api.py
@@ -15,19 +15,18 @@ __all__ = ['get_execution_engine', 'get_and_register_default_listener',
            'list_models', 'submit_models', 'wait_models', 'query_available_resources',
            'set_execution_engine', 'is_stopped_exec', 'budget_exhausted']
 
-def set_execution_engine(engine) -> None:
+
+def set_execution_engine(engine: AbstractExecutionEngine) -> None:
     global _execution_engine
     if _execution_engine is None:
         _execution_engine = engine
     else:
-        raise RuntimeError('execution engine is already set')
+        raise RuntimeError('Execution engine is already set.')
 
 
 def get_execution_engine() -> AbstractExecutionEngine:
-    """
-    Currently we assume the default execution engine is BaseExecutionEngine.
-    """
     global _execution_engine
+    assert _execution_engine is not None, 'You need to set execution engine, before using it.'
     return _execution_engine
 
 

--- a/nni/retiarii/execution/base.py
+++ b/nni/retiarii/execution/base.py
@@ -5,7 +5,7 @@ import logging
 import os
 import random
 import string
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
 
 from .interface import AbstractExecutionEngine, AbstractGraphListener
 from .. import codegen, utils
@@ -59,7 +59,7 @@ class BaseExecutionEngine(AbstractExecutionEngine):
 
     def submit_models(self, *models: Model) -> None:
         for model in models:
-            data = BaseGraphData(codegen.model_to_pytorch_script(model), model.evaluator)
+            data = self.pack_model_data(model)
             self._running_models[send_trial(data.dump())] = model
             self._history.append(model)
 
@@ -107,6 +107,10 @@ class BaseExecutionEngine(AbstractExecutionEngine):
     def budget_exhausted(self) -> bool:
         advisor = get_advisor()
         return advisor.stopping
+
+    @classmethod
+    def pack_model_data(cls, model: Model) -> Any:
+        return BaseGraphData(codegen.model_to_pytorch_script(model), model.evaluator)
 
     @classmethod
     def trial_execute_graph(cls) -> None:

--- a/nni/retiarii/execution/purepython.py
+++ b/nni/retiarii/execution/purepython.py
@@ -1,0 +1,5 @@
+from .base import BaseExecutionEngine
+
+
+class PurePythonExecutinoEngine(BaseExecutionEngine):
+    pass

--- a/nni/retiarii/execution/purepython.py
+++ b/nni/retiarii/execution/purepython.py
@@ -1,10 +1,45 @@
+from typing import Dict, Any, List
+
+from ..graph import Evaluator, Model
+from ..integration_api import receive_trial_parameters
+from ..utils import ContextStack, import_
 from .base import BaseExecutionEngine
 
 
+class PythonGraphData:
+    def __init__(self, model_class_name: str, mutation: Dict[str, Any], evaluator: Evaluator) -> None:
+        self.model_class_name = model_class_name
+        self.mutation = mutation
+        self.evaluator = evaluator
+
+    def dump(self) -> dict:
+        return {
+            'model_class_name': self.model_class_name,
+            'mutation': self.mutation,
+            'evaluator': self.evaluator
+        }
+
+    @staticmethod
+    def load(data) -> 'PythonGraphData':
+        return PythonGraphData(data['model_class_name'], data['mutation'], data['evaluator'])
+
+
 class PurePythonExecutinoEngine(BaseExecutionEngine):
-    def submit_models(self, *models):
-        pass
+    @classmethod
+    def pack_model_data(cls, model: Model) -> Any:
+        mutation = {mut.mutator.name: _unpack_if_only_one(mut.samples) for mut in model.history}
+        graph_data = PythonGraphData(model.class_name, mutation, model.evaluator)
+        return graph_data
 
     @classmethod
     def trial_execute_graph(cls) -> None:
-        pass
+        graph_data = PythonGraphData.load(receive_trial_parameters())
+        with ContextStack('fixed', graph_data.mutation):
+            model_cls = import_(graph_data.model_class_name)
+            graph_data.evaluator._execute(model_cls)
+
+
+def _unpack_if_only_one(ele: List[Any]):
+    if len(ele) == 1:
+        return ele[0]
+    return ele

--- a/nni/retiarii/execution/purepython.py
+++ b/nni/retiarii/execution/purepython.py
@@ -2,4 +2,9 @@ from .base import BaseExecutionEngine
 
 
 class PurePythonExecutinoEngine(BaseExecutionEngine):
-    pass
+    def submit_models(self, *models):
+        pass
+
+    @classmethod
+    def trial_execute_graph(cls) -> None:
+        pass

--- a/nni/retiarii/execution/python.py
+++ b/nni/retiarii/execution/python.py
@@ -24,10 +24,10 @@ class PythonGraphData:
         return PythonGraphData(data['model_class_name'], data['mutation'], data['evaluator'])
 
 
-class PurePythonExecutinoEngine(BaseExecutionEngine):
+class PurePythonExecutionEngine(BaseExecutionEngine):
     @classmethod
     def pack_model_data(cls, model: Model) -> Any:
-        mutation = {mut.mutator.name: _unpack_if_only_one(mut.samples) for mut in model.history}
+        mutation = {mut.mutator.label: _unpack_if_only_one(mut.samples) for mut in model.history}
         graph_data = PythonGraphData(model.class_name, mutation, model.evaluator)
         return graph_data
 

--- a/nni/retiarii/execution/python.py
+++ b/nni/retiarii/execution/python.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, List
 
 from ..graph import Evaluator, Model
 from ..integration_api import receive_trial_parameters
-from ..utils import ContextStack, import_
+from ..utils import ContextStack, import_, get_importable_name
 from .base import BaseExecutionEngine
 
 
@@ -28,7 +28,8 @@ class PurePythonExecutionEngine(BaseExecutionEngine):
     @classmethod
     def pack_model_data(cls, model: Model) -> Any:
         mutation = {mut.mutator.label: _unpack_if_only_one(mut.samples) for mut in model.history}
-        graph_data = PythonGraphData(model.class_name, mutation, model.evaluator)
+        graph_data = PythonGraphData(get_importable_name(model.python_class, relocate_module=True),
+                                     mutation, model.evaluator)
         return graph_data
 
     @classmethod

--- a/nni/retiarii/experiment/pytorch.py
+++ b/nni/retiarii/experiment/pytorch.py
@@ -114,12 +114,12 @@ def preprocess_model(base_model, trainer, applied_mutators, full_ir=True):
             _logger.error('Your base model cannot be parsed by torch.jit.script, please fix the following error:')
             raise e
         base_model_ir = convert_to_graph(script_module, base_model)
-        base_model_ir.evaluator = trainer
-
         # handle inline mutations
         mutators = process_inline_mutation(base_model_ir)
     else:
         base_model_ir, mutators = extract_mutation_from_pt_module(base_model)
+    base_model_ir.evaluator = trainer
+
     if mutators is not None and applied_mutators:
         raise RuntimeError('Have not supported mixed usage of LayerChoice/InputChoice and mutators, '
                             'do not use mutators when you use LayerChoice/InputChoice')

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -9,7 +9,7 @@ import abc
 import copy
 import json
 from enum import Enum
-from typing import (Any, Dict, Iterable, List, Optional, Tuple, Union, overload)
+from typing import (Any, Dict, Iterable, List, Optional, Tuple, Type, Union, overload)
 
 from .operation import Cell, Operation, _IOPseudoOperation
 from .utils import get_importable_name, import_, uid
@@ -80,8 +80,8 @@ class Model:
 
     Attributes
     ----------
-    class_name
-        Python class name that base model is converted from.
+    python_class
+        Python class that base model is converted from.
     status
         See `ModelStatus`.
     root_graph
@@ -104,7 +104,7 @@ class Model:
     def __init__(self, _internal=False):
         assert _internal, '`Model()` is private, use `model.fork()` instead'
         self.model_id: int = uid('model')
-        self.class_name: Optional[str] = None
+        self.python_class: Optional[Type] = None
 
         self.status: ModelStatus = ModelStatus.Mutating
 
@@ -120,7 +120,7 @@ class Model:
     def __repr__(self):
         return f'Model(model_id={self.model_id}, status={self.status}, graphs={list(self.graphs.keys())}, ' + \
             f'evaluator={self.evaluator}, metric={self.metric}, intermediate_metrics={self.intermediate_metrics}, ' + \
-            f'class_name={self.class_name})'
+            f'python_class={self.python_class})'
 
     @property
     def root_graph(self) -> 'Graph':

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -82,6 +82,8 @@ class Model:
     ----------
     python_class
         Python class that base model is converted from.
+    python_init_params
+        Initialization parameters of python class.
     status
         See `ModelStatus`.
     root_graph
@@ -105,6 +107,7 @@ class Model:
         assert _internal, '`Model()` is private, use `model.fork()` instead'
         self.model_id: int = uid('model')
         self.python_class: Optional[Type] = None
+        self.python_init_params: Optional[Dict[str, Any]] = None
 
         self.status: ModelStatus = ModelStatus.Mutating
 
@@ -137,6 +140,8 @@ class Model:
         """
         new_model = Model(_internal=True)
         new_model._root_graph_name = self._root_graph_name
+        new_model.python_class = self.python_class
+        new_model.python_init_params = self.python_init_params
         new_model.graphs = {name: graph._fork_to(new_model) for name, graph in self.graphs.items()}
         new_model.evaluator = copy.deepcopy(self.evaluator)  # TODO this may be a problem when evaluator is large
         new_model.history = [*self.history]

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -119,7 +119,8 @@ class Model:
 
     def __repr__(self):
         return f'Model(model_id={self.model_id}, status={self.status}, graphs={list(self.graphs.keys())}, ' + \
-            f'evaluator={self.evaluator}, metric={self.metric}, intermediate_metrics={self.intermediate_metrics})'
+            f'evaluator={self.evaluator}, metric={self.metric}, intermediate_metrics={self.intermediate_metrics}, ' + \
+            f'class_name={self.class_name})'
 
     @property
     def root_graph(self) -> 'Graph':

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -171,8 +171,8 @@ class Model:
 
     def get_nodes_by_label(self, label: str) -> List['Node']:
         """
-        Traverse all the nodes to find the matched node(s) with the given name.
-        There could be multiple nodes with the same name. Name space name can uniquely
+        Traverse all the nodes to find the matched node(s) with the given label.
+        There could be multiple nodes with the same label. Name space name can uniquely
         identify a graph or node.
 
         NOTE: the implementation does not support the class abstration
@@ -497,6 +497,8 @@ class Node:
         If two models have nodes with same ID, they are semantically the same node.
     name
         Mnemonic name. It should have an one-to-one mapping with ID.
+    label
+        Optional. If two nodes have the same label, they are considered same by the mutator.
     operation
         ...
     cell
@@ -519,7 +521,7 @@ class Node:
         # TODO: the operation is likely to be considered editable by end-user and it will be hard to debug
         # maybe we should copy it here or make Operation class immutable, in next release
         self.operation: Operation = operation
-        self.label: str = None  # FIXME: label is a misuse here. It should be merged into `name`
+        self.label: Optional[str] = None
 
     def __repr__(self):
         return f'Node(id={self.id}, name={self.name}, label={self.label}, operation={self.operation})'
@@ -683,7 +685,7 @@ class Mutation:
     the model that it comes from, and the model that it becomes.
 
     In general cases, the mutation logs are not reliable and should not be replayed as the mutators can
-    be arbitrarily complex. However, for inline mutations, the labels correspond to mutator names here,
+    be arbitrarily complex. However, for inline mutations, the labels correspond to mutator labels here,
     this can be useful for metadata visualization and python execution mode.
 
     Attributes

--- a/nni/retiarii/graph.py
+++ b/nni/retiarii/graph.py
@@ -706,8 +706,8 @@ class Mutation:
         Model that it becomes.
     """
 
-    def __init__(self, mutator: 'Mutator', samples: List[Any], from_: Model, to: Model):
-        self.mutator: 'Mutator' = mutator
+    def __init__(self, mutator: 'Mutator', samples: List[Any], from_: Model, to: Model):  # noqa: F821
+        self.mutator: 'Mutator' = mutator  # noqa: F821
         self.samples: List[Any] = samples
         self.from_: Model = from_
         self.to: Model = to

--- a/nni/retiarii/integration.py
+++ b/nni/retiarii/integration.py
@@ -12,7 +12,6 @@ from nni.utils import MetricType
 from .graph import MetricData
 from .execution.base import BaseExecutionEngine
 from .execution.cgo_engine import CGOExecutionEngine
-from .execution.api import set_execution_engine
 from .integration_api import register_advisor
 from .serializer import json_dumps, json_loads
 
@@ -49,7 +48,7 @@ class RetiariiAdvisor(MsgDispatcherBase):
     final_metric_callback
     """
 
-    def __init__(self):
+    def __init__(self, execution_):
         super(RetiariiAdvisor, self).__init__()
         register_advisor(self)  # register the current advisor as the "global only" advisor
         self.search_space = None
@@ -61,15 +60,6 @@ class RetiariiAdvisor(MsgDispatcherBase):
         self.final_metric_callback: Callable[[int, MetricData], None] = None
 
         self.parameters_count = 0
-
-        engine = self._create_execution_engine()
-        set_execution_engine(engine)
-
-    def _create_execution_engine(self):
-        if os.environ.get('CGO') == 'true':
-            return CGOExecutionEngine()
-        else:
-            return BaseExecutionEngine()
 
     def handle_initialize(self, data):
         """callback for initializing the advisor

--- a/nni/retiarii/integration.py
+++ b/nni/retiarii/integration.py
@@ -48,7 +48,7 @@ class RetiariiAdvisor(MsgDispatcherBase):
     final_metric_callback
     """
 
-    def __init__(self, execution_):
+    def __init__(self):
         super(RetiariiAdvisor, self).__init__()
         register_advisor(self)  # register the current advisor as the "global only" advisor
         self.search_space = None

--- a/nni/retiarii/integration.py
+++ b/nni/retiarii/integration.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import logging
-import os
 from typing import Any, Callable
 
 from nni.runtime.msg_dispatcher_base import MsgDispatcherBase
@@ -10,8 +9,6 @@ from nni.runtime.protocol import CommandType, send
 from nni.utils import MetricType
 
 from .graph import MetricData
-from .execution.base import BaseExecutionEngine
-from .execution.cgo_engine import CGOExecutionEngine
 from .integration_api import register_advisor
 from .serializer import json_dumps, json_loads
 

--- a/nni/retiarii/mutator.py
+++ b/nni/retiarii/mutator.py
@@ -3,7 +3,7 @@
 
 from typing import (Any, Iterable, List, Optional)
 
-from .graph import Model, Mutation
+from .graph import Model, Mutation, ModelStatus
 
 
 __all__ = ['Sampler', 'Mutator']
@@ -72,6 +72,7 @@ class Mutator:
         self.mutate(copy)
         self.sampler.mutation_end(self, copy)
         copy.history.append(Mutation(self, self._cur_samples, model, copy))
+        copy.status = ModelStatus.Frozen
         self._cur_model = None
         self._cur_choice_idx = None
         return copy

--- a/nni/retiarii/mutator.py
+++ b/nni/retiarii/mutator.py
@@ -41,12 +41,12 @@ class Mutator:
     For certain mutator subclasses, strategy or sampler can use `Mutator.dry_run()` to predict choice candidates.
     # Method names are open for discussion.
     
-    If mutator has a name, in most cases, it means that this mutator is applied to nodes with this name.
+    If mutator has a label, in most cases, it means that this mutator is applied to nodes with this label.
     """
 
-    def __init__(self, sampler: Optional[Sampler] = None, name: Optional[str] = None):
+    def __init__(self, sampler: Optional[Sampler] = None, label: Optional[str] = None):
         self.sampler: Optional[Sampler] = sampler
-        self.name = name
+        self.label: Optional[str] = label
         self._cur_model: Optional[Model] = None
         self._cur_choice_idx: Optional[int] = None
 

--- a/nni/retiarii/mutator.py
+++ b/nni/retiarii/mutator.py
@@ -3,7 +3,7 @@
 
 from typing import (Any, Iterable, List, Optional)
 
-from .graph import Model
+from .graph import Model, Mutation
 
 
 __all__ = ['Sampler', 'Mutator']
@@ -40,10 +40,13 @@ class Mutator:
     and then use `Mutator.apply()` to mutate model.
     For certain mutator subclasses, strategy or sampler can use `Mutator.dry_run()` to predict choice candidates.
     # Method names are open for discussion.
+    
+    If mutator has a name, in most cases, it means that this mutator is applied to nodes with this name.
     """
 
-    def __init__(self, sampler: Optional[Sampler] = None):
+    def __init__(self, sampler: Optional[Sampler] = None, name: Optional[str] = None):
         self.sampler: Optional[Sampler] = sampler
+        self.name = name
         self._cur_model: Optional[Model] = None
         self._cur_choice_idx: Optional[int] = None
 
@@ -64,9 +67,11 @@ class Mutator:
         copy = model.fork()
         self._cur_model = copy
         self._cur_choice_idx = 0
+        self._cur_samples = []
         self.sampler.mutation_start(self, copy)
         self.mutate(copy)
         self.sampler.mutation_end(self, copy)
+        copy.history.append(Mutation(self, self._cur_samples, model, copy))
         self._cur_model = None
         self._cur_choice_idx = None
         return copy
@@ -97,6 +102,7 @@ class Mutator:
         """
         assert self.sampler is not None and self._cur_model is not None and self._cur_choice_idx is not None
         ret = self.sampler.choice(list(candidates), self, self._cur_model, self._cur_choice_idx)
+        self._cur_samples.append(ret)
         self._cur_choice_idx += 1
         return ret
 

--- a/nni/retiarii/mutator.py
+++ b/nni/retiarii/mutator.py
@@ -40,7 +40,7 @@ class Mutator:
     and then use `Mutator.apply()` to mutate model.
     For certain mutator subclasses, strategy or sampler can use `Mutator.dry_run()` to predict choice candidates.
     # Method names are open for discussion.
-    
+
     If mutator has a label, in most cases, it means that this mutator is applied to nodes with this label.
     """
 

--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -68,7 +68,7 @@ class LayerChoice(nn.Module):
         try:
             return candidates[_get_fixed_value(label)]
         except KeyError:
-            super().__new__(cls, candidates, label=label, **kwargs)
+            return super().__new__(cls)
 
     def __init__(self, candidates: Union[Dict[str, nn.Module], List[nn.Module]], label: str = None, **kwargs):
         super(LayerChoice, self).__init__()
@@ -182,7 +182,7 @@ class InputChoice(nn.Module):
         try:
             return ChosenInputs(_get_fixed_value(label), reduction=reduction)
         except KeyError:
-            super().__new__(cls, n_candidates, n_chosen=n_chosen, reduction=reduction, label=label, **kwargs)
+            return super().__new__(cls)
 
     def __init__(self, n_candidates: int, n_chosen: int = 1, reduction: str = 'sum', label: str = None, **kwargs):
         super(InputChoice, self).__init__()
@@ -290,7 +290,7 @@ class ValueChoice(Translatable, nn.Module):
         try:
             return _get_fixed_value(label)
         except KeyError:
-            super().__new__(cls, candidates, label=label)
+            return super().__new__(cls)
 
     def __init__(self, candidates: List[Any], label: str = None):
         super().__init__()

--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -324,6 +324,14 @@ class ValueChoice(Translatable, nn.Module):
             raise KeyError(''.join([f'[{a}]' for a in self._accessor]) + f' does not work on {value}')
         return v
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        new_item = ValueChoice(self.candidates, self.label)
+        new_item._accessor = [*self._accessor]
+        return new_item
+
     def __getitem__(self, item):
         """
         Get a sub-element of value choice.

--- a/nni/retiarii/nn/pytorch/mutator.py
+++ b/nni/retiarii/nn/pytorch/mutator.py
@@ -155,7 +155,7 @@ class ManyChooseManyMutator(Mutator):
 def extract_mutation_from_pt_module(pytorch_model: nn.Module) -> Tuple[Model, Optional[List[Mutator]]]:
     model = Model(_internal=True)
     graph = Graph(model, uid(), '_model', _internal=True)._register()
-    model.class_name = get_importable_name(pytorch_model.__class__, relocate_module=True)
+    model.python_class = pytorch_model.__class__
     for module in pytorch_model.modules():
         if isinstance(module, (LayerChoice, InputChoice, ValueChoice)):
             # TODO: check the label of module and warn if it's auto-generated
@@ -172,8 +172,6 @@ def extract_mutation_from_pt_module(pytorch_model: nn.Module) -> Tuple[Model, Op
         if isinstance(module, Placeholder):
             raise NotImplementedError('Placeholder is not supported in python execution mode.')
     model.status = ModelStatus.Frozen
-    print(model._dump())
-    print(model)
     if not graph.hidden_nodes:
         return model, None
 

--- a/nni/retiarii/nn/pytorch/mutator.py
+++ b/nni/retiarii/nn/pytorch/mutator.py
@@ -129,9 +129,12 @@ def process_inline_mutation(model: Model) -> Optional[List[Mutator]]:
 
 
 class ManyChooseManyMutator(Mutator):
-    def __init__(self, label: Optional[str], name: Optional[str] = None):
+    """
+    Choose based on labels. Will not affect the model itself.
+    """
+
+    def __init__(self, label: Optional[str]):
         super().__init__(label=label)
-        self.name = name
 
     @staticmethod
     def candidates(node):
@@ -171,22 +174,21 @@ def extract_mutation_from_pt_module(pytorch_model: nn.Module) -> Tuple[Model, Op
         if hasattr(module, '_init_parameters'):
             for key, value in module._init_parameters.items():
                 if isinstance(value, ValueChoice):
-                    node = model.root_graph.add_node(name + '.init.' + key, 'ValueChoice', {'candidates': value.candidates})
+                    node = graph.add_node(name + '.init.' + key, 'ValueChoice', {'candidates': value.candidates})
                     node.label = value.label
 
         if isinstance(module, (LayerChoice, InputChoice, ValueChoice)):
             # TODO: check the label of module and warn if it's auto-generated
             pass
         if isinstance(module, LayerChoice):
-            node = model.root_graph.add_node(name, 'LayerChoice', {'candidates': module.names})
+            node = graph.add_node(name, 'LayerChoice', {'candidates': module.names})
             node.label = module.label
         if isinstance(module, InputChoice):
-            node = model.root_graph.add_node(name, 'InputChoice',
-                                             {'n_candidates': module.n_candidates, 'n_chosen': module.n_chosen})
+            node = graph.add_node(name, 'InputChoice',
+                                  {'n_candidates': module.n_candidates, 'n_chosen': module.n_chosen})
             node.label = module.label
         if isinstance(module, ValueChoice):
-            node = model.root_graph.add_node(name, 'ValueChoice',
-                                             {'candidates': module.candidates})
+            node = graph.add_node(name, 'ValueChoice', {'candidates': module.candidates})
             node.label = module.label
         if isinstance(module, Placeholder):
             raise NotImplementedError('Placeholder is not supported in python execution mode.')

--- a/nni/retiarii/nn/pytorch/mutator.py
+++ b/nni/retiarii/nn/pytorch/mutator.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 
 from ...mutator import Mutator
 from ...graph import Cell, Graph, Model, ModelStatus, Node
-from ...utils import get_importable_name, uid
+from ...utils import uid
 from .api import LayerChoice, InputChoice, ValueChoice, Placeholder
 
 

--- a/nni/retiarii/serializer.py
+++ b/nni/retiarii/serializer.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import json_tricks
 
-from .utils import get_importable_name, get_module_name, import_
+from .utils import get_importable_name, get_module_name, import_, reset_uid
 
 
 def get_init_parameters_or_fail(obj, silently=False):
@@ -83,9 +83,11 @@ class Translatable(abc.ABC):
         pass
 
 
-def _create_wrapper_cls(cls, store_init_parameters=True):
+def _create_wrapper_cls(cls, store_init_parameters=True, reset_mutation_uid=False):
     class wrapper(cls):
         def __init__(self, *args, **kwargs):
+            if reset_mutation_uid:
+                reset_uid('mutation')
             if store_init_parameters:
                 argname_list = list(inspect.signature(cls.__init__).parameters.keys())[1:]
                 full_args = {}
@@ -149,3 +151,15 @@ def basic_unit(cls):
     import torch.nn as nn
     assert issubclass(cls, nn.Module), 'When using @basic_unit, the class must be a subclass of nn.Module.'
     return serialize_cls(cls)
+
+
+def model_wrapper(cls):
+    """
+    Wrap the model if you are using pure-python execution engine.
+
+    The wrapper serves two purposes:
+
+        1. Capture the init parameters of python class so that it can be re-instantiated in another process.
+        2. Reset uid in `mutation` namespace so that each model counts from zero. Can be useful in unittest and other multi-model scenarios.
+    """
+    return _create_wrapper_cls(cls, reset_mutation_uid=True)

--- a/nni/retiarii/trial_entry.py
+++ b/nni/retiarii/trial_entry.py
@@ -20,6 +20,6 @@ if __name__ == '__main__':
         from .execution.cgo_engine import CGOExecutionEngine
         engine = CGOExecutionEngine()
     elif args.exec == 'py':
-        from .execution.purepython import PurePythonExecutinoEngine
-        engine = PurePythonExecutinoEngine()
+        from .execution.python import PurePythonExecutionEngine
+        engine = PurePythonExecutionEngine()
     engine.trial_execute_graph()

--- a/nni/retiarii/trial_entry.py
+++ b/nni/retiarii/trial_entry.py
@@ -6,13 +6,20 @@ Entrypoint for trials.
 
 Assuming execution engine is BaseExecutionEngine.
 """
-import os
+import argparse
 
-from .execution.base import BaseExecutionEngine
-from .execution.cgo_engine import CGOExecutionEngine
 
 if __name__ == '__main__':
-    if os.environ.get('CGO') == 'true':
-        CGOExecutionEngine.trial_execute_graph()
-    else:
-        BaseExecutionEngine.trial_execute_graph()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('exec', choices=['base', 'py', 'cgo'])
+    args = parser.parse_args()
+    if args.exec == 'base':
+        from .execution.base import BaseExecutionEngine
+        engine = BaseExecutionEngine()
+    elif args.exec == 'cgo':
+        from .execution.cgo_engine import CGOExecutionEngine
+        engine = CGOExecutionEngine()
+    elif args.exec == 'py':
+        from .execution.purepython import PurePythonExecutinoEngine
+        engine = PurePythonExecutinoEngine()
+    engine.trial_execute_graph()

--- a/nni/retiarii/trial_entry.py
+++ b/nni/retiarii/trial_entry.py
@@ -15,11 +15,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.exec == 'base':
         from .execution.base import BaseExecutionEngine
-        engine = BaseExecutionEngine()
+        engine = BaseExecutionEngine
     elif args.exec == 'cgo':
         from .execution.cgo_engine import CGOExecutionEngine
-        engine = CGOExecutionEngine()
+        engine = CGOExecutionEngine
     elif args.exec == 'py':
         from .execution.python import PurePythonExecutionEngine
-        engine = PurePythonExecutionEngine()
+        engine = PurePythonExecutionEngine
     engine.trial_execute_graph()

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -68,6 +68,13 @@ def get_importable_name(cls, relocate_module=False):
 
 
 class ContextStack:
+    """
+    This is to maintain a globally-accessible context envinronment that is visible to everywhere.
+
+    Use ``with ContextStack(namespace, value):`` to initiate, and use ``get_current_context(namespace)`` to
+    get the corresponding value in the namespace.
+    """
+
     _stack: Dict[str, List[Any]] = defaultdict(list)
 
     def __init__(self, key: str, value: Any):

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -31,6 +31,10 @@ def uid(namespace: str = 'default') -> int:
     return _last_uid[namespace]
 
 
+def reset_uid(namespace: str = 'default') -> None:
+    _last_uid[namespace] = 0
+
+
 def get_module_name(cls_or_func):
     module_name = cls_or_func.__module__
     if module_name == '__main__':

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -4,7 +4,7 @@
 import inspect
 import warnings
 from collections import defaultdict
-from typing import Any
+from typing import Any, List
 from pathlib import Path
 
 
@@ -61,3 +61,34 @@ def get_module_name(cls_or_func):
 def get_importable_name(cls, relocate_module=False):
     module_name = get_module_name(cls) if relocate_module else cls.__module__
     return module_name + '.' + cls.__name__
+
+
+class ContextStack:
+    _stack: List[Any] = []
+
+    def __init__(self, value: Any):
+        self.value = value
+
+    def __enter__(self):
+        self.push(self.value)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.pop()
+
+    @classmethod
+    def push(cls, value: Any):
+        cls._stack.append(value)
+
+    @classmethod
+    def pop(cls) -> None:
+        cls._stack.pop()
+
+    @classmethod
+    def top(cls) -> Any:
+        assert cls._stack, 'Context is empty.'
+        return cls._stack[-1]
+
+
+def get_current_context() -> Any:
+    return ContextStack.top()

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -4,7 +4,7 @@
 import inspect
 import warnings
 from collections import defaultdict
-from typing import Any, List
+from typing import Any, List, Dict
 from pathlib import Path
 
 
@@ -64,31 +64,32 @@ def get_importable_name(cls, relocate_module=False):
 
 
 class ContextStack:
-    _stack: List[Any] = []
+    _stack: Dict[str, List[Any]] = defaultdict(list)
 
-    def __init__(self, value: Any):
+    def __init__(self, key: str, value: Any):
+        self.key = key
         self.value = value
 
     def __enter__(self):
-        self.push(self.value)
+        self.push(self.key, self.value)
         return self
 
     def __exit__(self, *args, **kwargs):
-        self.pop()
+        self.pop(self.key)
 
     @classmethod
-    def push(cls, value: Any):
-        cls._stack.append(value)
+    def push(cls, key: str, value: Any):
+        cls._stack[key].append(value)
 
     @classmethod
-    def pop(cls) -> None:
-        cls._stack.pop()
+    def pop(cls, key: str) -> None:
+        cls._stack[key].pop()
 
     @classmethod
-    def top(cls) -> Any:
-        assert cls._stack, 'Context is empty.'
-        return cls._stack[-1]
+    def top(cls, key: str) -> Any:
+        assert cls._stack[key], 'Context is empty.'
+        return cls._stack[key][-1]
 
 
-def get_current_context() -> Any:
-    return ContextStack.top()
+def get_current_context(key: str) -> Any:
+    return ContextStack.top(key)

--- a/test/ut/retiarii/debug_mnist_pytorch.py
+++ b/test/ut/retiarii/debug_mnist_pytorch.py
@@ -3,22 +3,24 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
+import torch
+
 
 class _model(nn.Module):
     def __init__(self):
         super().__init__()
         self.stem = stem()
-        
-        self.fc1 = nn.Linear(1024, 256)
-        self.fc2 = nn.Linear(256, 10)
-        
+        self.flatten = torch.nn.Flatten()
+        self.fc1 = torch.nn.Linear(out_features=256, in_features=1024)
+        self.fc2 = torch.nn.Linear(out_features=10, in_features=256)
+        self.softmax = torch.nn.Softmax()
 
     def forward(self, image):
         stem = self.stem(image)
-        flatten = stem.view(stem.size(0), -1)
+        flatten = self.flatten(stem)
         fc1 = self.fc1(flatten)
         fc2 = self.fc2(fc1)
-        softmax = F.softmax(fc2, -1)
+        softmax = self.softmax(fc2)
         return softmax
 
 
@@ -26,10 +28,10 @@ class _model(nn.Module):
 class stem(nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv1 = nn.Conv2d(out_channels=32, in_channels=1, kernel_size=5)
-        self.pool1 = nn.MaxPool2d(kernel_size=2)
-        self.conv2 = nn.Conv2d(out_channels=64, in_channels=32, kernel_size=5)
-        self.pool2 = nn.MaxPool2d(kernel_size=2)
+        self.conv1 = torch.nn.Conv2d(out_channels=32, in_channels=1, kernel_size=5)
+        self.pool1 = torch.nn.MaxPool2d(kernel_size=2)
+        self.conv2 = torch.nn.Conv2d(out_channels=64, in_channels=32, kernel_size=5)
+        self.pool2 = torch.nn.MaxPool2d(kernel_size=2)
 
     def forward(self, *_inputs):
         conv1 = self.conv1(_inputs[0])

--- a/test/ut/retiarii/mnist_pytorch.json
+++ b/test/ut/retiarii/mnist_pytorch.json
@@ -5,10 +5,10 @@
 
         "nodes": {
             "stem": {"operation": {"type": "_cell", "cell_name": "stem"}},
-            "flatten": {"operation": {"type": "Flatten"}},
-            "fc1": {"operation": {"type": "Dense", "parameters": {"out_features": 256, "in_features": 1024}}},
-            "fc2": {"operation": {"type": "Dense", "parameters": {"out_features": 10, "in_features": 256}}},
-            "softmax": {"operation": {"type": "Softmax"}}
+            "flatten": {"operation": {"type": "__torch__.torch.nn.Flatten"}},
+            "fc1": {"operation": {"type": "__torch__.torch.nn.Linear", "parameters": {"out_features": 256, "in_features": 1024}}},
+            "fc2": {"operation": {"type": "__torch__.torch.nn.Linear", "parameters": {"out_features": 10, "in_features": 256}}},
+            "softmax": {"operation": {"type": "__torch__.torch.nn.Softmax"}}
         },
 
         "edges": [
@@ -23,10 +23,10 @@
 
     "stem": {
         "nodes": {
-            "conv1": {"operation": {"type": "__torch__.Conv2d", "parameters": {"out_channels": 32, "in_channels": 1, "kernel_size": 5}}},
-            "pool1": {"operation": {"type": "__torch__.MaxPool2d", "parameters": {"kernel_size": 2}}},
-            "conv2": {"operation": {"type": "__torch__.Conv2d", "parameters": {"out_channels": 64, "in_channels": 32, "kernel_size": 5}}},
-            "pool2": {"operation": {"type": "__torch__.MaxPool2d", "parameters": {"kernel_size": 2}}}
+            "conv1": {"operation": {"type": "__torch__.torch.nn.Conv2d", "parameters": {"out_channels": 32, "in_channels": 1, "kernel_size": 5}}},
+            "pool1": {"operation": {"type": "__torch__.torch.nn.MaxPool2d", "parameters": {"kernel_size": 2}}},
+            "conv2": {"operation": {"type": "__torch__.torch.nn.Conv2d", "parameters": {"out_channels": 64, "in_channels": 32, "kernel_size": 5}}},
+            "pool2": {"operation": {"type": "__torch__.torch.nn.MaxPool2d", "parameters": {"kernel_size": 2}}}
         },
 
         "edges": [
@@ -36,26 +36,5 @@
             {"head": ["conv2", null], "tail": ["pool2", null]},
             {"head": ["pool2", null], "tail": ["_outputs", 0]}
         ]
-    },
-
-    "_evaluator": {
-        "module": "nni.retiarii.trainer.PyTorchImageClassificationTrainer",
-        "kwargs": {
-            "dataset_cls": "MNIST",
-            "dataset_kwargs": {
-                "root": "data/mnist",
-                "download": true
-            },
-            "dataloader_kwargs": {
-                "batch_size": 32
-            },
-            "optimizer_cls" : "SGD",
-            "optimizer_kwargs": {
-                "lr": 1e-3
-            },
-            "trainer_kwargs": {
-                "max_epochs": 1
-            }
-        }
     }
 }

--- a/test/ut/retiarii/test_engine.py
+++ b/test/ut/retiarii/test_engine.py
@@ -12,22 +12,19 @@ from nni.retiarii.execution.python import PurePythonExecutionEngine
 from nni.retiarii.integration import RetiariiAdvisor
 
 
-class CodeGenTest(unittest.TestCase):
-    def test_mnist_example_pytorch(self):
-        with open('mnist_pytorch.json') as f:
+class EngineTest(unittest.TestCase):
+    def test_codegen(self):
+        with open(self.enclosing_dir / 'mnist_pytorch.json') as f:
             model = Model._load(json.load(f))
             script = model_to_pytorch_script(model)
-        with open('debug_mnist_pytorch.py') as f:
+        with open(self.enclosing_dir / 'debug_mnist_pytorch.py') as f:
             reference_script = f.read()
         self.assertEqual(script.strip(), reference_script.strip())
-
-
-class EngineTest(unittest.TestCase):
 
     def test_base_execution_engine(self):
         advisor = RetiariiAdvisor()
         set_execution_engine(BaseExecutionEngine())
-        with open('mnist_pytorch.json') as f:
+        with open(self.enclosing_dir / 'mnist_pytorch.json') as f:
             model = Model._load(json.load(f))
         submit_models(model, model)
 
@@ -59,9 +56,10 @@ class EngineTest(unittest.TestCase):
         advisor.assessor_worker.join()
 
     def setUp(self) -> None:
-        os.makedirs('generated', exist_ok=True)
+        self.enclosing_dir = Path(__file__).parent
+        os.makedirs(self.enclosing_dir / 'generated', exist_ok=True)
         from nni.runtime import protocol
-        protocol._out_file = open(Path(__file__).parent / 'generated/debug_protocol_out_file.py', 'wb')
+        protocol._out_file = open(self.enclosing_dir / 'generated/debug_protocol_out_file.py', 'wb')
 
     def tearDown(self) -> None:
         from nni.runtime import protocol

--- a/test/ut/retiarii/test_mutator.py
+++ b/test/ut/retiarii/test_mutator.py
@@ -60,7 +60,14 @@ def test_mutation():
     model2 = mutator.apply(model1)
     assert _get_pools(model2) == (global_pool, max_pool)
 
-    assert model2.history == [model0, model1]
+    assert len(model2.history) == 2
+    assert model2.history[0].from_ == model0
+    assert model2.history[0].to == model1
+    assert model2.history[1].from_ == model1
+    assert model2.history[1].to == model2
+    assert model2.history[0].mutator == mutator
+    assert model2.history[1].mutator == mutator
+
     assert _get_pools(model0) == (max_pool, max_pool)
     assert _get_pools(model1) == (avg_pool, global_pool)
 


### PR DESCRIPTION
This PR adds an execution engine that can directly execute graph without touching any graph converter and codegen stuff. It is expected to become the default execution engine in version 2.3.

I've also implemented a more useful mutation history tracking tool. This should make the upcoming visualization thing possible.

I tried to refact/damage as little code as possible. Some of the refactoring effort might come in future releases.

~I think a lot of tests are needed before it is ready for review.~

Depending on #3607.

## User experience

Currently I don't have the confidence to make this execution engine default. Two modifications are needed to (manually) enable the new engine.

1. Add `@model_wrapper` decorator outside the full PyTorch model.
2. Add `config.execution_engine = 'py'` to `RetiariiExeConfig`.
