### PR TITLE
fix sharedstorage it

### DIFF
--- a/test/config/integration_tests.yml
+++ b/test/config/integration_tests.yml
@@ -49,6 +49,11 @@ testCases:
     kwargs:
       rootpath: /tmp/nnimount/testlocalrootpath
 
+- name: sklearn-regression
+  configFile: test/config/examples/sklearn-regression.yml
+
+# mount point in local may late to umount when stop experiment in shared-storage-remote-azureblob,
+# so keep two shared storage tests away from each other.
 - name: shared-storage-remote-nfs
   configFile: test/config/sharedstorage_test/config_sharedstorage_remote_nfs.yml
   trainingService: remote
@@ -56,9 +61,6 @@ testCases:
     class: FileExistValidator
     kwargs:
       rootpath: /tmp/nnimount/testlocalrootpath
-
-- name: sklearn-regression
-  configFile: test/config/examples/sklearn-regression.yml
 
 - name: mnist-tensorflow
   configFile: test/config/examples/mnist-tfv2.yml

--- a/ts/nni_manager/core/nniTensorboardManager.ts
+++ b/ts/nni_manager/core/nniTensorboardManager.ts
@@ -114,9 +114,9 @@ class NNITensorboardManager implements TensorboardManager {
     }
 
     private setTensorboardVersion(): void {
-        let command = `python3 -c 'import tensorboard ; print(tensorboard.__version__)'`;
+        let command = `python3 -c 'import tensorboard ; print(tensorboard.__version__)' 2>&1`;
         if (process.platform === 'win32') {
-            command = `python -c "import tensorboard ; print(tensorboard.__version__)"`;
+            command = `python -c "import tensorboard ; print(tensorboard.__version__)" 2>&1`;
         }
         try {
             const tensorboardVersion = cp.execSync(command).toString();


### PR DESCRIPTION
1. mount point in local may late to umount when stop experiment in `shared-storage-remote-azureblob`, so keep two shared storage tests away from each other.
2. hide tensorboard not installed error in `nnictl_stderr`