### PR TITLE
Disable GPU in unit test

### DIFF
--- a/ts/nni_manager/test/training_service/localTrainingService.test.ts
+++ b/ts/nni_manager/test/training_service/localTrainingService.test.ts
@@ -24,7 +24,7 @@ describe('Unit Test for LocalTrainingService', () => {
     const config = <ExperimentConfig>{
         trialCommand: 'sleep 1h && echo hello',
         trialCodeDirectory: `${localCodeDir}`,
-        trialGpuNumber: 1,
+        trialGpuNumber: 0,  // TODO: add test case for gpu?
         trainingService: {
             platform: 'local'
         }


### PR DESCRIPTION
Currently the UT will not exit if the machine has GPU. This is because local training service test case will open GPU metric file and will never close it. We could add closing logic to fix it, but I think it's not the right way.
Our default UT environment is CPU-only, and by design an experiment with GPU number > 1 should fail on this type of machine. The test case was passing by accident because the error of GPU scheduler is silently ignored. And since it failed to generate GPU metric file, there is no closing issue.
This does not harm real experiments because they are stopped by `process.exit()`, which will not be blocked by file handlers.