### PR TITLE
[Quantization] fix parameter assign problem of weight

### DIFF
--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -8,7 +8,7 @@ from schema import Schema, And, Or, Optional
 from nni.compression.pytorch.utils.config_validation import QuantizerSchema
 from nni.compression.pytorch.compressor import BN_FOLD_TAG, Quantizer, QuantForward, QuantGrad, QuantType
 
-from .observers import default_weight_observer, default_histogram_observer
+from .observers import default_weight_observer, default_histogram_observer, PerChannelMinMaxObserver
 
 __all__ = ['NaiveQuantizer', 'QAT_Quantizer', 'DoReFaQuantizer', 'BNNQuantizer', 'LsqQuantizer', 'ObserverQuantizer']
 
@@ -301,6 +301,14 @@ class ObserverQuantizer(Quantizer):
                 calibration_config[name]['tracked_min_weight'] = -val
                 calibration_config[name]['tracked_qmin_weight'] = -127
                 calibration_config[name]['tracked_qmax_weight'] = 127
+                weight = module.weight
+                quantized_weight = self._quantize(weight,
+                                            module.weight_scale,
+                                            module.weight_zero_point,
+                                            module.weight_qmin,
+                                            module.weight_qmax)
+                delattr(module, 'weight')
+                module.register_parameter('weight', torch.nn.Parameter(quantized_weight))
             # refactor these magic numbers when customizations of dtype and qscheme are ready.
             if hasattr(module, 'input_scale'):
                 calibration_config[name]['input_bits'] = 8
@@ -389,6 +397,20 @@ class QAT_Quantizer(Quantizer):
                 layer.module.register_buffer('tracked_min_output', torch.zeros(1))
                 layer.module.register_buffer('tracked_max_output', torch.zeros(1))
         self.bound_model.to(device)
+
+    def load_calibration_config(self, calibration_config):
+        """
+        update quantization parameter by loading from calibration config
+        """
+        modules_to_compress = self.get_modules_to_compress()
+        for layer, config in modules_to_compress:
+            name = layer.name
+            if "input" in config.get("quant_types", []):
+                layer.module.tracked_min_input = calibration_config[name]['tracked_min_input']
+                layer.module.tracked_max_input = calibration_config[name]['tracked_max_input']
+            if "output" in config.get("quant_types", []):
+                layer.module.tracked_min_output = calibration_config[name]['tracked_min_output']
+                layer.module.tracked_max_output = calibration_config[name]['tracked_max_output']
 
     def _del_simulated_attr(self, module):
         """
@@ -928,6 +950,18 @@ class LsqQuantizer(Quantizer):
                 self.optimizer.add_param_group({"params": layer.module.input_scale})
 
         self.bound_model.to(device)
+
+    def load_calibration_config(self, calibration_config):
+        """
+        update quantization parameter by loading from calibration config
+        """
+        modules_to_compress = self.get_modules_to_compress()
+        for layer, config in modules_to_compress:
+            name = layer.name
+            if "weight" in config.get("quant_types", []):
+                layer.module.input_scale = calibration_config[name]['tracked_max_input'] / layer.module.input_qmax
+            if "output" in config.get("quant_types", []):
+                layer.module.output_scale = calibration_config[name]['tracked_max_output'] / layer.module.output_qmax
 
     @staticmethod
     def grad_scale(x, scale):

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -8,7 +8,7 @@ from schema import Schema, And, Or, Optional
 from nni.compression.pytorch.utils.config_validation import QuantizerSchema
 from nni.compression.pytorch.compressor import BN_FOLD_TAG, Quantizer, QuantForward, QuantGrad, QuantType
 
-from .observers import default_weight_observer, default_histogram_observer, PerChannelMinMaxObserver
+from .observers import default_weight_observer, default_histogram_observer
 
 __all__ = ['NaiveQuantizer', 'QAT_Quantizer', 'DoReFaQuantizer', 'BNNQuantizer', 'LsqQuantizer', 'ObserverQuantizer']
 
@@ -397,20 +397,6 @@ class QAT_Quantizer(Quantizer):
                 layer.module.register_buffer('tracked_min_output', torch.zeros(1))
                 layer.module.register_buffer('tracked_max_output', torch.zeros(1))
         self.bound_model.to(device)
-
-    def load_calibration_config(self, calibration_config):
-        """
-        update quantization parameter by loading from calibration config
-        """
-        modules_to_compress = self.get_modules_to_compress()
-        for layer, config in modules_to_compress:
-            name = layer.name
-            if "input" in config.get("quant_types", []):
-                layer.module.tracked_min_input = calibration_config[name]['tracked_min_input']
-                layer.module.tracked_max_input = calibration_config[name]['tracked_max_input']
-            if "output" in config.get("quant_types", []):
-                layer.module.tracked_min_output = calibration_config[name]['tracked_min_output']
-                layer.module.tracked_max_output = calibration_config[name]['tracked_max_output']
 
     def _del_simulated_attr(self, module):
         """
@@ -950,18 +936,6 @@ class LsqQuantizer(Quantizer):
                 self.optimizer.add_param_group({"params": layer.module.input_scale})
 
         self.bound_model.to(device)
-
-    def load_calibration_config(self, calibration_config):
-        """
-        update quantization parameter by loading from calibration config
-        """
-        modules_to_compress = self.get_modules_to_compress()
-        for layer, config in modules_to_compress:
-            name = layer.name
-            if "weight" in config.get("quant_types", []):
-                layer.module.input_scale = calibration_config[name]['tracked_max_input'] / layer.module.input_qmax
-            if "output" in config.get("quant_types", []):
-                layer.module.output_scale = calibration_config[name]['tracked_max_output'] / layer.module.output_qmax
 
     @staticmethod
     def grad_scale(x, scale):

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -252,8 +252,6 @@ class ObserverQuantizer(Quantizer):
                                             module.weight_zero_point,
                                             module.weight_qmin,
                                             module.weight_qmax)
-                delattr(module, 'weight')
-                module.register_parameter('weight', torch.nn.Parameter(quantized_weight))
             if "input" in config.get("quant_types", []):
                 scale, zero_point = self.calculate_qparams(layer.name, 'input')
                 module.register_buffer('input_scale', scale.to(self.device))
@@ -389,6 +387,10 @@ class QAT_Quantizer(Quantizer):
                 layer.module.register_buffer('tracked_min_output', torch.zeros(1))
                 layer.module.register_buffer('tracked_max_output', torch.zeros(1))
         self.bound_model.to(device)
+
+    def read_calibration_config(self, calibration_config: dict):
+        modules_to_compress = self.get_modules_to_compress()
+            
 
     def _del_simulated_attr(self, module):
         """

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -390,18 +390,6 @@ class QAT_Quantizer(Quantizer):
                 layer.module.register_buffer('tracked_max_output', torch.zeros(1))
         self.bound_model.to(device)
 
-    def init_quantize_parameter(self, calibration_config):
-        # Init quantization parameter from calibration config
-        modules_to_compress = self.get_modules_to_compress()
-        for layer, config in modules_to_compress:
-            name = layer.name
-            if "input" in config.get("quant_types", []):
-                layer.module.tracked_min_input = calibration_config[name]['tracked_min_input']
-                layer.module.tracked_max_input = calibration_config[name]['tracked_max_input']
-            if "output" in config.get("quant_types", []):
-                layer.module.tracked_min_output = calibration_config[name]['tracked_min_output']
-                layer.module.tracked_max_output = calibration_config[name]['tracked_max_output']
-
     def _del_simulated_attr(self, module):
         """
         delete redundant parameters in quantize module
@@ -940,16 +928,6 @@ class LsqQuantizer(Quantizer):
                 self.optimizer.add_param_group({"params": layer.module.input_scale})
 
         self.bound_model.to(device)
-
-    def init_quantize_parameter(self, calibration_config):
-        # Init quantization parameter from calibration config
-        modules_to_compress = self.get_modules_to_compress()
-        for layer, config in modules_to_compress:
-            name = layer.name
-            if "weight" in config.get("quant_types", []):
-                layer.module.input_scale = calibration_config[name]['tracked_max_input'] / layer.module.input_qmax
-            if "output" in config.get("quant_types", []):
-                layer.module.output_scale = calibration_config[name]['tracked_max_output'] / layer.module.output_qmax
 
     @staticmethod
     def grad_scale(x, scale):

--- a/nni/algorithms/compression/pytorch/quantization/quantizers.py
+++ b/nni/algorithms/compression/pytorch/quantization/quantizers.py
@@ -388,10 +388,6 @@ class QAT_Quantizer(Quantizer):
                 layer.module.register_buffer('tracked_max_output', torch.zeros(1))
         self.bound_model.to(device)
 
-    def read_calibration_config(self, calibration_config: dict):
-        modules_to_compress = self.get_modules_to_compress()
-            
-
     def _del_simulated_attr(self, module):
         """
         delete redundant parameters in quantize module

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -559,7 +559,7 @@ class QuantizerModuleWrapper(torch.nn.Module):
                 self.module.weight = new_weight
             else:
                 new_weight = self.module.old_weight
-                self.module.weight = new_weight.data
+                self.module.weight.data = new_weight.data
 
             self.quantizer.quant_grad(
                 new_weight,

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -559,7 +559,7 @@ class QuantizerModuleWrapper(torch.nn.Module):
                 self.module.weight = new_weight
             else:
                 new_weight = self.module.old_weight
-                self.module.weight.data = new_weight.data
+                self.module.weight = new_weight.data
 
             self.quantizer.quant_grad(
                 new_weight,


### PR DESCRIPTION
Error will be raised when using observer_quantizer since tensor assigned to parameter.
![image](https://user-images.githubusercontent.com/50486294/131647149-1982e71a-6396-4e84-bf05-c0b6449bdf74.png)

Change `self.module.weight` to `self.module.weight.data` in line 562 can resolve such problem.