### PR TITLE
Change file name validation to warning

### DIFF
--- a/ts/nni_manager/common/utils.ts
+++ b/ts/nni_manager/common/utils.ts
@@ -285,40 +285,6 @@ function countFilesRecursively(directory: string): Promise<number> {
     });
 }
 
-export function validateFileName(fileName: string): boolean {
-    const pattern: string = '^[a-z0-9A-Z._-]+$';
-    const validateResult = fileName.match(pattern);
-    if (validateResult) {
-        return true;
-    }
-    return false;
-}
-
-async function validateFileNameRecursively(directory: string): Promise<boolean> {
-    if (!fs.existsSync(directory)) {
-        throw Error(`Direcotory ${directory} doesn't exist`);
-    }
-
-    const fileNameArray: string[] = fs.readdirSync(directory);
-    let result = true;
-    for (const name of fileNameArray) {
-        const fullFilePath: string = path.join(directory, name);
-        try {
-            // validate file names and directory names
-            result = validateFileName(name);
-            if (fs.lstatSync(fullFilePath).isDirectory()) {
-                result = result && await validateFileNameRecursively(fullFilePath);
-            }
-            if (!result) {
-                return Promise.reject(new Error(`file name in ${fullFilePath} is not valid!`));
-            }
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-    return Promise.resolve(result);
-}
-
 /**
  * get the version of current package
  */
@@ -485,7 +451,7 @@ export function importModule(modulePath: string): any {
 }
 
 export {
-    countFilesRecursively, validateFileNameRecursively, generateParamFileName, getMsgDispatcherCommand, getCheckpointDir, getExperimentsInfoPath,
+    countFilesRecursively, generateParamFileName, getMsgDispatcherCommand, getCheckpointDir, getExperimentsInfoPath,
     getLogDir, getExperimentRootDir, getJobCancelStatus, getDefaultDatabaseDir, getIPV4Address, unixPathJoin, withLockSync, getFreePort, isPortOpen,
     mkDirP, mkDirPSync, delay, prepareUnitTest, parseArg, cleanupUnitTest, uniqueString, randomInt, randomSelect, getLogLevel, getVersion, getCmdPy, getTunerProc, isAlive, killPid, getNewLine
 };

--- a/ts/nni_manager/training_service/common/util.ts
+++ b/ts/nni_manager/training_service/common/util.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import * as tar from 'tar';
 import { getLogger } from '../../common/log';
 import { String } from 'typescript-string-operations';
-import { validateFileName } from '../../common/utils';
 import { GPU_INFO_COLLECTOR_FORMAT_WINDOWS } from './gpuData';
 
 /**
@@ -54,7 +53,6 @@ export function* listDirWithIgnoredFiles(root: string, relDir: string, ignoreFil
 export async function validateCodeDir(codeDir: string): Promise<number> {
     let fileCount: number = 0;
     let fileTotalSize: number = 0;
-    let fileNameValid: boolean = true;
     for (const relPath of listDirWithIgnoredFiles(codeDir, '', [])) {
         const d = path.join(codeDir, relPath);
         fileCount += 1;
@@ -66,13 +64,16 @@ export async function validateCodeDir(codeDir: string): Promise<number> {
         if (fileTotalSize > 300 * 1024 * 1024) {
             throw new Error(`File total size too large in code dir (${fileTotalSize} bytes already scanned, exceeds 300MB).`);
         }
-        fileNameValid = true;
-        relPath.split(path.sep).forEach(fpart => {
-            if (fpart !== '' && !validateFileName(fpart))
-                fileNameValid = false;
-        });
+        // NOTE: We added this test in case any training service or shared storage (e.g. HDFS) does not support complex file name.
+        // If there is no bug found for long time, feel free to remove it.
+        const fileNameValid = relPath.split(path.sep).every(fpart => (fpart.match('^[a-z0-9A-Z._-]*$') !== null));
         if (!fileNameValid) {
-            throw new Error(`Validate file name error: '${d}' is an invalid file name.`);
+            const message = [
+                `File ${relPath} in directory ${codeDir} contains spaces or special characters in its name.`,
+                'This might cause problem when uploading to cloud or remote machine.',
+                'If you encounter any error, please report an issue: https://github.com/microsoft/nni/issues'
+            ].join(' ');
+            getLogger('validateCodeDir').warning(message);
         }
     }
 


### PR DESCRIPTION
How to test: Use spaces and special characters in trial code's file names. There should be a warning message in nnimanager.log.
How to fully test: Use spaces and special characters in file names. Then run each training service once. (Consider add an IT test case)