### PR TITLE
added config_windows.yml for examples in /examples/trials

### DIFF
--- a/examples/trials/auto-gbdt/config_windows.yml
+++ b/examples/trials/auto-gbdt/config_windows.yml
@@ -1,0 +1,10 @@
+searchSpaceFile: search_space.json
+trialCommand: python main.py
+trialConcurrency: 1
+maxTrialNumber: 10
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: minimize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local

--- a/examples/trials/cifar10_pytorch/config_windows.yml
+++ b/examples/trials/cifar10_pytorch/config_windows.yml
@@ -1,0 +1,14 @@
+searchSpaceFile: search_space.json
+trialCommand: python main.py
+trialGpuNumber: 1
+trialConcurrency: 4
+maxTrialNumber: 10
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local
+  maxTrialNumberPerGpu: 2
+  useActiveGpu: false  # NOTE: Use "true" if you are using an OS with graphical interface (e.g. Windows 10, Ubuntu desktop)
+                       # Check the doc for details: https://nni.readthedocs.io/en/latest/reference/experiment_config.html#useactivegpu

--- a/examples/trials/efficientnet/config_windows.yml
+++ b/examples/trials/efficientnet/config_windows.yml
@@ -1,0 +1,15 @@
+searchSpaceFile: search_net.json
+trialCodeDirectory: EfficientNet-PyTorch
+trialCommand: python main.py /data/imagenet -j 12 -a efficientnet --batch-size 48 --lr 0.048 --wd 1e-5 --epochs 5 --request-from-nni
+trialGpuNumber: 1
+trialConcurrency: 4
+maxTrialNumber: 100
+tuner:
+  className: tuner.FixedProductTuner
+  codeDirectory: .
+  classArgs:
+    product: 2
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local
+  useActiveGpu: false  # NOTE: Use "true" if you are using an OS with graphical interface (e.g. Windows 10, Ubuntu desktop)
+                       # Check the doc for details: https://nni.readthedocs.io/en/latest/reference/experiment_config.html#useactivegputrial:

--- a/examples/trials/ga_squad/config_windows.yml
+++ b/examples/trials/ga_squad/config_windows.yml
@@ -1,0 +1,13 @@
+trialCommand: python trial.py
+trialGpuNumber: 0
+trialConcurrency: 1
+maxTrialNumber: 10
+maxExperimentDuration: 1h
+searchSpace: {}  # hard-coded in tuner
+tuner:
+  className: customer_tuner.CustomerTuner
+  codeDirectory: ../../tuners/ga_customer_tuner
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local

--- a/examples/trials/kaggle-tgs-salt/config_windows.yml
+++ b/examples/trials/kaggle-tgs-salt/config_windows.yml
@@ -1,0 +1,11 @@
+useAnnotation: true
+trialCommand: python train.py
+trialGpuNumber: 0
+trialConcurrency: 2
+maxTrialNumber: 10
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local

--- a/examples/trials/mnist-annotation/config_windows.yml
+++ b/examples/trials/mnist-annotation/config_windows.yml
@@ -1,0 +1,12 @@
+useAnnotation: true
+trialCommand: python mnist.py
+trialGpuNumber: 0
+trialConcurrency: 1
+maxTrialNumber: 10
+maxExperimentDuration: 1h
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local

--- a/examples/trials/mnist-batch-tune-keras/config_windows.yml
+++ b/examples/trials/mnist-batch-tune-keras/config_windows.yml
@@ -1,0 +1,10 @@
+searchSpaceFile: search_space.json
+trialCommand: python mnist-keras.py
+trialGpuNumber: 0
+trialConcurrency: 1
+maxTrialNumber: 10
+maxExperimentDuration: 1h
+tuner:
+  name: BatchTuner
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local

--- a/examples/trials/mnist-keras/config_windows.yml
+++ b/examples/trials/mnist-keras/config_windows.yml
@@ -1,0 +1,21 @@
+authorName: default
+experimentName: example_mnist-keras
+trialConcurrency: 1
+maxExecDuration: 1h
+maxTrialNum: 10
+#choice: local, remote, pai
+trainingServicePlatform: local
+searchSpacePath: search_space.json
+#choice: true, false
+useAnnotation: false
+tuner:
+  #choice: TPE, Random, Anneal, Evolution, BatchTuner, MetisTuner
+  #SMAC (SMAC should be installed through nnictl)
+  builtinTunerName: TPE
+  classArgs:
+    #choice: maximize, minimize
+    optimize_mode: maximize
+trial:
+  command: python mnist-keras.py
+  codeDir: .
+  gpuNum: 0

--- a/examples/trials/mnist-nested-search-space/config_windows.yml
+++ b/examples/trials/mnist-nested-search-space/config_windows.yml
@@ -1,0 +1,14 @@
+searchSpaceFile: search_space.json
+trialCommand: python mnist.py
+trialGpuNumber: 0
+trialConcurrency: 2
+maxTrialNumber: 100
+maxExperimentDuration: 1h
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local
+  useActiveGpu: false  # NOTE: Use "true" if you are using an OS with graphical interface (e.g. Windows 10, Ubuntu desktop)
+                       # Check the doc for details: https://nni.readthedocs.io/en/latest/reference/experiment_config.html#useactivegpu

--- a/examples/trials/mnist-pbt-tuner-pytorch/config_windows.yml
+++ b/examples/trials/mnist-pbt-tuner-pytorch/config_windows.yml
@@ -1,0 +1,14 @@
+searchSpaceFile: search_space.json
+trialCommand: python mnist.py
+trialGpuNumber: 1
+trialConcurrency: 3
+maxTrialNumber: 100
+maxExperimentDuration: 2h
+tuner:
+  name: PBTTuner
+  classArgs:
+    optimize_mode: maximize
+trainingService:  # For other platforms, check mnist-pytorch example
+  platform: local
+  useActiveGpu: false  # NOTE: Use "true" if you are using an OS with graphical interface (e.g. Windows 10, Ubuntu desktop)
+                       # Check the doc for details: https://nni.readthedocs.io/en/latest/reference/experiment_config.html#useactivegpu

--- a/examples/trials/mnist-pytorch/config_windows.yml
+++ b/examples/trials/mnist-pytorch/config_windows.yml
@@ -1,7 +1,3 @@
-
-# Use "nnictl create --config config.yml" to launch this experiment.
-# Afterwards, you can check "config_detailed.yml" for more explanation.
-
 searchSpaceFile: search_space.json
 trialCommand: python mnist.py
 trialGpuNumber: 0

--- a/examples/trials/mnist-pytorch/config_windows.yml
+++ b/examples/trials/mnist-pytorch/config_windows.yml
@@ -1,4 +1,4 @@
-# This is the minimal config file for an NNI experiment.
+
 # Use "nnictl create --config config.yml" to launch this experiment.
 # Afterwards, you can check "config_detailed.yml" for more explanation.
 

--- a/examples/trials/mnist-pytorch/config_windows.yml
+++ b/examples/trials/mnist-pytorch/config_windows.yml
@@ -1,0 +1,14 @@
+# This is the minimal config file for an NNI experiment.
+# Use "nnictl create --config config.yml" to launch this experiment.
+# Afterwards, you can check "config_detailed.yml" for more explanation.
+
+searchSpaceFile: search_space.json
+trialCommand: python mnist.py
+trialGpuNumber: 0
+trialConcurrency: 1
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:
+  platform: local

--- a/examples/trials/mnist-tfv2/config_windows.yml
+++ b/examples/trials/mnist-tfv2/config_windows.yml
@@ -1,7 +1,3 @@
-# This is the minimal config file for an NNI experiment.
-# Use "nnictl create --config config.yml" to launch this experiment.
-# Afterwards, you can check "config_detailed.yml" for more explanation.
-
 searchSpaceFile: search_space.json
 trialCommand: python mnist.py
 trialGpuNumber: 0

--- a/examples/trials/mnist-tfv2/config_windows.yml
+++ b/examples/trials/mnist-tfv2/config_windows.yml
@@ -1,0 +1,14 @@
+# This is the minimal config file for an NNI experiment.
+# Use "nnictl create --config config.yml" to launch this experiment.
+# Afterwards, you can check "config_detailed.yml" for more explanation.
+
+searchSpaceFile: search_space.json
+trialCommand: python mnist.py
+trialGpuNumber: 0
+trialConcurrency: 1
+tuner:
+  name: TPE
+  classArgs:
+    optimize_mode: maximize
+trainingService:
+  platform: local


### PR DESCRIPTION
Added `config_windows.yml` to the examples at `/examples/trials`

 `config.yml` is copied as is, but `python3` is changed to `python` for Windows systems

@liuzhe-lz 