### PR TITLE
add trial stdout button on local mode

### DIFF
--- a/ts/webui/src/components/public-child/OpenRow.tsx
+++ b/ts/webui/src/components/public-child/OpenRow.tsx
@@ -120,6 +120,11 @@ class OpenRow extends React.Component<OpenRowProps, OpenRowState> {
                                                 text='View trial error'
                                                 styles={{ root: { marginLeft: 15 } }}
                                             />
+                                            <PrimaryButton
+                                                onClick={this.openTrialLog.bind(this, 'TRIAL_STDOUT')}
+                                                text='View trial stdout'
+                                                styles={{ root: { marginLeft: 15 } }}
+                                            />
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
add `View trial stdout` button only for local mode:
![image](https://user-images.githubusercontent.com/61399850/119784382-b99e5a00-bf00-11eb-93d9-c7b9285334ec.png)
