### PR TITLE
Fix Retiarii version issues on full test

### DIFF
--- a/dependencies/recommended_gpu.txt
+++ b/dependencies/recommended_gpu.txt
@@ -5,7 +5,7 @@ tensorflow
 keras == 2.4.3
 torch == 1.10.0+cu111
 torchvision == 0.11.1+cu111
-pytorch-lightning >= 1.4.2
+pytorch-lightning >= 1.5.0
 onnx
 peewee
 graphviz

--- a/examples/nas/oneshot/enas/macro.py
+++ b/examples/nas/oneshot/enas/macro.py
@@ -32,7 +32,7 @@ class ENASLayer(mutables.MutableScope):
         if self.skipconnect is not None:
             connection = self.skipconnect(prev_layers[:-1])
             if connection is not None:
-                out += connection
+                out = out + connection
         return self.batch_norm(out)
 
 


### PR DESCRIPTION
### Description ###

1. I don't know why ENAS search space breaks for PyTorch 1.10. Maybe some mechanisms about inplace add changes.
2. Inconsistent version of PyTorch-lightning between recommended and recommended_gpu, as pointed out by @hzhua.

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###

Run pipeline.
