### PR TITLE
add recommend type for selector

### DIFF
--- a/docs/en_US/FeatureEngineering/GradientFeatureSelector.rst
+++ b/docs/en_US/FeatureEngineering/GradientFeatureSelector.rst
@@ -94,10 +94,10 @@ And you could reference the examples in ``/examples/feature_engineering/gradient
 
 
 * 
-  **X** (array-like, require) - The training input samples which shape = [n_samples, n_features]
+  **X** (array-like, require) - The training input samples which shape = [n_samples, n_features]. `np.ndarry` recommended.
 
 * 
-  **y** (array-like, require) - The target values (class labels in classification, real numbers in regression) which shape = [n_samples].
+  **y** (array-like, require) - The target values (class labels in classification, real numbers in regression) which shape = [n_samples]. `np.ndarry` recommended.
 
 * 
   **groups** (array-like, optional, default = None) - Groups of columns that must be selected as a unit. e.g. [0, 0, 1, 2] specifies the first two columns are part of a group. Which shape is [n_features].


### PR DESCRIPTION
if you pass in python lists, you will get an AttributeError.

```text
File "feature_to_vec.py", line 209, in train
    fgs.fit(total_x, total_y)
  File "/.../anaconda3/lib/python3.8/site-packages/nni/algorithms/feature_engineering/gradient_selector/gradient_selector.py", line 260, in fit
    self._fit(X, y, groups=groups)
  File "/.../anaconda3/lib/python3.8/site-packages/nni/algorithms/feature_engineering/gradient_selector/gradient_selector.py", line 290, in _fit
    data_train = self._prepare_data(X, y)
  File "/.../anaconda3/lib/python3.8/site-packages/nni/algorithms/feature_engineering/gradient_selector/gradient_selector.py", line 275, in _prepare_data
    return PrepareData(X=X.values if isinstance(X, pd.DataFrame) else X,
  File "/.../anaconda3/lib/python3.8/site-packages/nni/algorithms/feature_engineering/gradient_selector/fginitialize.py", line 138, in __init__
    self.disk_size = X.nbytes if not scipy.sparse.issparse(
AttributeError: 'list' object has no attribute 'nbytes'
```