### PR TITLE
Documentation typo fix in DoReFa compression 

### DIFF
--- a/docs/en_US/Compression/Quantizer.rst
+++ b/docs/en_US/Compression/Quantizer.rst
@@ -162,7 +162,7 @@ PyTorch code
    config_list = [{ 
        'quant_types': ['weight'],
        'quant_bits': 8, 
-       'op_types': 'default' 
+       'op_types': ['default'] 
    }]
    quantizer = DoReFaQuantizer(model, config_list)
    quantizer.compress()

--- a/docs/en_US/Compression/Quantizer.rst
+++ b/docs/en_US/Compression/Quantizer.rst
@@ -162,7 +162,7 @@ PyTorch code
    config_list = [{ 
        'quant_types': ['weight'],
        'quant_bits': 8, 
-       'op_types': ['default'] 
+       'op_types': 'default' 
    }]
    quantizer = DoReFaQuantizer(model, config_list)
    quantizer.compress()


### PR DESCRIPTION
Op_types requires a list to be passed in it. Raw string caused error.