### PR TITLE
fix wrong quantization target in weight quantization

### DIFF
--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import logging
-import copy
 from collections import defaultdict
 import torch
 from schema import Schema, And, Or, Optional

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -673,7 +673,7 @@ class DoReFaQuantizer(Quantizer):
         schema.validate(config_list)
 
     def quantize_weight(self, wrapper, **kwargs):
-        weight = wrapper.module.old_weight
+        weight = wrapper.module.weight
         weight_bits = get_bits_length(wrapper.config, 'weight')
         weight = weight.tanh()
         weight = weight / (2 * weight.abs().max()) + 0.5
@@ -783,7 +783,7 @@ class BNNQuantizer(Quantizer):
         schema.validate(config_list)
 
     def quantize_weight(self, wrapper, **kwargs):
-        weight = wrapper.module.old_weight
+        weight = wrapper.module.weight
         weight = torch.sign(weight)
         # remove zeros
         weight[weight == 0] = 1

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -559,6 +559,7 @@ class QuantizerModuleWrapper(torch.nn.Module):
                 self.module.weight = new_weight
             else:
                 new_weight = self.module.old_weight
+                self.module.weight = new_weight.data
 
             self.quantizer.quant_grad(
                 new_weight,

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -618,14 +618,12 @@ class Quantizer(Compressor):
                 if hasattr(wrapper.module, "old_bias"):
                     self.optimizer.add_param_group({"params": getattr(wrapper.module, "old_bias")})
 
-    def quantize_weight(self, weight, wrapper, **kwargs):
+    def quantize_weight(self, wrapper, **kwargs):
         """
         quantize should overload this method to quantize weight.
         This method is effectively hooked to :meth:`forward` of the model.
         Parameters
         ----------
-        weight : Tensor
-            weight of module that needs to be quantized
         wrapper : QuantizerModuleWrapper
             the wrapper for origin module
         """
@@ -918,7 +916,7 @@ def quantize_helper(tensor, quant_type, wrapper, input_tensor=None, **kwargs):
     if quant_type == QuantType.QUANT_INPUT:
         output = wrapper.quantizer.quantize_input(tensor, wrapper=wrapper, **kwargs)
     elif quant_type == QuantType.QUANT_WEIGHT:
-        output = wrapper.quantizer.quantize_weight(tensor, wrapper, input_tensor=input_tensor, **kwargs)
+        output = wrapper.quantizer.quantize_weight(wrapper, input_tensor=input_tensor, **kwargs)
     elif quant_type == QuantType.QUANT_OUTPUT:
         output = wrapper.quantizer.quantize_output(tensor, wrapper, **kwargs)
     else:

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -618,12 +618,14 @@ class Quantizer(Compressor):
                 if hasattr(wrapper.module, "old_bias"):
                     self.optimizer.add_param_group({"params": getattr(wrapper.module, "old_bias")})
 
-    def quantize_weight(self, wrapper, **kwargs):
+    def quantize_weight(self, weight, wrapper, **kwargs):
         """
         quantize should overload this method to quantize weight.
         This method is effectively hooked to :meth:`forward` of the model.
         Parameters
         ----------
+        weight : Tensor
+            weight of module that needs to be quantized
         wrapper : QuantizerModuleWrapper
             the wrapper for origin module
         """
@@ -916,7 +918,7 @@ def quantize_helper(tensor, quant_type, wrapper, input_tensor=None, **kwargs):
     if quant_type == QuantType.QUANT_INPUT:
         output = wrapper.quantizer.quantize_input(tensor, wrapper=wrapper, **kwargs)
     elif quant_type == QuantType.QUANT_WEIGHT:
-        output = wrapper.quantizer.quantize_weight(wrapper, input_tensor=input_tensor, **kwargs)
+        output = wrapper.quantizer.quantize_weight(tensor, wrapper, input_tensor=input_tensor, **kwargs)
     elif quant_type == QuantType.QUANT_OUTPUT:
         output = wrapper.quantizer.quantize_output(tensor, wrapper, **kwargs)
     else:

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -265,6 +265,23 @@ class CompressorTestCase(TestCase):
         assert all(torch.sum(mask1['weight_mask'], (1, 2, 3)).numpy() == np.array([0., 0., 0, 0., 25.]))
         assert all(torch.sum(mask2['weight_mask'], (1, 2, 3)).numpy() == np.array([125., 125., 125., 125., 125., 125., 125., 0., 0., 0.]))
 
+    def test_torch_quantizer_interface(self):
+        # test quantize_weight
+        quantizers = [torch_quantizer.DoReFaQuantizer, torch_quantizer.BNNQuantizer]
+        for quantizer in quantizers:
+            model = TorchModel()
+            config_list = [{
+                'quant_types': ['weight'],
+                'quant_bits': 8,
+                'op_types': ['Conv2d', 'Linear']
+            }]
+            quantizer = quantizer(model, config_list)
+            quantizer.compress()
+            weight = torch.tensor([[1, 2], [3, 5]]).float()
+            # test interface
+            quantizer.quantize_weight(weight, model.conv2)
+
+
     def test_torch_observer_quantizer(self):
         model = TorchModel()
         # test invalid config

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -328,7 +328,7 @@ class CompressorTestCase(TestCase):
         eps = 1e-7
         input = torch.tensor([[0, 4], [2, 1]]).float()
         weight = torch.tensor([[1, 2], [3, 5]]).float()
-        model.conv2.module.old_weight.data = weight
+        model.conv2.module.weight.data = weight
         quantizer.quantize_weight(model.conv2, input_tensor=input)
         assert math.isclose(model.conv2.module.scale, 5 / 255, abs_tol=eps)
         assert model.conv2.module.zero_point == 0

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -329,13 +329,13 @@ class CompressorTestCase(TestCase):
         input = torch.tensor([[0, 4], [2, 1]]).float()
         weight = torch.tensor([[1, 2], [3, 5]]).float()
         model.conv2.module.old_weight.data = weight
-        quantizer.quantize_weight(model.conv2, input_tensor=input)
+        quantizer.quantize_weight(weight, model.conv2, input_tensor=input)
         assert math.isclose(model.conv2.module.scale, 5 / 255, abs_tol=eps)
         assert model.conv2.module.zero_point == 0
         # range including 0
         weight = torch.tensor([[-1, 2], [3, 5]]).float()
         model.conv2.module.old_weight.data = weight
-        quantizer.quantize_weight(model.conv2, input_tensor=input)
+        quantizer.quantize_weight(weight, model.conv2, input_tensor=input)
         assert math.isclose(model.conv2.module.scale, 6 / 255, abs_tol=eps)
         assert model.conv2.module.zero_point in (42, 43)
         # test value of weight and bias after quantization
@@ -345,7 +345,7 @@ class CompressorTestCase(TestCase):
         bias_valid = torch.tensor([2.3432, 3.4342, 1.3414, 5.2341])
         model.conv2.module.old_weight.data = weight
         model.conv2.module.bias.data = bias
-        quantizer.quantize_weight(model.conv2, input_tensor=input)
+        quantizer.quantize_weight(weight, model.conv2, input_tensor=input)
         assert torch.all(torch.isclose(model.conv2.module.weight.data, weight_valid, rtol=1e-4))
         assert torch.all(torch.isclose(model.conv2.module.bias.data, bias_valid, rtol=1e-7))
 

--- a/test/ut/sdk/test_compressor_torch.py
+++ b/test/ut/sdk/test_compressor_torch.py
@@ -334,7 +334,7 @@ class CompressorTestCase(TestCase):
         assert model.conv2.module.zero_point == 0
         # range including 0
         weight = torch.tensor([[-1, 2], [3, 5]]).float()
-        model.conv2.module.old_weight.data = weight
+        model.conv2.module.weight = weight
         quantizer.quantize_weight(model.conv2, input_tensor=input)
         assert math.isclose(model.conv2.module.scale, 6 / 255, abs_tol=eps)
         assert model.conv2.module.zero_point in (42, 43)
@@ -343,7 +343,7 @@ class CompressorTestCase(TestCase):
         weight_valid = torch.tensor([[1.1242, 2.3421], [3.7707, 5.9723]])
         bias = torch.tensor([2.3432, 3.4342, 1.3414, 5.2341])
         bias_valid = torch.tensor([2.3432, 3.4342, 1.3414, 5.2341])
-        model.conv2.module.old_weight.data = weight
+        model.conv2.module.weight = weight
         model.conv2.module.bias.data = bias
         quantizer.quantize_weight(model.conv2, input_tensor=input)
         assert torch.all(torch.isclose(model.conv2.module.weight.data, weight_valid, rtol=1e-4))


### PR DESCRIPTION
This pr contains two things:
1. When bn fold is enable, the folded weight is assign to `module.weight`, QAT quantizer should quantize `module.weight` instead of `module.old_weight`
2. pass the weight that should be quantized to each quantizer directly to make the training graph more clearly.