### PR TITLE
[webui] add basename in router

### DIFF
--- a/ts/webui/src/components/stateless-component/NNItabs.tsx
+++ b/ts/webui/src/components/stateless-component/NNItabs.tsx
@@ -2,19 +2,19 @@ import * as React from 'react';
 import { NavLink } from 'react-router-dom';
 
 const OVERVIEWTABS = (
-    <NavLink to={'/oview'} activeClassName='selected' className='common-tabs'>
+    <NavLink to='/oview' activeClassName='selected' className='common-tabs'>
         Overview
     </NavLink>
 );
 
 const DETAILTABS = (
-    <NavLink to={'/detail'} activeClassName='selected' className='common-tabs'>
+    <NavLink to='/detail' activeClassName='selected' className='common-tabs'>
         Trials detail
     </NavLink>
 );
 
 const NNILOGO = (
-    <NavLink to={'/oview'}>
+    <NavLink to='/oview'>
         <img src={require('../../static/img/logo.png')} alt='NNI logo' style={{ height: 40 }} />
     </NavLink>
 );

--- a/ts/webui/src/index.tsx
+++ b/ts/webui/src/index.tsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import { getPrefix } from './static/function';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 const Overview = lazy(() => import('./components/Overview'));
 const TrialsDetail = lazy(() => import('./components/TrialsDetail'));
@@ -9,8 +10,10 @@ import './index.css';
 import './static/style/loading.scss';
 import * as serviceWorker from './serviceWorker';
 
+const path = getPrefix();
+
 ReactDOM.render(
-    <Router>
+    <Router basename={path === undefined ? null : path}>
         <Suspense
             fallback={
                 <div className='loading'>

--- a/ts/webui/src/static/const.ts
+++ b/ts/webui/src/static/const.ts
@@ -1,10 +1,17 @@
+import { getPrefix } from './function';
+
 // when there are more trials than this threshold, metrics will be updated in group of this size to avoid freezing
 const METRIC_GROUP_UPDATE_THRESHOLD = 100;
 const METRIC_GROUP_UPDATE_SIZE = 20;
 
-const MANAGER_IP = `/api/v1/nni`;
+const prefix = getPrefix();
+
+const MANAGER_IP = prefix === undefined ? '/api/v1/nni' : `/api/v1/nni${prefix}`;
+// how about /logs apis?
 const DOWNLOAD_IP = `/logs`;
+
 const WEBUIDOC = 'https://nni.readthedocs.io/en/latest/Tutorial/WebUI.html';
+
 const trialJobStatus = [
     'UNKNOWN',
     'WAITING',

--- a/ts/webui/src/static/const.ts
+++ b/ts/webui/src/static/const.ts
@@ -6,8 +6,7 @@ const METRIC_GROUP_UPDATE_SIZE = 20;
 
 const prefix = getPrefix();
 
-const MANAGER_IP = prefix === undefined ? '/api/v1/nni' : `/api/v1/nni${prefix}`;
-// how about /logs apis?
+const MANAGER_IP = prefix === undefined ? '/api/v1/nni' : `${prefix}`;
 const DOWNLOAD_IP = `/logs`;
 
 const WEBUIDOC = 'https://nni.readthedocs.io/en/latest/Tutorial/WebUI.html';

--- a/ts/webui/src/static/function.ts
+++ b/ts/webui/src/static/function.ts
@@ -8,7 +8,7 @@ function getPrefix(): string | undefined {
     const pathName = window.location.pathname;
     let newPathName = pathName;
 
-    if (pathName.endsWith('/oview' || '/detail' || '/experiment')) {
+    if (pathName.endsWith('/oview') || pathName.endsWith('/detail') || pathName.endsWith('/experiment')) {
         newPathName = pathName.replace('/oview' || '/detail' || '/experiment', '');
     }
 

--- a/ts/webui/src/static/function.ts
+++ b/ts/webui/src/static/function.ts
@@ -4,6 +4,17 @@ import { IContextualMenuProps } from '@fluentui/react';
 import { MANAGER_IP } from './const';
 import { MetricDataRecord, FinalType, TableObj, Tensorboard } from './interface';
 
+function getPrefix(): string | undefined {
+    const pathName = window.location.pathname;
+    let newPathName = pathName;
+
+    if (pathName.endsWith('/oview' || '/detail' || '/experiment')) {
+        newPathName = pathName.replace('/oview' || '/detail' || '/experiment', '');
+    }
+
+    return newPathName === '' ? undefined : newPathName;
+}
+
 async function requestAxios(url: string): Promise<any> {
     const response = await axios.get(url);
     if (response.status === 200) {
@@ -346,6 +357,7 @@ function getTensorboardMenu(queryTensorboardList: Tensorboard[], stopFunc, seeDe
     return tensorboardMenu;
 }
 export {
+    getPrefix,
     convertTime,
     convertDuration,
     convertTimeAsUnit,


### PR DESCRIPTION
related issue: #2771 

With this PR merged, you could run an experiment with command `nnictl create --config xx.yml --url_prefix customURL` open webui website look like this : `ip:port/customURL/oview`

- [x] test with **Hao Ni**'s PR #3643
- [x] Rest api: `/api/v1/nni${prefix}`, 如果用户未设置prefix，`api/v1/nni`
- [x] `/logs api` needs prefix? -> no need to add prefix for /logs api


### 测试用例
（1）`nnictl create --config xx.yml` 起一个实验，观察 ip:port/oview、 /detail、 /experiment 页面是否正常
（2）`nnictl create --config xx.yml --url_prefix customPrefix` 起一个实验，观察 ip:port/customPrefix/oview、/detail、 /experiment 页面是否正常
（3）`nnictl create --config xx.yml --url_prefix /customerURL` 起一个实验，此时会提醒不能以 `/`  开头，路径无效
（4）`nnictl create --config xx.yml --url_prefix customer/xxx` 起一个实验，观察 ip:port/customPrefix/oview、/detail、 /experiment 页面是否正常