### PR TITLE
Update ConfigSpace to 0.4.11

### DIFF
--- a/dependencies/required_extra.txt
+++ b/dependencies/required_extra.txt
@@ -6,7 +6,7 @@ ConfigSpaceNNI
 smac4nni
 
 # BOHB
-ConfigSpace==0.4.7
+ConfigSpace==0.4.11
 statsmodels==0.12.0
 
 # PPOTuner


### PR DESCRIPTION
As described in #3909, there is a missing dependency in ConfigSpace 0.4.7, which is fixed in 0.4.11