### PR TITLE
[Model Compression] fix data contiguous bug in amc example

### DIFF
--- a/examples/model_compress/pruning/amc/utils.py
+++ b/examples/model_compress/pruning/amc/utils.py
@@ -49,7 +49,7 @@ def accuracy(output, target, topk=(1, 5)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res + appendices
 

--- a/examples/model_compress/pruning/amc/utils.py
+++ b/examples/model_compress/pruning/amc/utils.py
@@ -31,7 +31,7 @@ class AverageMeter(object):
 
 
 def accuracy(output, target, topk=(1, 5)):
-    """Compute the precision@k for the specified values of k"""
+    """Computes the precision@k for the specified values of k"""
     batch_size = target.size(0)
     num = output.size(1)
     target_topk = []

--- a/examples/model_compress/pruning/amc/utils.py
+++ b/examples/model_compress/pruning/amc/utils.py
@@ -31,7 +31,7 @@ class AverageMeter(object):
 
 
 def accuracy(output, target, topk=(1, 5)):
-    """Computes the precision@k for the specified values of k"""
+    """Compute the precision@k for the specified values of k"""
     batch_size = target.size(0)
     num = output.size(1)
     target_topk = []


### PR DESCRIPTION
When running amc example `amc_search.py`, error `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.` will be raised. Adding `contiguous()` to tensor can fix this bug.