### PR TITLE
Fix 2 bugs found in bug bash

### DIFF
--- a/nni/tools/nnictl/launcher.py
+++ b/nni/tools/nnictl/launcher.py
@@ -600,7 +600,7 @@ def manage_external_experiment(args, mode):
     else:
         print_normal('NNI can not detect experiment id in argument, will use last folder name as experiment id in experiment_dir argument.')
         experiment_id = Path(args.experiment_dir).name
-        log_dir = os.path.dirname(args.experiment_dir)
+        log_dir = str(Path(args.experiment_dir).parent)
         if not experiment_id:
             print_error("Please set experiment id argument, or add id as the last folder name in experiment_dir argument.")
             exit(1)

--- a/ts/nni_manager/rest_server/restHandler.ts
+++ b/ts/nni_manager/rest_server/restHandler.ts
@@ -306,10 +306,10 @@ class NNIRestHandler {
                 encoding = 'utf8';
             }
             this.nniManager.getTrialFile(req.params.id, filename).then((content: Buffer | string) => {
-                if (content instanceof Buffer) {
-                    res.header('Content-Type', 'application/octet-stream');
-                } else if (content === '') {
-                    content = `${filename} is empty.`;
+                const contentType = content instanceof Buffer ? 'application/octet-stream' : 'text/plain';
+                res.header('Content-Type', contentType);
+                if (content === '') {
+                    content = `${filename} is empty.`;  // FIXME: this should be handled in front-end
                 }
                 res.send(content);
             }).catch((err: Error) => {


### PR DESCRIPTION
1. nnictl view —experiment path/to/exp-id/ (with backslash) does not work
2. log files have content type “json”