### PR TITLE
Update QuickStart.rst

### DIFF
--- a/docs/en_US/Tutorial/QuickStart.rst
+++ b/docs/en_US/Tutorial/QuickStart.rst
@@ -117,7 +117,7 @@ Three steps to start an experiment
               train(args, model, device, train_loader, optimizer, epoch)
               test_acc = test(args, model, device, test_loader)
     -         print(test_acc)
-    +         nni.report_intermeidate_result(test_acc)
+    +         nni.report_intermediate_result(test_acc)
     -     print('final accuracy:', test_acc)
     +     nni.report_final_result(test_acc)
            


### PR DESCRIPTION
Fixing a spelling mistake done in the Quickstart tutorial. Changed from "report_intermeidate_result" to "report_intermediate_result".