### PR TITLE
[Model Compression] Fix register backward hook for TransformerHeadPruner

### DIFF
--- a/nni/algorithms/compression/pytorch/pruning/transformer_pruning_head_masker.py
+++ b/nni/algorithms/compression/pytorch/pruning/transformer_pruning_head_masker.py
@@ -437,7 +437,7 @@ class TaylorFOHeadMasker(AttentionHeadMasker):
                 md.head_importance_scores = heads_scores
 
         for _, _, _, output_proj in self.pruner.masking_groups:
-            handle = output_proj.register_backward_hook(grad_hook)
+            handle = output_proj.register_full_backward_hook(grad_hook)
             self.backward_hooks[output_proj.group_idx] = handle
 
     def get_mask(self, num_prune, weight_group, **kwargs):


### PR DESCRIPTION
When criterion `taylorfo` is used, and if the user attempts to re-instantiate the pruner after speedup, a mismatch in dimension could happen (it seems that the dimension of data collected by the hook is incorrect), with the following warning message. 
`UserWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.`