### PR TITLE
Adapt system auto tuning examples to NNI V2

### DIFF
--- a/docs/en_US/ResearchPublications.rst
+++ b/docs/en_US/ResearchPublications.rst
@@ -95,11 +95,14 @@ New Algorithms
 
 .. code-block:: bibtex
 
-   @article{gao2020opevo,
-     title={OpEvo: An Evolutionary Method for Tensor Operator Optimization},
-     author={Gao, Xiaotian and Wei, Cui and Zhang, Lintao and Yang, Mao},
-     journal={arXiv preprint arXiv:2006.05664},
-     year={2020}
+   @article{Gao2021opevo, 
+        title={OpEvo: An Evolutionary Method for Tensor Operator Optimization}, 
+        volume={35},
+        url={https://ojs.aaai.org/index.php/AAAI/article/view/17462}, 
+        number={14}, 
+        journal={Proceedings of the AAAI Conference on Artificial Intelligence},
+        author={Gao, Xiaotian and Cui, Wei and Zhang, Lintao and Yang, Mao},
+        year={2021}, month={May}, pages={12320-12327}
    }
 
 Measurement and Understanding

--- a/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_smac.yml
+++ b/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_smac.yml
@@ -1,21 +1,15 @@
-authorName: default
 experimentName: auto_rocksdb_SMAC
+searchSpaceFile: search_space.json
+trialCommand: python3 main.py
+trialCodeDirectory: .
+trialGpuNumber: 0
 trialConcurrency: 1
-maxExecDuration: 12h
-maxTrialNum: 256
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+maxExperimentDuration: 24h
+maxTrialNumber: 256
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: SMAC
+  name: SMAC
   classArgs:
-    #choice: maximize, minimize
     optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+trainingService:
+  platform: local
+  useActiveGpu: False

--- a/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_tpe.yml
+++ b/examples/trials/systems_auto_tuning/rocksdb-fillrandom/config_tpe.yml
@@ -1,21 +1,15 @@
-authorName: default
 experimentName: auto_rocksdb_TPE
+searchSpaceFile: search_space.json
+trialCommand: python3 main.py
+trialCodeDirectory: .
+trialGpuNumber: 0
 trialConcurrency: 1
-maxExecDuration: 12h
-maxTrialNum: 256
-#choice: local, remote, pai
-trainingServicePlatform: local
-searchSpacePath: search_space.json
-#choice: true, false
-useAnnotation: false
+maxExperimentDuration: 24h
+maxTrialNumber: 256
 tuner:
-  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
-  #SMAC (SMAC should be installed through nnictl)
-  builtinTunerName: TPE
+  name: TPE
   classArgs:
-    #choice: maximize, minimize
     optimize_mode: maximize
-trial:
-  command: python3 main.py
-  codeDir: .
-  gpuNum: 0
+trainingService:
+  platform: local
+  useActiveGpu: False


### PR DESCRIPTION
This PR adapts config files of RocksDB example to NNI V2, and updates the citation information of OpEvo paper. I do not adapt the configuration files of OpEvo to NNI V2, since they run in a docker in which NNI 1.5 is installed and I would like to keep all setup same as that of experiments in our paper.