### PR TITLE
Fix backward incompatible config behavior

### DIFF
--- a/nni/experiment/config/algorithm.py
+++ b/nni/experiment/config/algorithm.py
@@ -39,6 +39,9 @@ class _AlgorithmConfig(ConfigBase):
     code_directory: Optional[PathLike] = None
     class_args: Optional[Dict[str, Any]] = None
 
+    def _canonicalize(self, parents):
+        super()._canonicalize(parents)
+
     def _validate_canonical(self):
         super()._validate_canonical()
         if self.class_name is None:  # assume it's built-in algorithm by default

--- a/nni/experiment/config/algorithm.py
+++ b/nni/experiment/config/algorithm.py
@@ -39,9 +39,6 @@ class _AlgorithmConfig(ConfigBase):
     code_directory: Optional[PathLike] = None
     class_args: Optional[Dict[str, Any]] = None
 
-    def _canonicalize(self, parents):
-        super()._canonicalize(parents)
-
     def _validate_canonical(self):
         super()._validate_canonical()
         if self.class_name is None:  # assume it's built-in algorithm by default

--- a/nni/experiment/config/exp_config.py
+++ b/nni/experiment/config/exp_config.py
@@ -89,7 +89,7 @@ class ExperimentConfig(ConfigBase):
             for algo_type in ['tuner', 'assessor', 'advisor']:
                 # add placeholder items, so users can write `config.tuner.name = 'random'`
                 if getattr(self, algo_type) is None:
-                    setattr(self, algo_type, _AlgorithmConfig(name='_none_'))
+                    setattr(self, algo_type, _AlgorithmConfig(name='_none_', class_args={}))
         elif not utils.is_missing(self.training_service):
             # training service is set via json or constructor
             if isinstance(self.training_service, list):

--- a/test/ut/experiment/test_exp_config.py
+++ b/test/ut/experiment/test_exp_config.py
@@ -1,3 +1,4 @@
+import copy
 import os.path
 from pathlib import Path
 
@@ -45,6 +46,9 @@ minimal_canon = {
         'reuseMode': False,
     },
 }
+
+minimal_canon_2 = copy.deepcopy(minimal_canon)
+minimal_canon_2['tuner']['classArgs'] = {}
 
 ## detailed config ##
 
@@ -100,7 +104,7 @@ def test_all():
     minimal = ExperimentConfig(**minimal_json)
     assert minimal.json() == minimal_canon
 
-    assert minimal_class.json() == minimal_canon
+    assert minimal_class.json() == minimal_canon_2
 
     detailed = ExperimentConfig.load(expand_path('assets/config.yaml'))
     assert detailed.json() == detailed_canon


### PR DESCRIPTION
To support usage like this:

```python
config = ExperimentConfig("local")
config.tuner.class_args['seed'] = 1
```