### PR TITLE
Fix interface of CGO's accelerator to support pytorch-lightning 1.4.2

### DIFF
--- a/dependencies/recommended.txt
+++ b/dependencies/recommended.txt
@@ -8,7 +8,7 @@ torch == 1.9.0+cpu ; sys_platform != "darwin"
 torch == 1.9.0 ; sys_platform == "darwin"
 torchvision == 0.10.0+cpu ; sys_platform != "darwin"
 torchvision == 0.10.0 ; sys_platform == "darwin"
-pytorch-lightning >= 1.2.8, < 1.4.2
+pytorch-lightning >= 1.4.2
 onnx
 peewee
 graphviz

--- a/nni/retiarii/evaluator/pytorch/cgo/accelerator.py
+++ b/nni/retiarii/evaluator/pytorch/cgo/accelerator.py
@@ -53,7 +53,7 @@ class BypassPlugin(TrainingTypePlugin):
     def all_gather(self, tensor: torch.Tensor, group: Optional[Any] = None, sync_grads: bool = False) -> torch.Tensor:
         """Perform a all_gather on all processes """
         return tensor
-    
+
     def teardown(self):
         """
         This method is called to teardown the training process.
@@ -105,24 +105,24 @@ def get_accelerator_connector(
         **other_trainier_kwargs) -> AcceleratorConnector:
     gpu_ids = Trainer()._parse_devices(gpus, auto_select_gpus, tpu_cores)
     return AcceleratorConnector(
-            num_processes,
-            devices,
-            tpu_cores,
-            ipus,
-            distributed_backend,
-            accelerator,
-            gpus,
-            gpu_ids,
-            num_nodes,
-            sync_batchnorm,
-            benchmark,
-            replace_sampler_ddp,
-            deterministic,
-            precision,
-            amp_backend,
-            amp_level,
-            plugins,
-        )
+        num_processes,
+        devices,
+        tpu_cores,
+        ipus,
+        distributed_backend,
+        accelerator,
+        gpus,
+        gpu_ids,
+        num_nodes,
+        sync_batchnorm,
+        benchmark,
+        replace_sampler_ddp,
+        deterministic,
+        precision,
+        amp_backend,
+        amp_level,
+        plugins,
+    )
 
 
 @serialize_cls

--- a/nni/retiarii/evaluator/pytorch/cgo/trainer.py
+++ b/nni/retiarii/evaluator/pytorch/cgo/trainer.py
@@ -26,6 +26,6 @@ class Trainer(pl.Trainer):
         if use_cgo:
             if "accelerator" in trainer_kwargs:
                 raise ValueError("accelerator should not be set when cross-graph optimization is enabled.")
-            trainer_kwargs['accelerator'] = BypassAccelerator(device='cpu')
+            trainer_kwargs['accelerator'] = BypassAccelerator(device='cpu', **trainer_kwargs)
 
         super().__init__(**trainer_kwargs)


### PR DESCRIPTION
Pytorch-lightning updates its interface of TrainingTypePlugin and AcceleratorConnector.
This PR includes:

- [x] implement the teardown interface in BypassPlugin
- [x] use the trainer's kwargs to get the precision_plugin