### PR TITLE
[Model Compression Quantization] Unify variable name

### DIFF
--- a/examples/model_compress/quantization/mixed_precision_speedup_mnist.py
+++ b/examples/model_compress/quantization/mixed_precision_speedup_mnist.py
@@ -58,10 +58,10 @@ def post_training_quantization_example(train_loader, test_loader, device):
     model = NaiveModel()
 
     config = {
-        'conv1':{'weight_bit':8, 'activation_bit':8},
-        'conv2':{'weight_bit':32, 'activation_bit':32},
-        'fc1':{'weight_bit':16, 'activation_bit':16},
-        'fc2':{'weight_bit':8, 'activation_bit':8}
+        'conv1':{'weight_bits':8, 'output_bits':8},
+        'conv2':{'weight_bits':32, 'output_bits':32},
+        'fc1':{'weight_bits':16, 'output_bits':16},
+        'fc2':{'weight_bits':8, 'output_bits':8}
     }
 
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
@@ -102,8 +102,10 @@ def quantization_aware_training_example(train_loader, test_loader, device):
     ]
 
     # finetune the model by using QAT
+    # enable batchnorm folding mode
+    dummy_input = torch.randn(1, 1, 28, 28)
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
-    quantizer = QAT_Quantizer(model, configure_list, optimizer)
+    quantizer = QAT_Quantizer(model, configure_list, optimizer, dummy_input=dummy_input)
     quantizer.compress()
 
     model.to(device)

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -354,7 +354,7 @@ class QAT_Quantizer(Quantizer):
     http://openaccess.thecvf.com/content_cvpr_2018/papers/Jacob_Quantization_and_Training_CVPR_2018_paper.pdf
     """
 
-    def __init__(self, model, config_list, optimizer=None, dummy_input=None):
+    def __init__(self, model, config_list, optimizer, dummy_input=None):
         """
         Parameters
         ----------
@@ -379,6 +379,7 @@ class QAT_Quantizer(Quantizer):
                     given, the batch normalization folding would be disabled.
         """
 
+        assert isinstance(optimizer, torch.optim.Optimizer), "unrecognized optimizer type"
         super().__init__(model, config_list, optimizer, dummy_input)
         self.quant_grad = QATGrad.apply
         modules_to_compress = self.get_modules_to_compress()
@@ -642,7 +643,8 @@ class DoReFaQuantizer(Quantizer):
     (https://arxiv.org/abs/1606.06160)
     """
 
-    def __init__(self, model, config_list, optimizer=None):
+    def __init__(self, model, config_list, optimizer):
+        assert isinstance(optimizer, torch.optim.Optimizer), "unrecognized optimizer type"
         super().__init__(model, config_list, optimizer)
         device = next(model.parameters()).device
         modules_to_compress = self.get_modules_to_compress()
@@ -749,7 +751,8 @@ class BNNQuantizer(Quantizer):
     (https://arxiv.org/abs/1602.02830)
     """
 
-    def __init__(self, model, config_list, optimizer=None):
+    def __init__(self, model, config_list, optimizer):
+        assert isinstance(optimizer, torch.optim.Optimizer), "unrecognized optimizer type"
         super().__init__(model, config_list, optimizer)
         device = next(model.parameters()).device
         self.quant_grad = ClipGrad.apply
@@ -848,7 +851,7 @@ class LsqQuantizer(Quantizer):
        https://arxiv.org/pdf/1902.08153.pdf
     """
 
-    def __init__(self, model, config_list, optimizer=None):
+    def __init__(self, model, config_list, optimizer):
         """
         Parameters
         ----------
@@ -868,6 +871,7 @@ class LsqQuantizer(Quantizer):
                 - op_types : list of string
                     types of nn.module you want to apply quantization, eg. 'Conv2d'
         """
+        assert isinstance(optimizer, torch.optim.Optimizer), "unrecognized optimizer type"
         super().__init__(model, config_list, optimizer)
         device = next(model.parameters()).device
         self.quant_grad = QuantForward()

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -310,8 +310,8 @@ class ObserverQuantizer(Quantizer):
                 val = float(module.weight_scale * module.weight_qmax)
                 calibration_config[name]['tracked_max_weight'] = val
                 calibration_config[name]['tracked_min_weight'] = -val
-                calibration_config[name]['tracked_weight_qmin'] = -127
-                calibration_config[name]['tracked_weight_qmax'] = 127
+                calibration_config[name]['tracked_qmin_weight'] = -127
+                calibration_config[name]['tracked_qmax_weight'] = 127
             # refactor these magic numbers when customizations of dtype and qscheme are ready.
             if hasattr(module, 'input_scale'):
                 calibration_config[name]['input_bits'] = 8
@@ -319,8 +319,8 @@ class ObserverQuantizer(Quantizer):
                 min_input = float(module.input_scale * (module.input_qmin - module.input_zero_point))
                 calibration_config[name]['tracked_min_input'] = min_input
                 calibration_config[name]['tracked_max_input'] = max_input
-                calibration_config[name]['tracked_input_qmin'] = 0
-                calibration_config[name]['tracked_input_qmax'] = 127
+                calibration_config[name]['tracked_qmin_input'] = 0
+                calibration_config[name]['tracked_qmax_input'] = 127
             if hasattr(module, 'output_scale'):
                 calibration_config[name]['output_bits'] = 8
                 max_input = float(module.output_scale * (module.output_qmax - module.output_zero_point))

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -148,8 +148,8 @@ class ObserverQuantizer(Quantizer):
         self.device = next(model.parameters()).device
         modules_to_compress = self.get_modules_to_compress()
         all_observers = defaultdict(dict)
-        weight_q_min, weight_q_max = -127, 127
-        output_q_min, output_q_max = 0, 127  # reduce_range is set to True
+        weight_qmin, weight_qmax = -127, 127
+        output_qmin, output_qmax = 0, 127  # reduce_range is set to True
         self.compressed = False
 
         for layer, config in modules_to_compress:
@@ -157,16 +157,16 @@ class ObserverQuantizer(Quantizer):
             module = layer.module
             if "weight" in config.get("quant_types", []):
                 all_observers[layer_name]["weight"] = default_weight_observer()
-                setattr(module, "weight_qmax", weight_q_max)
-                setattr(module, "weight_qmin", weight_q_min)
+                setattr(module, "weight_qmax", weight_qmax)
+                setattr(module, "weight_qmin", weight_qmin)
             if "input" in config.get("quant_types", []):
                 all_observers[layer_name]["input"] = default_histogram_observer()
-                setattr(module, "input_qmax", output_q_max)
-                setattr(module, "input_qmin", output_q_min)
+                setattr(module, "input_qmax", output_qmax)
+                setattr(module, "input_qmin", output_qmin)
             if "output" in config.get("quant_types", []):
                 all_observers[layer_name]["output"] = default_histogram_observer()
-                setattr(module, "output_qmax", output_q_max)
-                setattr(module, "output_qmin", output_q_min)
+                setattr(module, "output_qmax", output_qmax)
+                setattr(module, "output_qmin", output_qmin)
         self.all_observers = all_observers
         self.bound_model.to(self.device)
 

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -615,6 +615,8 @@ class Quantizer(Compressor):
                 # we still need to deal with the old_bias when it occurs
                 if hasattr(wrapper.module, "old_bias"):
                     self.optimizer.add_param_group({"params": getattr(wrapper.module, "old_bias")})
+        else:
+            _logger.warning("Quantization step may not happen since optimizer is not set. Suggest passing an optimizer to Quantizer.")
 
     def quantize_weight(self, wrapper, **kwargs):
         """

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -834,7 +834,7 @@ class QuantGrad(torch.autograd.Function):
     @classmethod
     def get_bits_length(cls, config, quant_type):
         """
-        Get bit for quantize config
+        Get bits for quantize config
         Parameters
         ----------
         config : Dict

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -615,8 +615,6 @@ class Quantizer(Compressor):
                 # we still need to deal with the old_bias when it occurs
                 if hasattr(wrapper.module, "old_bias"):
                     self.optimizer.add_param_group({"params": getattr(wrapper.module, "old_bias")})
-        else:
-            _logger.warning("Quantization step may not happen since optimizer is not set. Suggest passing an optimizer to Quantizer.")
 
     def quantize_weight(self, wrapper, **kwargs):
         """

--- a/nni/compression/pytorch/quantization_speedup/frontend_to_onnx.py
+++ b/nni/compression/pytorch/quantization_speedup/frontend_to_onnx.py
@@ -9,26 +9,26 @@ The main function of this page is to convert pytorch model to onnx model.
 Convertion from pytorch model to onnx model is primary so that a critical
 problem is caused that Layer name of pytorch model fail to convert to onnx
 layer name directly. To solve it, we wrap pytorch model in new wrapper which
-multiply bit number and input before computation of each op. Only in this
-way can onnx model get bit number of corresponded layer.
+multiply bits number and input before computation of each op. Only in this
+way can onnx model get bits number of corresponded layer.
 """
 
 class LayernameModuleWrapper(torch.nn.Module):
-    def __init__(self, module, module_bit) -> None:
+    def __init__(self, module, module_bits) -> None:
         """
         Parameters
         ----------
         module : torch.nn.Module
             Layer module of pytorch model
-        module_bit : int
-            Bit width setting for module
+        module_bits : int
+            Bits width setting for module
         """
         super().__init__()
         self.module = module
-        self.module_bit = module_bit
+        self.module_bits = module_bits
 
     def forward(self, inputs):
-        inputs = inputs*self.module_bit
+        inputs = inputs*self.module_bits
         inputs = self.module(inputs)
         return inputs
 
@@ -93,14 +93,14 @@ def unwrapper(model_onnx, index2name, config):
 
 def torch_to_onnx(model, config, input_shape, model_path, input_names, output_names):
     """
-    Convert torch model to onnx model and get layer bit config of onnx model.
+    Convert torch model to onnx model and get layer bits config of onnx model.
 
     Parameters
     ----------
     model : pytorch model
         The model to speed up by quantization
     config : dict
-        Config recording bit number and name of layers
+        Config recording bits number and name of layers
     input_shape : tuple
         The input shape of model, shall pass it to torch.onnx.export
     model_path : str
@@ -119,7 +119,7 @@ def torch_to_onnx(model, config, input_shape, model_path, input_names, output_na
     """
     # Support Gemm, Conv, Relu, Clip(Relu6) and MaxPool
     support_op = [torch.nn.Conv2d, torch.nn.Linear, torch.nn.ReLU, torch.nn.ReLU6, torch.nn.MaxPool2d]
-    # Transfer bit number to onnx layer by using wrapper
+    # Transfer bits number to onnx layer by using wrapper
     index2name = {}
     name2index = {}
     if config is not None:

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -317,7 +317,9 @@ class CompressorTestCase(TestCase):
             'op_types': ['ReLU']
         }]
         model.relu = torch.nn.ReLU()
-        quantizer = torch_quantizer.QAT_Quantizer(model, config_list)
+
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
+        quantizer = torch_quantizer.QAT_Quantizer(model, config_list, optimizer)
         quantizer.compress()
 
         # test quantize
@@ -390,9 +392,10 @@ class CompressorTestCase(TestCase):
         quantize_algorithm_set = [torch_quantizer.QAT_Quantizer, torch_quantizer.DoReFaQuantizer, torch_quantizer.BNNQuantizer]
 
         for config, quantize_algorithm in zip(config_set, quantize_algorithm_set):
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
             model = TorchModel()
             model.relu = torch.nn.ReLU()
-            quantizer = quantize_algorithm(model, config)
+            quantizer = quantize_algorithm(model, config, optimizer)
             quantizer.compress()
 
             x = torch.rand((1, 1, 28, 28), requires_grad=True)

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -49,7 +49,8 @@ class CompressorTestCase(TestCase):
         }]
 
         model.relu = torch.nn.ReLU()
-        quantizer = torch_quantizer.QAT_Quantizer(model, config_list)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
+        quantizer = torch_quantizer.QAT_Quantizer(model, config_list, optimizer)
         quantizer.compress()
         modules_to_compress = quantizer.get_modules_to_compress()
         modules_to_compress_name = [t[0].name for t in modules_to_compress]
@@ -392,9 +393,9 @@ class CompressorTestCase(TestCase):
         quantize_algorithm_set = [torch_quantizer.QAT_Quantizer, torch_quantizer.DoReFaQuantizer, torch_quantizer.BNNQuantizer]
 
         for config, quantize_algorithm in zip(config_set, quantize_algorithm_set):
-            optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
             model = TorchModel()
             model.relu = torch.nn.ReLU()
+            optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
             quantizer = quantize_algorithm(model, config, optimizer)
             quantizer.compress()
 

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -350,14 +350,14 @@ class CompressorTestCase(TestCase):
         eps = 1e-7
         x = torch.tensor([[-0.2, 0], [0.1, 0.2]])
         out = model.relu(x)
-        assert math.isclose(model.relu.module.tracked_min_activation, 0, abs_tol=eps)
-        assert math.isclose(model.relu.module.tracked_max_activation, 0.002, abs_tol=eps)
+        assert math.isclose(model.relu.module.tracked_min_output, 0, abs_tol=eps)
+        assert math.isclose(model.relu.module.tracked_max_output, 0.002, abs_tol=eps)
 
         quantizer.step_with_optimizer()
         x = torch.tensor([[0.2, 0.4], [0.6, 0.8]])
         out = model.relu(x)
-        assert math.isclose(model.relu.module.tracked_min_activation, 0.002, abs_tol=eps)
-        assert math.isclose(model.relu.module.tracked_max_activation, 0.00998, abs_tol=eps)
+        assert math.isclose(model.relu.module.tracked_min_output, 0.002, abs_tol=eps)
+        assert math.isclose(model.relu.module.tracked_max_output, 0.00998, abs_tol=eps)
 
     def test_torch_quantizer_export(self):
         config_list_qat = [{


### PR DESCRIPTION
This pr targets unifying two variable names in quantization code. They are too messy for developer and code reader. The first is `output`.`activation` -> `output`. The second is `bits`, `bit` -> `bits`. This pr also fixes a bug in quantization speedup conveniently ( [bug](https://github.com/microsoft/nni/blob/master/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py#L227) ) and adds warning for not setting optimizer in quantizer.

- [x] unify two variable names
- [x] quantization speedup fug fix [bug](https://github.com/microsoft/nni/blob/master/nni/compression/pytorch/quantization_speedup/integrated_tensorrt.py#L227) 
- [x] add warning for not setting optimizer in quantizer