### PR TITLE
Change NNI manager IP detection method and remove `netifaces` dependency

### DIFF
--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -1,7 +1,6 @@
 astor
 hyperopt == 0.1.2
 json_tricks
-netifaces
 psutil
 pyyaml
 requests

--- a/nni/tools/nnictl/config_schema.py
+++ b/nni/tools/nnictl/config_schema.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 
-import netifaces
 from schema import And, Optional, Or, Regex, Schema, SchemaError
 from nni.tools.package_utils import (
     create_validator_instance,
@@ -493,7 +492,6 @@ class NNIConfigSchema:
         self.validate_tuner_adivosr_assessor(experiment_config)
         self.validate_pai_trial_conifg(experiment_config)
         self.validate_kubeflow_operators(experiment_config)
-        self.validate_eth0_device(experiment_config)
         self.validate_hybrid_platforms(experiment_config)
         self.validate_frameworkcontroller_trial_config(experiment_config)
 
@@ -598,13 +596,6 @@ class NNIConfigSchema:
             if experiment_config.get('trial').get('outputDir'):
                 print_warning(warning_information.format('outputDir'))
             self.validate_pai_config_path(experiment_config)
-
-    def validate_eth0_device(self, experiment_config):
-        '''validate whether the machine has eth0 device'''
-        if experiment_config.get('trainingServicePlatform') not in ['local'] \
-                and not experiment_config.get('nniManagerIp') \
-                and 'eth0' not in netifaces.interfaces():
-            raise SchemaError('This machine does not contain eth0 network device, please set nniManagerIp in config file!')
 
     def validate_hybrid_platforms(self, experiment_config):
         required_config_name_map = {

--- a/ts/nni_manager/common/utils.ts
+++ b/ts/nni_manager/common/utils.ts
@@ -8,6 +8,7 @@ import { randomBytes } from 'crypto';
 import * as cpp from 'child-process-promise';
 import * as cp from 'child_process';
 import { ChildProcess, spawn, StdioOptions } from 'child_process';
+import * as dgram from 'dgram';
 import * as fs from 'fs';
 import * as net from 'net';
 import * as os from 'os';
@@ -217,28 +218,24 @@ function cleanupUnitTest(): void {
     setExperimentStartupInfo(true, 'unittest', 8080, 'unittest', undefined, logLevel);
 }
 
-let cachedipv4Address: string = '';
+let cachedIpv4Address: string | null = null;
+
 /**
- * Get IPv4 address of current machine
+ * Get IPv4 address of current machine.
  */
 function getIPV4Address(): string {
-    if (cachedipv4Address && cachedipv4Address.length > 0) {
-        return cachedipv4Address;
+    if (cachedIpv4Address !== null) {
+        return cachedIpv4Address;
     }
 
-    const networkInterfaces = os.networkInterfaces();
-    if (networkInterfaces.eth0) {
-        for (const item of networkInterfaces.eth0) {
-            if (item.family === 'IPv4') {
-                cachedipv4Address = item.address;
-                return cachedipv4Address;
-            }
-        }
-    } else {
-        throw Error(`getIPV4Address() failed because os.networkInterfaces().eth0 is undefined. Please specify NNI manager IP in config.`);
-    }
+    // creates "udp connection" to a non-exist target, and get local address of the connection.
+    // since udp is connectionless, this does not send actual packets.
+    const socket = dgram.createSocket('udp4');
+    socket.connect(1, '192.0.2.0');
+    cachedIpv4Address = socket.address().address;
+    socket.close();
 
-    throw Error('getIPV4Address() failed because no valid IPv4 address found.')
+    return cachedIpv4Address;
 }
 
 /**


### PR DESCRIPTION
This method will get the IP address of default router, which means, when anyone creates connection and sends packets via standard library, it will use this address.
The method is platform independent and is irrelative to "eth0", so at Python side it does not need `netifaces` to do validation.