### PR TITLE
Fix unused hyperlink in doc

### DIFF
--- a/docs/zh_CN/Tutorial/HowToDebug.rst
+++ b/docs/zh_CN/Tutorial/HowToDebug.rst
@@ -108,4 +108,4 @@ Dispatcher 失败， 这通常是 Tuner 失败的情况。 可检查 Dispatcher 
 
 如图，每个 Trial 都有日志路径，可以从中找到 Trial 的日志和 stderr。
 
-除了 Experiment 级调试之外，NNI 还提供调试单个 Trial 的功能，而无需启动整个 Experiment。 有关调试单个 Trial 代码的更多信息，请参考 `独立运行模式 <../TrialExample/Trials.rst#用于调试的独立模式>`__ 。
+除了 Experiment 级调试之外，NNI 还提供调试单个 Trial 的功能，而无需启动整个 Experiment。 有关调试单个 Trial 代码的更多信息，请参考 `独立运行模式 <../TrialExample/Trials#standalone-mode-for-debugging>`__ 。


### PR DESCRIPTION
Related to issue #4232 
The problems exposed have been fixed, but there still may be implicit problem.