### PR TITLE
fix trial status not correct when trial is early stoped

### DIFF
--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -434,7 +434,7 @@ class NNIManager implements Manager {
 
     private get maxTrialDuration(): number {
         const value = this.experimentProfile.params.maxTrialDuration;
-        let duration = (value === undefined ? Infinity : toSeconds(value));
+        const duration = (value === undefined ? Infinity : toSeconds(value)) * 1000;
         // Fix timeout warning : Infinity does not fit into a 32-bit signed integer(2147483647).
         return duration > 2147483647 ? 2147483647 : duration;
     }
@@ -683,7 +683,7 @@ class NNIManager implements Manager {
                     this.currSubmittedTrialNum++;
                     this.log.info('submitTrialJob: form:', form);
                     const trialJobDetail: TrialJobDetail = await this.trainingService.submitTrialJob(form);
-                    setTimeout(async () => this.stopTrialJobIfOverMaxDurationTimer(trialJobDetail.id), 1000 * this.maxTrialDuration);
+                    setTimeout(async () => this.stopTrialJobIfOverMaxDurationTimer(trialJobDetail.id), this.maxTrialDuration);
                     const Snapshot: TrialJobDetail = Object.assign({}, trialJobDetail);
                     await this.storeExperimentProfile();
                     this.trialJobs.set(trialJobDetail.id, Snapshot);

--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -28,7 +28,6 @@ import {
 } from './commands';
 import { createDispatcherInterface, createDispatcherPipeInterface, IpcInterface } from './ipcInterface';
 import { NNIRestServer } from '../rest_server/nniRestServer';
-import { inflate } from 'zlib';
 
 /**
  * NNIManager which implements Manager interface

--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -434,7 +434,9 @@ class NNIManager implements Manager {
 
     private get maxTrialDuration(): number {
         const value = this.experimentProfile.params.maxTrialDuration;
-        return (value === undefined ? Infinity : toSeconds(value));
+        let duration = (value === undefined ? Infinity : toSeconds(value));
+        // Fix timeout warning : Infinity does not fit into a 32-bit signed integer(2147483647).
+        return duration > 2147483647 ? 2147483647 : duration;
     }
 
     private async initTrainingService(config: ExperimentConfig): Promise<TrainingService> {

--- a/ts/nni_manager/training_service/local/localTrainingService.ts
+++ b/ts/nni_manager/training_service/local/localTrainingService.ts
@@ -237,6 +237,9 @@ class LocalTrainingService implements TrainingService {
             return Promise.resolve();
         }
         tkill(trialJob.pid, 'SIGTERM');
+
+        this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
+
         const startTime = Date.now();
         while(await isAlive(trialJob.pid)) {    
             if (Date.now() - startTime > 4999) {
@@ -249,9 +252,7 @@ class LocalTrainingService implements TrainingService {
             }
             await delay(500);
         }
-
-        this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
-
+        
         return Promise.resolve();
     }
 

--- a/ts/nni_manager/training_service/local/localTrainingService.ts
+++ b/ts/nni_manager/training_service/local/localTrainingService.ts
@@ -236,21 +236,12 @@ class LocalTrainingService implements TrainingService {
 
             return Promise.resolve();
         }
-        tkill(trialJob.pid, 'SIGTERM');
-        this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
-        
-        const startTime = Date.now();
-        while(await isAlive(trialJob.pid)) {    
-            if (Date.now() - startTime > 4999) {
-                tkill(trialJob.pid, 'SIGKILL', (err) => {
-                    if (err) {
-                        this.log.error(`kill trial job error: ${err}`);
-                    }
-                });
-                break;
+        tkill(trialJob.pid, 'SIGKILL', (err) => {
+            if (err) {
+                this.log.error(`kill trial job error: ${err}`);
             }
-            await delay(500);
-        }
+        });
+        this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
 
         return Promise.resolve();
     }

--- a/ts/nni_manager/training_service/local/localTrainingService.ts
+++ b/ts/nni_manager/training_service/local/localTrainingService.ts
@@ -237,9 +237,8 @@ class LocalTrainingService implements TrainingService {
             return Promise.resolve();
         }
         tkill(trialJob.pid, 'SIGTERM');
-
         this.setTrialJobStatus(trialJob, getJobCancelStatus(isEarlyStopped));
-
+        
         const startTime = Date.now();
         while(await isAlive(trialJob.pid)) {    
             if (Date.now() - startTime > 4999) {
@@ -252,7 +251,7 @@ class LocalTrainingService implements TrainingService {
             }
             await delay(500);
         }
-        
+
         return Promise.resolve();
     }
 


### PR DESCRIPTION
Caused: the trial status was update when the trial process is exit completely(e.g. from RUNING to EARLY_STOPPED), but process exiting will cost some times which could cause status not match. 

Resue mode do not have this issue.