### PR TITLE
restore weight by default for qat quantizer

### DIFF
--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -570,14 +570,13 @@ class QAT_Quantizer(Quantizer):
                 calibration_config[name]['tracked_max_input'] = float(module.tracked_max_input)
 
                 # Recover weight/bias for batch normalization folding
+                actual_weight = getattr(module, 'old_weight', None)
+                if actual_weight is None:
+                    logger.warning("Can not recover weight for layer %s. "
+                                   "This may lead to a wrong accuracy performance on the backend.", name)
+                delattr(module, 'weight')
+                module.register_parameter('weight', actual_weight)
                 if hasattr(module, BN_FOLD_TAG):
-                    actual_weight = getattr(module, 'old_weight', None)
-                    if actual_weight is None:
-                        logger.warning("Can not recover weight for layer %s. "
-                                       "This may lead to a wrong accuracy performance on the backend.", name)
-                    delattr(module, 'weight')
-                    module.register_parameter('weight', actual_weight)
-
                     actual_bias = getattr(module, 'old_bias', None)
                     delattr(module, 'bias')
                     if actual_bias is not None:


### PR DESCRIPTION
By default, the type of `weight` will change from `torch.nn.Parameter` to `torch.Tensor(buffer)`. This will make its weight unable  to be accessed by functions like `named_parameters()`. So I think it is better to restore it by default.