### PR TITLE
[Retiarii] fix missed "attributes" in ToDevice pytorch op

### DIFF
--- a/nni/retiarii/operation_def/torch_op_def.py
+++ b/nni/retiarii/operation_def/torch_op_def.py
@@ -491,7 +491,8 @@ class AtenAvgpool2d(PyTorchOperation):
 class ToDevice(PyTorchOperation):
     _artificial_op_name = "ToDevice"
 
-    def __init__(self, type_name: str, parameters: Dict[str, Any], _internal: bool = False):
+    def __init__(self, type_name: str, parameters: Dict[str, Any], _internal: bool = False,
+                 attributes: Dict[str, Any] = None):
         self.type = "ToDevice"
         self.device = parameters['device']
         self.overridden_device_repr = None


### PR DESCRIPTION
In https://github.com/microsoft/nni/pull/4214/, `Operation.new(...)` added `attributes` to be used in `__init__`. 
The `ToDevice` pytorch op is implemented for CGO, which missed the `attributes` in `__init__`.