### PR TITLE
Fix deepcopy of mutables

### DIFF
--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -3,7 +3,6 @@
 
 import copy
 import warnings
-from abc import ABC, abstractclassmethod
 from typing import Any, List, Union, Dict, Optional
 
 import torch

--- a/nni/retiarii/nn/pytorch/api.py
+++ b/nni/retiarii/nn/pytorch/api.py
@@ -297,7 +297,7 @@ class ValueChoice(Translatable, Mutable):
     # FIXME: prior is designed but not supported yet
 
     @classmethod
-    def create_fixed_module(cls, candidates: Optional[List[Any]] = None, *, label: Optional[str] = None, **kwargs):
+    def create_fixed_module(cls, candidates: List[Any], *, label: Optional[str] = None, **kwargs):
         return get_fixed_value(label)
 
     def __init__(self, candidates: List[Any], *, prior: Optional[List[float]] = None, label: Optional[str] = None):

--- a/nni/retiarii/nn/pytorch/component.py
+++ b/nni/retiarii/nn/pytorch/component.py
@@ -25,7 +25,8 @@ class Repeat(nn.Module):
     blocks : function, list of function, module or list of module
         The block to be repeated. If not a list, it will be replicated into a list.
         If a list, it should be of length ``max_depth``, the modules will be instantiated in order and a prefix will be taken.
-        If a function, it will be called to instantiate a module. Otherwise the module will be deep-copied.
+        If a function, it will be called (the argument is the index) to instantiate a module.
+        Otherwise the module will be deep-copied.
     depth : int or tuple of int
         If one number, the block will be repeated by a fixed number of times. If a tuple, it should be (min, max),
         meaning that the block will be repeated at least `min` times and at most `max` times.
@@ -69,7 +70,7 @@ class Repeat(nn.Module):
         assert repeat <= len(blocks), f'Not enough blocks to be used. {repeat} expected, only found {len(blocks)}.'
         blocks = blocks[:repeat]
         if not isinstance(blocks[0], nn.Module):
-            blocks = [b() for b in blocks]
+            blocks = [b(i) for i, b in enumerate(blocks)]
         return blocks
 
 

--- a/nni/retiarii/nn/pytorch/component.py
+++ b/nni/retiarii/nn/pytorch/component.py
@@ -33,13 +33,19 @@ class Repeat(Mutable):
 
     @classmethod
     def create_fixed_module(cls,
-                            blocks: Union[Callable[[], nn.Module], List[Callable[[], nn.Module]], nn.Module, List[nn.Module], None] = None,
-                            depth: Union[int, Tuple[int, int], None] = None, label: Optional[str] = None):
+                            blocks: Union[Callable[[int], nn.Module],
+                                          List[Callable[[int], nn.Module]],
+                                          nn.Module,
+                                          List[nn.Module]],
+                            depth: Union[int, Tuple[int, int]], *, label: Optional[str] = None):
         repeat = get_fixed_value(label)
         return nn.Sequential(*cls._replicate_and_instantiate(blocks, repeat))
 
     def __init__(self,
-                 blocks: Union[Callable[[], nn.Module], List[Callable[[], nn.Module]], nn.Module, List[nn.Module]],
+                 blocks: Union[Callable[[int], nn.Module],
+                               List[Callable[[int], nn.Module]],
+                               nn.Module,
+                               List[nn.Module]],
                  depth: Union[int, Tuple[int, int]], *, label: Optional[str] = None):
         super().__init__()
         self._label = generate_new_label(label)

--- a/nni/retiarii/nn/pytorch/nasbench101.py
+++ b/nni/retiarii/nn/pytorch/nasbench101.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 
 from nni.retiarii.mutator import InvalidMutation, Mutator
 from nni.retiarii.graph import Model
-from nni.retiarii.utils import NoContextError
 from .api import InputChoice, ValueChoice, LayerChoice
 from .utils import Mutable, generate_new_label, get_fixed_dict
 

--- a/nni/retiarii/nn/pytorch/nasbench101.py
+++ b/nni/retiarii/nn/pytorch/nasbench101.py
@@ -6,11 +6,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from nni.retiarii.mutator import InvalidMutation, Mutator
+from nni.retiarii.graph import Model
+from nni.retiarii.utils import NoContextError
 from .api import InputChoice, ValueChoice, LayerChoice
-from .utils import generate_new_label, get_fixed_dict
-from ...mutator import InvalidMutation, Mutator
-from ...graph import Model
-from ...utils import NoContextError
+from .utils import Mutable, generate_new_label, get_fixed_dict
 
 _logger = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ class _NasBench101CellFixed(nn.Module):
         return outputs
 
 
-class NasBench101Cell(nn.Module):
+class NasBench101Cell(Mutable):
     """
     Cell structure that is proposed in NAS-Bench-101 [nasbench101]_ .
 
@@ -289,23 +289,22 @@ class NasBench101Cell(nn.Module):
             return OrderedDict([(str(i), t) for i, t in enumerate(x)])
         return OrderedDict(x)
 
-    def __new__(cls, op_candidates: Union[Dict[str, Callable[[int], nn.Module]], List[Callable[[int], nn.Module]]],
-                in_features: int, out_features: int, projection: Callable[[int, int], nn.Module],
-                max_num_nodes: int = 7, max_num_edges: int = 9, label: Optional[str] = None):
+    @classmethod
+    def create_fixed_module(cls, op_candidates: Union[Dict[str, Callable[[int], nn.Module]], List[Callable[[int], nn.Module]], None] = None,
+                            in_features: Optional[int] = None, out_features: Optional[int] = None,
+                            projection: Optional[Callable[[int, int], nn.Module]] = None,
+                            max_num_nodes: int = 7, max_num_edges: int = 9, label: Optional[str] = None):
         def make_list(x): return x if isinstance(x, list) else [x]
 
-        try:
-            label, selected = get_fixed_dict(label)
-            op_candidates = cls._make_dict(op_candidates)
-            num_nodes = selected[f'{label}/num_nodes']
-            adjacency_list = [make_list(selected[f'{label}/input{i}']) for i in range(1, num_nodes)]
-            if sum([len(e) for e in adjacency_list]) > max_num_edges:
-                raise InvalidMutation(f'Expected {max_num_edges} edges, found: {adjacency_list}')
-            return _NasBench101CellFixed(
-                [op_candidates[selected[f'{label}/op{i}']] for i in range(1, num_nodes - 1)],
-                adjacency_list, in_features, out_features, num_nodes, projection)
-        except NoContextError:
-            return super().__new__(cls)
+        label, selected = get_fixed_dict(label)
+        op_candidates = cls._make_dict(op_candidates)
+        num_nodes = selected[f'{label}/num_nodes']
+        adjacency_list = [make_list(selected[f'{label}/input{i}']) for i in range(1, num_nodes)]
+        if sum([len(e) for e in adjacency_list]) > max_num_edges:
+            raise InvalidMutation(f'Expected {max_num_edges} edges, found: {adjacency_list}')
+        return _NasBench101CellFixed(
+            [op_candidates[selected[f'{label}/op{i}']] for i in range(1, num_nodes - 1)],
+            adjacency_list, in_features, out_features, num_nodes, projection)
 
     def __init__(self, op_candidates: Union[Dict[str, Callable[[int], nn.Module]], List[Callable[[int], nn.Module]]],
                  in_features: int, out_features: int, projection: Callable[[int, int], nn.Module],

--- a/nni/retiarii/nn/pytorch/nasbench101.py
+++ b/nni/retiarii/nn/pytorch/nasbench101.py
@@ -289,9 +289,8 @@ class NasBench101Cell(Mutable):
         return OrderedDict(x)
 
     @classmethod
-    def create_fixed_module(cls, op_candidates: Union[Dict[str, Callable[[int], nn.Module]], List[Callable[[int], nn.Module]], None] = None,
-                            in_features: Optional[int] = None, out_features: Optional[int] = None,
-                            projection: Optional[Callable[[int, int], nn.Module]] = None,
+    def create_fixed_module(cls, op_candidates: Union[Dict[str, Callable[[int], nn.Module]], List[Callable[[int], nn.Module]]],
+                            in_features: int, out_features: int, projection: Callable[[int, int], nn.Module],
                             max_num_nodes: int = 7, max_num_edges: int = 9, label: Optional[str] = None):
         def make_list(x): return x if isinstance(x, list) else [x]
 

--- a/nni/retiarii/nn/pytorch/utils.py
+++ b/nni/retiarii/nn/pytorch/utils.py
@@ -1,6 +1,35 @@
-from typing import Any, Optional, Tuple
+from abc import ABC, abstractclassmethod
+from typing import Any, Optional, Tuple, Union
 
-from nni.retiarii.utils import ModelNamespace, get_current_context
+import torch.nn as nn
+from nni.retiarii.utils import NoContextError, ModelNamespace, get_current_context
+
+
+class Mutable(ABC, nn.Module):
+    """
+    This should be the base class for all PyTorch mutables including layer choice, input choice, etc.
+    This is not considered as an interface, but rather as a base class consisting of commonly used class/instance methods.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if not args and not kwargs:
+            # this can be the case of copy/deepcopy
+            # attributes are assigned afterwards in __dict__
+            return super().__new__(cls)
+
+        try:
+            return cls.create_fixed_module(*args, **kwargs)
+        except NoContextError:
+            return super().__new__(cls)
+
+    @abstractclassmethod
+    def create_fixed_module(cls, *args, **kwargs) -> Union[nn.Module, Any]:
+        """
+        Try to create a fixed module from fixed dict.
+        If the code is running in a trial, this method would succeed, and a concrete module instead of a mutable will be created.
+        Raises no context error if the creation failed.
+        """
+        ...
 
 
 def generate_new_label(label: Optional[str]):

--- a/nni/retiarii/nn/pytorch/utils.py
+++ b/nni/retiarii/nn/pytorch/utils.py
@@ -1,14 +1,17 @@
-from abc import ABC, abstractclassmethod
 from typing import Any, Optional, Tuple, Union
 
 import torch.nn as nn
 from nni.retiarii.utils import NoContextError, ModelNamespace, get_current_context
 
 
-class Mutable(ABC, nn.Module):
+class Mutable(nn.Module):
     """
-    This should be the base class for all PyTorch mutables including layer choice, input choice, etc.
+    This is just an implementation trick for now.
+
+    In future, this could be the base class for all PyTorch mutables including layer choice, input choice, etc.
     This is not considered as an interface, but rather as a base class consisting of commonly used class/instance methods.
+    For API developers, it's not recommended to use ``isinstance(module, Mutable)`` to check for mutable modules either,
+    before the design is finalized.
     """
 
     def __new__(cls, *args, **kwargs):
@@ -22,14 +25,14 @@ class Mutable(ABC, nn.Module):
         except NoContextError:
             return super().__new__(cls)
 
-    @abstractclassmethod
+    @classmethod
     def create_fixed_module(cls, *args, **kwargs) -> Union[nn.Module, Any]:
         """
         Try to create a fixed module from fixed dict.
         If the code is running in a trial, this method would succeed, and a concrete module instead of a mutable will be created.
         Raises no context error if the creation failed.
         """
-        ...
+        raise NotImplementedError
 
 
 def generate_new_label(label: Optional[str]):

--- a/test/ut/retiarii/test_highlevel_apis.py
+++ b/test/ut/retiarii/test_highlevel_apis.py
@@ -483,6 +483,19 @@ class GraphIR(unittest.TestCase):
         self.assertTrue((self._get_converted_pytorch_model(model2)(torch.zeros(1, 16)) == 4).all())
         self.assertTrue((self._get_converted_pytorch_model(model3)(torch.zeros(1, 16)) == 5).all())
 
+        @model_wrapper
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = nn.Repeat(nn.LayerChoice([AddOne(), nn.Identity()]), (3, 5))
+
+            def forward(self, x):
+                return self.block(x)
+
+        model, mutators = self._get_model_with_mutators(Net())
+        self.assertEqual(len(mutators), 1)
+        assert len(mutators) == 2
+
     def test_cell(self):
         @self.get_serializer()
         class Net(nn.Module):

--- a/test/ut/retiarii/test_highlevel_apis.py
+++ b/test/ut/retiarii/test_highlevel_apis.py
@@ -483,18 +483,53 @@ class GraphIR(unittest.TestCase):
         self.assertTrue((self._get_converted_pytorch_model(model2)(torch.zeros(1, 16)) == 4).all())
         self.assertTrue((self._get_converted_pytorch_model(model3)(torch.zeros(1, 16)) == 5).all())
 
+    def test_repeat_complex(self):
+        class AddOne(nn.Module):
+            def forward(self, x):
+                return x + 1
+
         @model_wrapper
         class Net(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.block = nn.Repeat(nn.LayerChoice([AddOne(), nn.Identity()]), (3, 5))
+                self.block = nn.Repeat(nn.LayerChoice([AddOne(), nn.Identity()], label='lc'), (3, 5), label='rep')
 
             def forward(self, x):
                 return self.block(x)
 
         model, mutators = self._get_model_with_mutators(Net())
-        self.assertEqual(len(mutators), 1)
-        assert len(mutators) == 2
+        self.assertEqual(len(mutators), 2)
+        self.assertEqual(set([mutator.label for mutator in mutators]), {'lc', 'rep'})
+
+        sampler = RandomSampler()
+        for _ in range(10):
+            new_model = model
+            for mutator in mutators:
+                new_model = mutator.bind_sampler(sampler).apply(new_model)
+            result = self._get_converted_pytorch_model(new_model)(torch.zeros(1, 1)).item()
+            self.assertIn(result, [0., 3., 4., 5.])
+
+        # independent layer choice
+        @model_wrapper
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = nn.Repeat(lambda index: nn.LayerChoice([AddOne(), nn.Identity()]), (2, 3), label='rep')
+
+            def forward(self, x):
+                return self.block(x)
+
+        model, mutators = self._get_model_with_mutators(Net())
+        self.assertEqual(len(mutators), 4)
+
+        result = []
+        for _ in range(20):
+            new_model = model
+            for mutator in mutators:
+                new_model = mutator.bind_sampler(sampler).apply(new_model)
+            result.append(self._get_converted_pytorch_model(new_model)(torch.zeros(1, 1)).item())
+
+        self.assertIn(1., result)
 
     def test_cell(self):
         @self.get_serializer()


### PR DESCRIPTION
### Description ###

This can be merged into v2.6.

Fix issues that prevents layer choices from being deep-copied.

### Checklist ###
  - [x] test case
  - [x] doc (in #4399)

### How to test ###

```python
self.blocks = nn.Repeat(nn.LayerChoice([...]), (1, 3))
```
