### PR TITLE
fix wrong lr scheduler for cream

### DIFF
--- a/examples/nas/legacy/cream/lib/utils/util.py
+++ b/examples/nas/legacy/cream/lib/utils/util.py
@@ -176,5 +176,5 @@ def create_supernet_scheduler(cfg, optimizer):
     ITERS = cfg.EPOCHS * \
         (1280000 / (cfg.NUM_GPU * cfg.DATASET.BATCH_SIZE))
     lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lambda step: (
-        cfg.LR - step / ITERS) if step <= ITERS else 0, last_epoch=-1)
+        1.0 - step / ITERS) if step <= ITERS else 0, last_epoch=-1)
     return lr_scheduler, cfg.EPOCHS


### PR DESCRIPTION
It seems that cream uses linear scheduler to train the super network. The initial multiplicative factor should be 1.0 instead of the initial learning rate (Although the initial learning rate of training the supernet is exactly 1.0 ). 