### PR TITLE
Fix v2 level pruner default config bug

### DIFF
--- a/nni/algorithms/compression/v2/pytorch/base/compressor.py
+++ b/nni/algorithms/compression/v2/pytorch/base/compressor.py
@@ -9,7 +9,7 @@ import torch
 from torch.nn import Module
 
 from nni.common.graph_utils import TorchModuleGraph
-from nni.algorithms.compression.v2.pytorch.utils import get_module_by_name
+from nni.algorithms.compression.v2.pytorch.utils.pruning import get_module_by_name, weighted_modules
 
 _logger = logging.getLogger(__name__)
 
@@ -30,14 +30,6 @@ def _setattr(model: Module, name: str, module: Module):
         setattr(parent_module, name_list[-1], module)
     else:
         raise '{} not exist.'.format(name)
-
-
-weighted_modules = [
-    'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d', 'ConvTranspose2d', 'ConvTranspose3d',
-    'Linear', 'Bilinear',
-    'PReLU',
-    'Embedding', 'EmbeddingBag',
-]
 
 
 class Compressor:

--- a/nni/algorithms/compression/v2/pytorch/utils/pruning.py
+++ b/nni/algorithms/compression/v2/pytorch/utils/pruning.py
@@ -8,7 +8,12 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from nni.algorithms.compression.v2.pytorch.base.compressor import weighted_modules
+weighted_modules = [
+    'Conv1d', 'Conv2d', 'Conv3d', 'ConvTranspose1d', 'ConvTranspose2d', 'ConvTranspose3d',
+    'Linear', 'Bilinear',
+    'PReLU',
+    'Embedding', 'EmbeddingBag',
+]
 
 
 def config_list_canonical(model: Module, config_list: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
This could let v2 level pruner work with config_list['op_types'] = 'default'