### PR TITLE
Support Speedup for Slim Pruner.

### DIFF
--- a/nni/compression/pytorch/utils/mask_conflict.py
+++ b/nni/compression/pytorch/utils/mask_conflict.py
@@ -184,6 +184,7 @@ class ChannelMaskConflict(MaskFix):
         super(ChannelMaskConflict, self).__init__(
             masks, model, dummy_input, traced)
         self.conv_prune_dim = detect_mask_prune_dim(masks, model)
+        self.channel_prune_type = detect_channel_prune_type(masks, model)
         _logger.info('Dectected conv prune dim" %d', self.conv_prune_dim)
 
     def fix_mask(self):
@@ -200,7 +201,8 @@ class ChannelMaskConflict(MaskFix):
         """
         if self.conv_prune_dim == 0:
             channel_depen = ChannelDependency(
-                self.model, self.dummy_input, self.traced)
+                self.model, self.dummy_input, self.traced, self.channel_prune_type)
+
         else:
             channel_depen = InputChannelDependency(
                 self.model, self.dummy_input, self.traced)
@@ -307,10 +309,43 @@ class ChannelMaskConflict(MaskFix):
 
         return self.masks
 
+def detect_channel_prune_type(masks, model):
+    """
+    User can prune a channel through two ways: 1) prune
+    the corresponding filter of the conv layer(all the
+    filter related pruner), 2) prune the BN layers that
+    followed after a conv(Slim pruner). This function find
+    the pruning type of the masks.
+
+    Parameters
+    ----------
+    masks: dict
+        A dict object that stores the masks.
+    model: nn.Module
+        Model object which the mask can be applied on.
+    Returns:
+    -------
+    prune_type: str
+        Could be Filter or Batchnorm
+    """
+    prune_type = 'Filter'
+    all_batch_norm = True
+    for layer_name in masks:
+        _, m = get_module_by_name(model, layer_name)
+        if m is None or (not isinstance(m, torch.nn.BatchNorm2d)):
+            all_batch_norm = False
+            break
+    if all_batch_norm:
+        # if all masks are for batchnorm layers, then the prune_type is BatchNorm
+        # Note, actually we currently do not support pruning both Conv and BatchNorm
+        # at the same time.
+        prune_type = 'Batchnorm'
+    return prune_type
 
 def detect_mask_prune_dim(masks, model):
     """
     Detect how the masks of convolutional layers are pruned.
+
     Parameters
     ----------
     masks: dict

--- a/nni/compression/pytorch/utils/mask_conflict.py
+++ b/nni/compression/pytorch/utils/mask_conflict.py
@@ -191,11 +191,6 @@ class ChannelMaskConflict(MaskFix):
         """
         Fix the mask conflict before the mask inference for the layers that
         has shape dependencies. This function should be called before the
-        mask inference of the 'speedup' module.
-        """
-        """
-        Fix the mask conflict before the mask inference for the layers that
-        has shape dependencies. This function should be called before the
         mask inference of the 'speedup' module. Only structured pruning masks
         are supported.
         """
@@ -323,6 +318,7 @@ def detect_channel_prune_type(masks, model):
         A dict object that stores the masks.
     model: nn.Module
         Model object which the mask can be applied on.
+
     Returns:
     -------
     prune_type: str

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -101,7 +101,7 @@ class ChannelDependency(Dependency):
         prune_type: str
             This parameter indicates the channel pruning type: 1) `Filter`
             prune the filter of the convolution layer to prune the corresponding
-            channels 2) prune the channel in the batchnorm layer
+            channels 2) `Batchnorm`: prune the channel in the batchnorm layer
         """
         self.prune_type = prune_type
         self.target_types = []


### PR DESCRIPTION
Speedup does not support Slim pruners at the beginning(v1.6). Slim pruner prunes the BN layers which is not supported in the
mask_conflict utils, in this PR, we support the BN layers in mask_conflict so that Slim pruner is supported in speedup.