### PR TITLE
hotfix: fix time format issue

### DIFF
--- a/ts/nni_manager/common/log.ts
+++ b/ts/nni_manager/common/log.ts
@@ -75,9 +75,8 @@ export class Logger {
             return;
         }
 
-        // `time.toLocaleString('sv')` trick does not work for Windows
-        const isoTime = new Date(new Date().toLocaleString() + ' UTC').toISOString();
-        const time = isoTime.slice(0, 10) + ' ' + isoTime.slice(11, 19);
+        const jsonTime = new Date().toJSON();
+        const time = jsonTime.slice(0, 10) + ' ' + jsonTime.slice(11, 19);
 
         const levelName = levelNames.has(level) ? levelNames.get(level) : level.toString();
 

--- a/ts/nni_manager/common/log.ts
+++ b/ts/nni_manager/common/log.ts
@@ -75,14 +75,17 @@ export class Logger {
             return;
         }
 
-        const jsonTime = new Date().toJSON();
-        const time = jsonTime.slice(0, 10) + ' ' + jsonTime.slice(11, 19);
+        const zeroPad = (num: number) => num.toString().padStart(2, '0');
+        const now = new Date();
+        const date = now.getFullYear() + '-' + zeroPad(now.getMonth() + 1) + '-' + zeroPad(now.getDate());
+        const time = zeroPad(now.getHours()) + ':' + zeroPad(now.getMinutes()) + ':' + zeroPad(now.getSeconds());
+        const datetime = date + ' ' + time;
 
         const levelName = levelNames.has(level) ? levelNames.get(level) : level.toString();
 
         const message = args.map(arg => (typeof arg === 'string' ? arg : util.inspect(arg))).join(' ');
         
-        const record = `[${time}] ${levelName} (${this.name}) ${message}\n`;
+        const record = `[${datetime}] ${levelName} (${this.name}) ${message}\n`;
 
         if (logFile === undefined) {
             console.log(record);

--- a/ts/nni_manager/common/log.ts
+++ b/ts/nni_manager/common/log.ts
@@ -75,7 +75,7 @@ export class Logger {
             return;
         }
 
-        const zeroPad = (num: number) => num.toString().padStart(2, '0');
+        const zeroPad = (num: number): string => num.toString().padStart(2, '0');
         const now = new Date();
         const date = now.getFullYear() + '-' + zeroPad(now.getMonth() + 1) + '-' + zeroPad(now.getDate());
         const time = zeroPad(now.getHours()) + ':' + zeroPad(now.getMinutes()) + ':' + zeroPad(now.getSeconds());


### PR DESCRIPTION
We should not use Date().toLocaleString() to get a formatted time string since it uses the local time format on user's machine and the format is different across platforms (windows, linux, mac) even node versions. This will lead to a failure when starting the rest server. Instead, we construct the time format by ourselves (since using libraries like `strftime` require extra dependences) which should be consistent across different platforms.

BTW, not sure why we add a ' UTC' to a local time and convert it to a UTC time. This will lead to a incorrect time if you are not in +0000.