### PR TITLE
Upgrade typing extension version

### DIFF
--- a/dependencies/recommended.txt
+++ b/dependencies/recommended.txt
@@ -14,3 +14,4 @@ peewee
 graphviz
 gym
 tianshou >= 0.4.1
+typing-extensions >= 3.10  # pylint requires newer typing extension. Override requirements in tensorflow

--- a/dependencies/recommended.txt
+++ b/dependencies/recommended.txt
@@ -4,7 +4,6 @@
 tensorflow == 2.5.0
 keras == 2.4.3
 tensorboard == 2.5.0
-typing-extensions >= 3.10  # pylint requires newer typing extension. Override requirements in tensorflow
 torch == 1.9.0+cpu ; sys_platform != "darwin"
 torch == 1.9.0 ; sys_platform == "darwin"
 torchvision == 0.10.0+cpu ; sys_platform != "darwin"

--- a/dependencies/recommended.txt
+++ b/dependencies/recommended.txt
@@ -4,6 +4,7 @@
 tensorflow == 2.5.0
 keras == 2.4.3
 tensorboard == 2.5.0
+typing-extensions >= 3.10  # pylint requires newer typing extension. Override requirements in tensorflow
 torch == 1.9.0+cpu ; sys_platform != "darwin"
 torch == 1.9.0 ; sys_platform == "darwin"
 torchvision == 0.10.0+cpu ; sys_platform != "darwin"
@@ -14,4 +15,3 @@ peewee
 graphviz
 gym
 tianshou >= 0.4.1
-typing-extensions >= 3.10  # pylint requires newer typing extension. Override requirements in tensorflow

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -71,6 +71,7 @@ stages:
         python -m pip install -r dependencies/required.txt
         python -m pip install -r dependencies/recommended.txt
         python -m pip install -r dependencies/required_extra.txt
+        python -m pip install "typing-extensions>=3.10"  # pylint requires newer typing extension. Override requirements in tensorflow
       displayName: Install requirements
     - script: python -m pylint --rcfile pylintrc nni
       displayName: pylint


### PR DESCRIPTION
There is a conflict between typing-extension required by pylint and required by tensorflow. I don't think tensorflow has a reasonable version request to pin typing-extension at 3.7. I'll respect pylint's dependency requirement.