### PR TITLE
Improve trial intermediate result graph: trials have not intermediate default key

### DIFF
--- a/ts/webui/src/components/modals/Compare.tsx
+++ b/ts/webui/src/components/modals/Compare.tsx
@@ -55,6 +55,7 @@ interface CompareProps {
     trials: TableObj[];
     title: string;
     showDetails: boolean;
+    intermediateKeyList?: string[];
     onHideDialog: () => void;
     changeSelectTrialIds?: () => void;
 }
@@ -68,6 +69,7 @@ class Compare extends React.Component<CompareProps, CompareState> {
         super(props);
 
         this.state = {
+            // 这里一进来默认了trial intermediate是有default Key的，但实际人家可以没有这个值
             intermediateKey: 'default'
         };
     }
@@ -226,9 +228,9 @@ class Compare extends React.Component<CompareProps, CompareState> {
     };
 
     render(): React.ReactNode {
-        const { trials, title, showDetails } = this.props;
+        const { trials, title, showDetails, intermediateKeyList } = this.props;
         const { intermediateKey } = this.state;
-        let intermediateAllKeysList: string[] = [];
+        const intermediateAllKeysList: string[] = intermediateKeyList !== undefined ? intermediateKeyList : [];
 
         const flatten = (m: Map<SingleAxis, any>): Map<string, any> => {
             return new Map(Array.from(m).map(([key, value]) => [key.baseName, value]));
@@ -243,19 +245,19 @@ class Compare extends React.Component<CompareProps, CompareState> {
             intermediates: _parseIntermediates(trial, intermediateKey)
         }));
 
-        if (trials[0].intermediates !== undefined && trials[0].intermediates[0]) {
-            const parsedMetric = parseMetrics(trials[0].intermediates[0].data);
-            if (parsedMetric !== undefined && typeof parsedMetric === 'object') {
-                const allIntermediateKeys: string[] = [];
-                // just add type=number keys
-                for (const key in parsedMetric) {
-                    if (typeof parsedMetric[key] === 'number') {
-                        allIntermediateKeys.push(key);
-                    }
-                }
-                intermediateAllKeysList = allIntermediateKeys;
-            }
-        }
+        // if (trials[0].intermediates !== undefined && trials[0].intermediates[0]) {
+        //     const parsedMetric = parseMetrics(trials[0].intermediates[0].data);
+        //     if (parsedMetric !== undefined && typeof parsedMetric === 'object') {
+        //         const allIntermediateKeys: string[] = [];
+        //         // just add type=number keys
+        //         for (const key in parsedMetric) {
+        //             if (typeof parsedMetric[key] === 'number') {
+        //                 allIntermediateKeys.push(key);
+        //             }
+        //         }
+        //         intermediateAllKeysList = allIntermediateKeys;
+        //     }
+        // }
 
         return (
             <Modal

--- a/ts/webui/src/components/modals/Compare.tsx
+++ b/ts/webui/src/components/modals/Compare.tsx
@@ -69,8 +69,9 @@ class Compare extends React.Component<CompareProps, CompareState> {
         super(props);
 
         this.state = {
-            // 这里一进来默认了trial intermediate是有default Key的，但实际人家可以没有这个值
-            intermediateKey: 'default'
+            // intermediate result maybe don't have the 'default' key...
+            intermediateKey:
+                this.props.intermediateKeyList !== undefined ? this.props.intermediateKeyList[0] : 'default'
         };
     }
 
@@ -231,7 +232,6 @@ class Compare extends React.Component<CompareProps, CompareState> {
         const { trials, title, showDetails, intermediateKeyList } = this.props;
         const { intermediateKey } = this.state;
         const intermediateAllKeysList: string[] = intermediateKeyList !== undefined ? intermediateKeyList : [];
-
         const flatten = (m: Map<SingleAxis, any>): Map<string, any> => {
             return new Map(Array.from(m).map(([key, value]) => [key.baseName, value]));
         };
@@ -244,20 +244,6 @@ class Compare extends React.Component<CompareProps, CompareState> {
             metrics: flatten(trial.metrics(TRIALS.inferredMetricSpace())),
             intermediates: _parseIntermediates(trial, intermediateKey)
         }));
-
-        // if (trials[0].intermediates !== undefined && trials[0].intermediates[0]) {
-        //     const parsedMetric = parseMetrics(trials[0].intermediates[0].data);
-        //     if (parsedMetric !== undefined && typeof parsedMetric === 'object') {
-        //         const allIntermediateKeys: string[] = [];
-        //         // just add type=number keys
-        //         for (const key in parsedMetric) {
-        //             if (typeof parsedMetric[key] === 'number') {
-        //                 allIntermediateKeys.push(key);
-        //             }
-        //         }
-        //         intermediateAllKeysList = allIntermediateKeys;
-        //     }
-        // }
 
         return (
             <Modal
@@ -278,7 +264,8 @@ class Compare extends React.Component<CompareProps, CompareState> {
                             onClick={this.closeCompareModal}
                         />
                     </div>
-                    {intermediateAllKeysList.length > 1 ? (
+                    {intermediateAllKeysList.length > 1 ||
+                    (intermediateAllKeysList.length === 1 && intermediateAllKeysList !== ['default']) ? (
                         <Stack horizontalAlign='end' className='selectKeys'>
                             <Dropdown
                                 className='select'

--- a/ts/webui/src/components/trial-detail/TableList.tsx
+++ b/ts/webui/src/components/trial-detail/TableList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@fluentui/react';
 import { EXPERIMENT, TRIALS } from '../../static/datamodel';
 import { TOOLTIP_BACKGROUND_COLOR } from '../../static/const';
-import { convertDuration, formatTimestamp, copyAndSort, parametersType } from '../../static/function';
+import { convertDuration, formatTimestamp, copyAndSort, parametersType, parseMetrics } from '../../static/function';
 import { TableObj, SortInfo, SearchItems } from '../../static/interface';
 import { getTrialsBySearchFilters } from './search/searchFunction';
 import { blocked, copy, LineChart, tableListIcon } from '../buttons/Icon';
@@ -469,6 +469,25 @@ class TableList extends React.Component<TableListProps, TableListState> {
         }));
     };
 
+    private ccc = (): string[] => {
+        const { intermediateDialogTrial } = this.state;
+        let intermediateAllKeysList: string[] = [];
+        if (intermediateDialogTrial![0].intermediates !== undefined && intermediateDialogTrial![0].intermediates[0]) {
+            const parsedMetric = parseMetrics(intermediateDialogTrial![0].intermediates[0].data);
+            if (parsedMetric !== undefined && typeof parsedMetric === 'object') {
+                const allIntermediateKeys: string[] = [];
+                // just add type=number keys
+                for (const key in parsedMetric) {
+                    if (typeof parsedMetric[key] === 'number') {
+                        allIntermediateKeys.push(key);
+                    }
+                }
+                intermediateAllKeysList = allIntermediateKeys;
+            }
+        }
+        return intermediateAllKeysList;
+    };
+
     componentDidUpdate(prevProps: TableListProps): void {
         if (this.props.tableSource !== prevProps.tableSource) {
             this._updateTableSource();
@@ -564,6 +583,7 @@ class TableList extends React.Component<TableListProps, TableListState> {
                         title='Intermediate results'
                         showDetails={false}
                         trials={[intermediateDialogTrial]}
+                        intermediateKeyList={this.ccc()}
                         onHideDialog={(): void => {
                             this.setState({ intermediateDialogTrial: undefined });
                         }}


### PR DESCRIPTION
**This PR is for trial detail -- `intermediate` modal, look like this picture. we don't think out this status that trial doesn't have `default` key in its intermediate result in `nni<=2.4`**

![image](https://user-images.githubusercontent.com/61399850/132817317-7bce50f4-bf0c-409d-8b15-a8a12451bdd0.png)

### before this PR
 if trial doesn't have `default` key in intermediate result, the graph is liking this:
the dropdown didn't show the selected key, the graph also is null.

![image](https://user-images.githubusercontent.com/61399850/132817514-4656f3d2-6d8c-4ad9-bb1a-3d3bf9eea6fe.png)

### After this PR
if trial doesn't have `default` key, we'll show this trial's other key(number type), such as `other`.

![image](https://user-images.githubusercontent.com/61399850/132817921-7092c99f-662d-4d69-881f-57244bc454e5.png)
