### PR TITLE
[Quantization Speedup]fix precision type

### DIFF
--- a/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py
+++ b/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py
@@ -23,7 +23,7 @@ class CalibrateType:
     MINMAX = trt.CalibrationAlgoType.MINMAX_CALIBRATION
 
 Precision_Dict = {
-    8: trt.float32,
+    8: trt.int8,
     16: trt.float16,
     32: trt.float32
 }


### PR DESCRIPTION
This pr fixes issue #3882 . The type of 8bit should be `trt.int8` in `Precision_Dict`.
> https://github.com/microsoft/nni/blob/009722a67ba034734ca4f488f537f933788fd910/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py#L25-L29