### PR TITLE
flops counter formatting fix

### DIFF
--- a/nni/compression/pytorch/utils/counter.py
+++ b/nni/compression/pytorch/utils/counter.py
@@ -313,12 +313,13 @@ class ModelProfiler:
 
         table.field_names = headers
         for i, result in enumerate(self.results):
+            flops_count = int(result['flops'].item()) if isinstance(result['flops'], torch.Tensor) else int(result['flops'])
             row_values = [
                 i,
                 result['name'],
                 result['module_type'],
                 str(result['weight_shape']),
-                result['flops'],
+                flops_count,
                 result['params'],
             ]
             name_counter[result['name']] += 1


### PR DESCRIPTION
Fix a minor formatting issue. Previously the counter prints out the FLOPs as a tensor directly.
before:
![before](https://user-images.githubusercontent.com/43978113/122149692-130a0100-ce8f-11eb-92de-a9026dcdc5e8.png)
after:
![after](https://user-images.githubusercontent.com/43978113/122149709-1ac9a580-ce8f-11eb-81fc-e2b7707ac769.png)
