### PR TITLE
fix no build result issue

### DIFF
--- a/ts/nni_manager/tsconfig.json
+++ b/ts/nni_manager/tsconfig.json
@@ -25,7 +25,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "ESNext",
-    "incremental": true,
-    "tsBuildInfoFile": "./.tsbuildinfo"
+    "incremental": false
   }
 }


### PR DESCRIPTION
Although "incremental" can detect the least costly way of each build,  it will prevent build if it detect there is no change in cache(.tsbuildinfo), which will cause no build result out put at pipeline process.

Set it to "false" as default could solve this issue.