### PR TITLE
Enable `fixed_arch` on Retiarii

### DIFF
--- a/docs/en_US/NAS/ApiReference.rst
+++ b/docs/en_US/NAS/ApiReference.rst
@@ -106,3 +106,5 @@ Utilities
 ---------
 
 ..  autofunction:: nni.retiarii.serialize
+
+..  autofunction:: nni.retiarii.fixed_arch

--- a/docs/en_US/NAS/OneshotTrainer.rst
+++ b/docs/en_US/NAS/OneshotTrainer.rst
@@ -34,4 +34,10 @@ See `API reference <./ApiReference.rst>`__ for detailed usages. Here, we show an
   trainer.fit()
   final_architecture = trainer.export()
 
-**Format of the exported architecture.** TBD.
+After the searching is done, we can use the exported architecture to instantiate the full network for retraining. Here is an example:
+
+.. code-block:: python
+
+  from nni.retiarii import fixed_arch
+  with fixed_arch('/path/to/checkpoint.json'):
+    model = Model()

--- a/docs/en_US/NAS/OneshotTrainer.rst
+++ b/docs/en_US/NAS/OneshotTrainer.rst
@@ -38,6 +38,6 @@ After the searching is done, we can use the exported architecture to instantiate
 
 .. code-block:: python
 
-  from nni.retiarii import fixed_arch
-  with fixed_arch('/path/to/checkpoint.json'):
-    model = Model()
+    from nni.retiarii import fixed_arch
+    with fixed_arch('/path/to/checkpoint.json'):
+        model = Model()

--- a/docs/en_US/NAS/WriteOneshot.rst
+++ b/docs/en_US/NAS/WriteOneshot.rst
@@ -16,7 +16,7 @@ A typical example is DartsTrainer, where learnable-parameters are used to combin
     class DartsLayerChoice(nn.Module):
         def __init__(self, layer_choice):
             super(DartsLayerChoice, self).__init__()
-            self.name = layer_choice.key
+            self.name = layer_choice.label
             self.op_choices = nn.ModuleDict(layer_choice.named_children())
             self.alpha = nn.Parameter(torch.randn(len(self.op_choices)) * 1e-3)
 

--- a/examples/nas/oneshot/darts/retrain.py
+++ b/examples/nas/oneshot/darts/retrain.py
@@ -12,8 +12,8 @@ from torch.utils.tensorboard import SummaryWriter
 import datasets
 import utils
 from model import CNN
-from nni.nas.pytorch.fixed import apply_fixed_architecture
 from nni.nas.pytorch.utils import AverageMeter
+from nni.retiarii import fixed_arch
 
 logger = logging.getLogger('nni')
 
@@ -119,8 +119,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     dataset_train, dataset_valid = datasets.get_dataset("cifar10", cutout_length=16)
 
-    model = CNN(32, 3, 36, 10, args.layers, auxiliary=True)
-    apply_fixed_architecture(model, args.arc_checkpoint)
+    with fixed_arch(args.arc_checkpoint):
+        model = CNN(32, 3, 36, 10, args.layers, auxiliary=True)
     criterion = nn.CrossEntropyLoss()
 
     model.to(device)

--- a/nni/retiarii/__init__.py
+++ b/nni/retiarii/__init__.py
@@ -4,5 +4,6 @@
 from .operation import Operation
 from .graph import *
 from .execution import *
+from .fixed import fixed_arch
 from .mutator import *
 from .serializer import basic_unit, json_dump, json_dumps, json_load, json_loads, serialize, serialize_cls, model_wrapper

--- a/nni/retiarii/fixed.py
+++ b/nni/retiarii/fixed.py
@@ -13,6 +13,7 @@ def fixed_arch(fixed_arch: Union[str, Path, Dict[str, Any]], verbose=True):
     Load architecture from ``fixed_arch`` and apply to model. This should be used as a context manager. For example,
 
     .. code-block:: python
+
         with fixed_arch('/path/to/export.json'):
             model = Model(3, 224, 224)
 

--- a/nni/retiarii/fixed.py
+++ b/nni/retiarii/fixed.py
@@ -34,6 +34,6 @@ def fixed_arch(fixed_arch: Union[str, Path, Dict[str, Any]], verbose=True):
             fixed_arch = json.load(f)
 
     if verbose:
-        _logger.info(f'Fixed architecture: {fixed_arch}', __name__)
+        _logger.info(f'Fixed architecture: %s', fixed_arch)
 
     return ContextStack('fixed', fixed_arch)

--- a/nni/retiarii/fixed.py
+++ b/nni/retiarii/fixed.py
@@ -1,0 +1,39 @@
+import json
+import logging
+from pathlib import Path
+from typing import Union, Dict, Any
+
+from .utils import ContextStack
+
+_logger = logging.getLogger(__name__)
+
+
+def fixed_arch(fixed_arch: Union[str, Path, Dict[str, Any]], verbose=True):
+    """
+    Load architecture from ``fixed_arch`` and apply to model. This should be used as a context manager. For example,
+
+    .. code-block:: python
+        with fixed_arch('/path/to/export.json'):
+            model = Model(3, 224, 224)
+
+    Parameters
+    ----------
+    fixed_arc : str, Path or dict
+        Path to the JSON that stores the architecture, or dict that stores the exported architecture.
+    verbose : bool
+        Print log messages if set to True
+
+    Returns
+    -------
+    ContextStack
+        Context manager that provides a fixed architecture when creates the model.
+    """
+
+    if isinstance(fixed_arch, (str, Path)):
+        with open(fixed_arch) as f:
+            fixed_arch = json.load(f)
+
+    if verbose:
+        _logger.info(f'Fixed architecture: {fixed_arch}', __name__)
+
+    return ContextStack('fixed', fixed_arch)

--- a/nni/retiarii/oneshot/pytorch/darts.py
+++ b/nni/retiarii/oneshot/pytorch/darts.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger(__name__)
 class DartsLayerChoice(nn.Module):
     def __init__(self, layer_choice):
         super(DartsLayerChoice, self).__init__()
-        self.name = layer_choice.key
+        self.name = layer_choice.label
         self.op_choices = nn.ModuleDict(OrderedDict([(name, layer_choice[name]) for name in layer_choice.names]))
         self.alpha = nn.Parameter(torch.randn(len(self.op_choices)) * 1e-3)
 
@@ -45,7 +45,7 @@ class DartsLayerChoice(nn.Module):
 class DartsInputChoice(nn.Module):
     def __init__(self, input_choice):
         super(DartsInputChoice, self).__init__()
-        self.name = input_choice.key
+        self.name = input_choice.label
         self.alpha = nn.Parameter(torch.randn(input_choice.n_candidates) * 1e-3)
         self.n_chosen = input_choice.n_chosen or 1
 

--- a/nni/retiarii/oneshot/pytorch/darts.py
+++ b/nni/retiarii/oneshot/pytorch/darts.py
@@ -3,6 +3,7 @@
 
 import copy
 import logging
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
@@ -19,7 +20,7 @@ class DartsLayerChoice(nn.Module):
     def __init__(self, layer_choice):
         super(DartsLayerChoice, self).__init__()
         self.name = layer_choice.key
-        self.op_choices = nn.ModuleDict(layer_choice.named_children())
+        self.op_choices = nn.ModuleDict(OrderedDict([(name, layer_choice[name]) for name in layer_choice.names]))
         self.alpha = nn.Parameter(torch.randn(len(self.op_choices)) * 1e-3)
 
     def forward(self, *args, **kwargs):
@@ -38,7 +39,7 @@ class DartsLayerChoice(nn.Module):
             yield name, p
 
     def export(self):
-        return torch.argmax(self.alpha).item()
+        return list(self.op_choices.keys())[torch.argmax(self.alpha).item()]
 
 
 class DartsInputChoice(nn.Module):


### PR DESCRIPTION
Fix #3969.

Added an API called `fixed_arch` to enable users to quickly use the exported architecture.

I haven't tested on other trainers because their retraining code looks over complex. I'll do that as a follow-up task.