### PR TITLE
Fix bug: GPUs are not released in Reusable Training Service

### DIFF
--- a/ts/nni_manager/training_service/reusable/trialDispatcher.ts
+++ b/ts/nni_manager/training_service/reusable/trialDispatcher.ts
@@ -732,6 +732,9 @@ class TrialDispatcher implements TrainingService {
      * @param trial 
      */
     private releaseEnvironment(trial: TrialDetail): void {
+        if (true === this.enableGpuScheduler) {
+            this.gpuScheduler.removeGpuReservation(trial);
+        }
         if (trial.environment !== undefined) {
             if (trial.environment.runningTrialCount <= 0) {
                 throw new Error(`TrialDispatcher: environment ${trial.environment.id} has no counted running trial!`);
@@ -739,9 +742,6 @@ class TrialDispatcher implements TrainingService {
             trial.environment.runningTrialCount--;
             trial.environment.latestTrialReleasedTime = Date.now();
             trial.environment = undefined;
-        }
-        if (true === this.enableGpuScheduler) {
-            this.gpuScheduler.removeGpuReservation(trial);
         }
     }
 


### PR DESCRIPTION
Because `trial.environment` is first released, it is always `undefined`.
https://github.com/microsoft/nni/blob/5eb43ea7815d8a0cf93d0a4bb6f29faf57ae6553/ts/nni_manager/training_service/reusable/trialDispatcher.ts#L734-L746

The `gpuScheduler` will never release it because it requires `trial.environment !== undefined `
https://github.com/microsoft/nni/blob/5eb43ea7815d8a0cf93d0a4bb6f29faf57ae6553/ts/nni_manager/training_service/reusable/gpuScheduler.ts#L99-L104

To fix this bug, `this.gpuScheduler.removeGpuReservation(trial)` should be executed at the beginning of `releaseEnvironment`
