### PR TITLE
[Doc & Pipeline] Fix page level & upgrade python verison in fast-test-legacy

### DIFF
--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -10,7 +10,8 @@ PythonWebHDFS
 colorama
 scikit-learn >= 0.24.1 ; python_version >= "3.7"
 scikit-learn < 1.0 ; python_version < "3.7"
-websockets
+websockets >= 10.1 ; python_version >= "3.7"
+websockets <= 10.0 ; python_version < "3.7"
 filelock
 prettytable
 cloudpickle

--- a/docs/en_US/Compression/QuickStart.rst
+++ b/docs/en_US/Compression/QuickStart.rst
@@ -4,7 +4,6 @@ Quick Start
 ..  toctree::
     :hidden:
 
-    Tutorial <Tutorial>
     Notebook Example <compression_pipeline_example>
 
 

--- a/docs/en_US/model_compression.rst
+++ b/docs/en_US/model_compression.rst
@@ -25,6 +25,7 @@ For details, please refer to the following tutorials:
 
     Overview <Compression/Overview>
     Quick Start <Compression/QuickStart>
+    Tutorial <Compression/Tutorial>
     Pruning <Compression/pruning>
     Pruning V2 <Compression/v2_pruning>
     Quantization <Compression/quantization>

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -225,7 +225,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.7
+        versionSpec: 3.6
       displayName: Configure Python version
 
     - task: NodeTool@0

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -225,7 +225,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.6
+        versionSpec: 3.7
       displayName: Configure Python version
 
     - task: NodeTool@0


### PR DESCRIPTION
### Description ###
The tutorial page is under quick start now, raise it under Compression doc.

Pin websockets <= 10.0 if python version < 3.7

Doc structure before:
![image](https://user-images.githubusercontent.com/33053116/141973104-70cb671e-ba5a-4df7-865b-a9f42766d9b0.png)

Doc structure after:
![image](https://user-images.githubusercontent.com/33053116/141972936-6c47db2b-91b2-449d-ba63-7a38e3e359dc.png)


### How to test ###
Review the compression doc title level.
