### PR TITLE
Fix a bug in retiarii

### DIFF
--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -43,7 +43,7 @@ def get_module_name(cls_or_func):
             if inspect.getmodule(frm[0]).__name__ == '__main__':
                 # main module found
                 main_file_path = Path(inspect.getsourcefile(frm[0]))
-                if main_file_path.parents[0] != Path('.'):
+                if main_file_path.parents[0] != Path().resolve():
                     raise RuntimeError(f'You are using "{main_file_path}" to launch your experiment, '
                                        f'please launch the experiment under the directory where "{main_file_path.name}" is located.')
                 module_name = main_file_path.stem

--- a/nni/retiarii/utils.py
+++ b/nni/retiarii/utils.py
@@ -43,7 +43,7 @@ def get_module_name(cls_or_func):
             if inspect.getmodule(frm[0]).__name__ == '__main__':
                 # main module found
                 main_file_path = Path(inspect.getsourcefile(frm[0]))
-                if main_file_path.parents[0] != Path().resolve():
+                if not Path().samefile(main_file_path.parent):
                     raise RuntimeError(f'You are using "{main_file_path}" to launch your experiment, '
                                        f'please launch the experiment under the directory where "{main_file_path.name}" is located.')
                 module_name = main_file_path.stem


### PR DESCRIPTION
Absolute path does not equal to relative path, even if they point to same location, at least in Python 3.9 and Linux.

And I really don't like the restriction that script must be run at specific location...