### PR TITLE
Improve NNI manager logging

### DIFF
--- a/nni/tools/nnictl/launcher.py
+++ b/nni/tools/nnictl/launcher.py
@@ -43,7 +43,7 @@ def print_log_content(config_file_name):
     print_normal(' Stderr:')
     print(check_output_command(stderr_full_path))
 
-def start_rest_server(port, platform, mode, experiment_id, foreground=False, log_dir=None, log_level=None):
+def start_rest_server(port, platform, mode, experiment_id, foreground=False, log_dir=None, log_level='info'):
     '''Run nni manager process'''
     if detect_port(port):
         print_error('Port %s is used by another process, please reset the port!\n' \
@@ -367,8 +367,8 @@ def launch_experiment(args, experiment_config, mode, experiment_id, config_versi
     if config_version == 1:
         log_dir = experiment_config['logDir'] if experiment_config.get('logDir') else NNI_HOME_DIR
     else:
-        log_dir = experiment_config['experimentWorkingDirectory'] if experiment_config.get('experimentWorkingDirectory') else NNI_HOME_DIR
-    log_level = experiment_config['logLevel'] if experiment_config.get('logLevel') else None
+        log_dir = experiment_config.get('experimentWorkingDirectory', NNI_HOME_DIR)
+    log_level = experiment_config.get('logLevel', 'info')
     #view experiment mode do not need debug function, when view an experiment, there will be no new logs created
     foreground = False
     if mode != 'view':
@@ -383,8 +383,7 @@ def launch_experiment(args, experiment_config, mode, experiment_id, config_versi
     else:
         platform = experiment_config['trainingService']['platform']
 
-    rest_process, start_time = start_rest_server(args.port, platform, \
-                                                 mode, experiment_id, foreground, log_dir, log_level)
+    rest_process, start_time = start_rest_server(args.port, platform, mode, experiment_id, foreground, log_dir, log_level)
     # save experiment information
     Experiments().add_experiment(experiment_id, args.port, start_time,
                                  platform,

--- a/nni/tools/nnictl/launcher.py
+++ b/nni/tools/nnictl/launcher.py
@@ -43,7 +43,7 @@ def print_log_content(config_file_name):
     print_normal(' Stderr:')
     print(check_output_command(stderr_full_path))
 
-def start_rest_server(port, platform, mode, experiment_id, foreground=False, log_dir=None, log_level='info'):
+def start_rest_server(port, platform, mode, experiment_id, foreground=False, log_dir=None, log_level=None):
     '''Run nni manager process'''
     if detect_port(port):
         print_error('Port %s is used by another process, please reset the port!\n' \
@@ -367,8 +367,8 @@ def launch_experiment(args, experiment_config, mode, experiment_id, config_versi
     if config_version == 1:
         log_dir = experiment_config['logDir'] if experiment_config.get('logDir') else NNI_HOME_DIR
     else:
-        log_dir = experiment_config.get('experimentWorkingDirectory', NNI_HOME_DIR)
-    log_level = experiment_config.get('logLevel', 'info')
+        log_dir = experiment_config['experimentWorkingDirectory'] if experiment_config.get('experimentWorkingDirectory') else NNI_HOME_DIR
+    log_level = experiment_config['logLevel'] if experiment_config.get('logLevel') else 'info'
     #view experiment mode do not need debug function, when view an experiment, there will be no new logs created
     foreground = False
     if mode != 'view':
@@ -383,7 +383,8 @@ def launch_experiment(args, experiment_config, mode, experiment_id, config_versi
     else:
         platform = experiment_config['trainingService']['platform']
 
-    rest_process, start_time = start_rest_server(args.port, platform, mode, experiment_id, foreground, log_dir, log_level)
+    rest_process, start_time = start_rest_server(args.port, platform, \
+                                                 mode, experiment_id, foreground, log_dir, log_level)
     # save experiment information
     Experiments().add_experiment(experiment_id, args.port, start_time,
                                  platform,

--- a/ts/nni_manager/common/log.ts
+++ b/ts/nni_manager/common/log.ts
@@ -111,7 +111,7 @@ export function getLogger(name: string = 'root'): Logger {
 
 /* management functions */
 
-export function setLevel(levelName: string): void {
+export function setLogLevel(levelName: string): void {
     if (levelName) {
         const level = module.exports[levelName.toUpperCase()];
         if (typeof level === 'number') {
@@ -123,7 +123,7 @@ export function setLevel(levelName: string): void {
     }
 }
 
-export function start(logPath: string): void {
+export function startLogging(logPath: string): void {
     logFile = fs.createWriteStream(logPath, {
         flags: 'a+',
         encoding: 'utf8',
@@ -131,7 +131,7 @@ export function start(logPath: string): void {
     });
 }
 
-export function stop(): void {
+export function stopLogging(): void {
     if (logFile !== null) {
         logFile.end();
         logFile = null;

--- a/ts/nni_manager/common/log.ts
+++ b/ts/nni_manager/common/log.ts
@@ -26,40 +26,11 @@ const levelNames = new Map<number, string>([
     [TRACE, 'TRACE'],
 ]);
 
-/* global states */
+/* global_ states */
 
 let logFile: Writable | null = null;
 let logLevel: number = 0;
 const loggers = new Map<string, Logger>();
-
-/* management functions */
-
-export function setLevel(levelName: string): void {
-    if (levelName) {
-        const level = module.exports[levelName.toUpperCase()];
-        if (typeof level === 'number') {
-            logLevel = level;
-        } else {
-            console.log('[ERROR] Bad log level:', levelName);
-            getLogger('logging').error('Bad log level:', levelName);
-        }
-    }
-}
-
-export function start(logPath: string): void {
-    logFile = fs.createWriteStream(logPath, {
-        flags: 'a+',
-        encoding: 'utf8',
-        autoClose: true
-    });
-}
-
-export function stop(): void {
-    if (logFile !== null) {
-        logFile.end();
-        logFile = null;
-    }
-}
 
 /* major api */
 
@@ -136,4 +107,33 @@ export function getLogger(name: string = 'root'): Logger {
         loggers.set(name, logger);
     }
     return logger;
+}
+
+/* management functions */
+
+export function setLevel(levelName: string): void {
+    if (levelName) {
+        const level = module.exports[levelName.toUpperCase()];
+        if (typeof level === 'number') {
+            logLevel = level;
+        } else {
+            console.log('[ERROR] Bad log level:', levelName);
+            getLogger('logging').error('Bad log level:', levelName);
+        }
+    }
+}
+
+export function start(logPath: string): void {
+    logFile = fs.createWriteStream(logPath, {
+        flags: 'a+',
+        encoding: 'utf8',
+        autoClose: true
+    });
+}
+
+export function stop(): void {
+    if (logFile !== null) {
+        logFile.end();
+        logFile = null;
+    }
 }

--- a/ts/nni_manager/common/utils.ts
+++ b/ts/nni_manager/common/utils.ts
@@ -23,7 +23,6 @@ import { ExperimentStartupInfo, getExperimentStartupInfo, setExperimentStartupIn
 import { ExperimentConfig, Manager } from './manager';
 import { ExperimentManager } from './experimentManager';
 import { HyperParameters, TrainingService, TrialJobStatus } from './trainingService';
-import { logLevelNameMap } from './log';
 
 function getExperimentRootDir(): string {
     return getExperimentStartupInfo()
@@ -195,9 +194,6 @@ function prepareUnitTest(): void {
     Container.snapshot(ExperimentManager);
 
     const logLevel: string = parseArg(['--log_level', '-ll']);
-    if (logLevel.length > 0 && !logLevelNameMap.has(logLevel)) {
-        console.log(`FATAL: invalid log_level: ${logLevel}`);
-    }
 
     setExperimentStartupInfo(true, 'unittest', 8080, 'unittest', undefined, logLevel);
     mkDirPSync(getLogDir());

--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -362,7 +362,6 @@ class NNIManager implements Manager {
             hasError = true;
             this.log.error(`${err.stack}`);
         } finally {
-            this.log.close();
             process.exit(hasError ? 1 : 0);
         }
     }

--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -10,7 +10,7 @@ import * as component from '../common/component';
 import { DataStore, MetricDataRecord, MetricType, TrialJobInfo } from '../common/datastore';
 import { NNIError } from '../common/errors';
 import { getExperimentId, getDispatcherPipe } from '../common/experimentStartupInfo';
-import { getLogger, Logger } from '../common/log';
+import { Logger, getLogger, stopLogging } from '../common/log';
 import {
     ExperimentProfile, Manager, ExperimentStatus,
     NNIManagerStatus, ProfileUpdateType, TrialJobStatistics
@@ -362,6 +362,7 @@ class NNIManager implements Manager {
             hasError = true;
             this.log.error(`${err.stack}`);
         } finally {
+            stopLogging();
             process.exit(hasError ? 1 : 0);
         }
     }

--- a/ts/nni_manager/main.ts
+++ b/ts/nni_manager/main.ts
@@ -53,6 +53,7 @@ async function initContainer(foreground: boolean, platformMode: string, logFileN
         } else {
             logging.start(logFileName);
         }
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         logging.setLevel(logLevel);
     }
     const ds: DataStore = component.get(DataStore);

--- a/ts/nni_manager/main.ts
+++ b/ts/nni_manager/main.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as component from './common/component';
 import { Database, DataStore } from './common/datastore';
 import { setExperimentStartupInfo } from './common/experimentStartupInfo';
-import * as logging from './common/log';
+import { getLogger, setLogLevel, startLogging } from './common/log';
 import { Manager, ExperimentStartUpMode } from './common/manager';
 import { ExperimentManager } from './common/experimentManager';
 import { TensorboardManager } from './common/tensorboardManager';
@@ -49,12 +49,12 @@ async function initContainer(foreground: boolean, platformMode: string, logFileN
     const DEFAULT_LOGFILE: string = path.join(getLogDir(), 'nnimanager.log');
     if (!foreground) {
         if (logFileName === undefined) {
-            logging.start(DEFAULT_LOGFILE);
+            startLogging(DEFAULT_LOGFILE);
         } else {
-            logging.start(logFileName);
+            startLogging(logFileName);
         }
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        logging.setLevel(logLevel);
+        setLogLevel(logLevel);
     }
     const ds: DataStore = component.get(DataStore);
 
@@ -130,11 +130,9 @@ mkDirP(getLogDir())
             await initContainer(foreground, mode);
             const restServer: NNIRestServer = component.get(NNIRestServer);
             await restServer.start();
-            const log = logging.getLogger();
-            log.info(`Rest server listening on: ${restServer.endPoint}`);
+            getLogger('main').info(`Rest server listening on: ${restServer.endPoint}`);
         } catch (err) {
-            const log = logging.getLogger();
-            log.error(`${err.stack}`);
+            getLogger('main').error(`${err.stack}`);
             throw err;
         }
     })

--- a/ts/nni_manager/main.ts
+++ b/ts/nni_manager/main.ts
@@ -53,6 +53,7 @@ async function initContainer(foreground: boolean, platformMode: string, logFileN
         } else {
             logging.start(logFileName);
         }
+        logging.setLevel(logLevel);
     }
     const ds: DataStore = component.get(DataStore);
 
@@ -109,11 +110,6 @@ if (logDir.length > 0) {
 }
 
 const logLevel: string = parseArg(['--log_level', '-ll']);
-if (logLevel.length > 0 && (logging as any)[logLevel] === undefined) {
-    console.log(`FATAL: invalid log_level: ${logLevel}`);
-} else {
-    logging.setLevel(logLevel);
-}
 
 const readonlyArg: string = parseArg(['--readonly', '-r']);
 if (!('true' || 'false').includes(readonlyArg.toLowerCase())) {


### PR DESCRIPTION
This PR implements following improvements:
1. Allow TS loggers to have "name" like Python counterpart, so it can distinguish log messages from different modules. This will be helpful for 3rd party training service.
2. Correctly format log message to string (rather than array).
3. Automatically stringify JSON objects and arrays, so you won't see `[Object object]` in log.

Before:
```
[2021-04-21 10:37:34] INFO [ 'Datastore initialization done' ]
```

Now:
```
[2021-05-10 12:07:56] INFO (root) Datastore initialization done
```