### PR TITLE
[Quantization speedup]support TensorRT8.0.0

### DIFF
--- a/docs/en_US/Compression/QuantizationSpeedup.rst
+++ b/docs/en_US/Compression/QuantizationSpeedup.rst
@@ -48,7 +48,11 @@ Prerequisite
 ------------
 CUDA version >= 11.0
 
-TensorRT version >= 7.2
+TensorRT version >= 8.0
+
+Note
+
+* If you haven't installed TensorRT before or use the old version, please refer to `TensorRT Installation Guide <https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html>`__\  
 
 Usage
 -----

--- a/docs/en_US/Compression/QuantizationSpeedup.rst
+++ b/docs/en_US/Compression/QuantizationSpeedup.rst
@@ -48,7 +48,7 @@ Prerequisite
 ------------
 CUDA version >= 11.0
 
-TensorRT version >= 8.0
+TensorRT version >= 7.2
 
 Note
 

--- a/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py
+++ b/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py
@@ -12,7 +12,8 @@ from . import calibrator as calibrator
 from . import trt_pycuda as common
 from .backend import BaseModelSpeedup
 
-# TRT_LOGGER = trt.Logger(trt.Logger.VERBOSE)
+TRT8 = 8
+TRT7 = 7
 TRT_LOGGER = trt.Logger()
 logger = logging.getLogger(__name__)
 
@@ -122,20 +123,41 @@ def build_engine(model_file, config=None, extra_layer_bit=32, strict_datatype=Fa
     with trt.Builder(TRT_LOGGER) as builder, builder.create_network(common.EXPLICIT_BATCH) as network, \
         trt.OnnxParser(network, TRT_LOGGER) as parser, builder.create_builder_config() as trt_config:
         # Attention that, builder should be set to 1 because of the implementation of allocate_buffer
+        trt_version = int(trt.__version__[0])
+        assert trt_version == TRT8 or trt_version == TRT7, "Version of TensorRT is too old, please \
+            update TensorRT to version >= 7.0"
+        if trt_version == TRT7:
+            logger.warning("TensorRT7 is deprecated and may be removed in the following release.")
+
         builder.max_batch_size = 1
-        trt_config.max_workspace_size = common.GiB(4)
+        if trt_version == TRT8:
+            trt_config.max_workspace_size = common.GiB(4)
+        else:
+            builder.max_workspace_size = common.GiB(4)
 
         if extra_layer_bit == 32 and config is None:
             pass
         elif extra_layer_bit == 16 and config is None:
-            trt_config.set_flag(trt.BuilderFlag.FP16)
+            if trt_version == TRT8:
+                trt_config.set_flag(trt.BuilderFlag.FP16)
+            else:
+                builder.fp16_mode = True
         elif extra_layer_bit == 8 and config is None:
             # entire model in 8bit mode
-            trt_config.set_flag(trt.BuilderFlag.INT8)
+            if trt_version == TRT8:
+                trt_config.set_flag(trt.BuilderFlag.INT8)
+            else:
+                builder.int8_mode = True
         else:
-            trt_config.set_flag(trt.BuilderFlag.INT8)
-            trt_config.set_flag(trt.BuilderFlag.FP16)
-            trt_config.set_flag(trt.BuilderFlag.STRICT_TYPES)
+            if trt_version == TRT8:
+                trt_config.set_flag(trt.BuilderFlag.INT8)
+                trt_config.set_flag(trt.BuilderFlag.FP16)
+                if strict_datatype:
+                    trt_config.set_flag(trt.BuilderFlag.STRICT_TYPES)
+            else:
+                builder.int8_mode = True
+                builder.fp16_mode = True
+                builder.strict_type_constraints = strict_datatype
 
         valid_config(config)
 
@@ -148,7 +170,10 @@ def build_engine(model_file, config=None, extra_layer_bit=32, strict_datatype=Fa
                 return None
 
         if calib is not None:
-            trt_config.int8_calibrator = calib
+            if trt_version == TRT8:
+                trt_config.int8_calibrator = calib
+            else:
+                builder.int8_calibrator = calib
             # This design may not be correct if output more than one
             for i in range(network.num_layers):
                 if config is None:
@@ -196,7 +221,10 @@ def build_engine(model_file, config=None, extra_layer_bit=32, strict_datatype=Fa
                     out_tensor.dynamic_range = (tracked_min_activation, tracked_max_activation)
 
         # Build engine and do int8 calibration.
-        engine = builder.build_engine(network, trt_config)
+        if trt_version == TRT8:
+            engine = builder.build_engine(network, trt_config)
+        else:
+            engine.builder.build_cuda_engine(network)
         return engine
 
 class ModelSpeedupTensorRT(BaseModelSpeedup):


### PR DESCRIPTION
This PR aims to support the latest TensorRT version. Current quantization speedup tool is implemented based on TensorRT7.0. However, the latest tensorrt python api has changed which separates network definition and configuration after version 8.0. All configuration of low precision have been moved to IBuilderConfig and our current implementation can't work on it (the problem raised in issue #3857 ). This PR supports the new TensorRT version and the new api.