### PR TITLE
Fix SVD error for `numpy >= 1.21` in DNGO

### DIFF
--- a/nni/algorithms/hpo/dngo_tuner.py
+++ b/nni/algorithms/hpo/dngo_tuner.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import numpy as np
 import torch
@@ -112,7 +113,10 @@ class DNGOTuner(Tuner):
         x_arr = []
         for x in self.x:
             x_arr.append([x[k] for k in sorted(x.keys())])
-        self.model.train(np.array(x_arr), np.array(self.y), do_optimize=True)
+        try:
+            self.model.train(np.array(x_arr), np.array(self.y), do_optimize=True)
+        except np.linalg.LinAlgError as e:
+            warnings.warn(f'numpy linalg error encountered in DNGO model training: {e}')
         self._model_initialized = True
 
     def _get_default_value(self, value):

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -180,7 +180,6 @@ stages:
         set -e
         python -m pip install -r dependencies/recommended.txt
         python -m pip install -e .[PPOTuner,DNGO]
-        python -m pip install "scipy<1.8"  # enforce scipy version for DNGO on pipeline
       displayName: Install extra dependencies
 
     # Need del later
@@ -375,7 +374,6 @@ stages:
         set -e
         python -m pip install -r dependencies/recommended.txt
         python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
-        python -m pip install "scipy<1.8"  # enforce scipy version for DNGO on pipeline
       displayName: Install extra dependencies
 
     # Need del later

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -180,6 +180,7 @@ stages:
         set -e
         python -m pip install -r dependencies/recommended.txt
         python -m pip install -e .[PPOTuner,DNGO]
+        python -m pip install "scipy<1.8"  # enforce scipy version for DNGO on pipeline
       displayName: Install extra dependencies
 
     # Need del later
@@ -374,6 +375,7 @@ stages:
         set -e
         python -m pip install -r dependencies/recommended.txt
         python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
+        python -m pip install "scipy<1.8"  # enforce scipy version for DNGO on pipeline
       displayName: Install extra dependencies
 
     # Need del later


### PR DESCRIPTION
```
2022-01-14T07:46:47.0355624Z _______________________ BuiltinTunersTestCase.test_dngo ________________________
2022-01-14T07:46:47.0356414Z 
2022-01-14T07:46:47.0356903Z self = <ut.sdk.test_builtin_tuners.BuiltinTunersTestCase testMethod=test_dngo>
2022-01-14T07:46:47.0357241Z 
2022-01-14T07:46:47.0357640Z     def test_dngo(self):
2022-01-14T07:46:47.0358171Z         tuner_fn = lambda: DNGOTuner(trials_per_update=100, num_epochs_per_training=1)
2022-01-14T07:46:47.0358811Z >       self.search_space_test_all(tuner_fn, fail_types=["choice_str", "choice_mixed",
2022-01-14T07:46:47.0359478Z                                                          "normal", "lognormal", "qnormal", "qlognormal"])
2022-01-14T07:46:47.0359863Z 
2022-01-14T07:46:47.0360277Z ut/sdk/test_builtin_tuners.py:397: 
2022-01-14T07:46:47.0360802Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2022-01-14T07:46:47.0361415Z ut/sdk/test_builtin_tuners.py:174: in search_space_test_all
2022-01-14T07:46:47.0361942Z     self.search_space_test_one(tuner_factory, single_search_space)
2022-01-14T07:46:47.0363498Z ut/sdk/test_builtin_tuners.py:80: in search_space_test_one
2022-01-14T07:46:47.0364893Z     self.send_trial_result(tuner, self.params_each_round * i + k, parameters[k], random.uniform(-100, 100))
2022-01-14T07:46:47.0365632Z ut/sdk/test_builtin_tuners.py:61: in send_trial_result
2022-01-14T07:46:47.0366218Z     tuner.receive_trial_result(parameter_id, parameters, metrics)
2022-01-14T07:46:47.0366768Z ../nni/algorithms/hpo/dngo_tuner.py:63: in receive_trial_result
2022-01-14T07:46:47.0367275Z     self._update_model()
2022-01-14T07:46:47.0367720Z ../nni/algorithms/hpo/dngo_tuner.py:115: in _update_model
2022-01-14T07:46:47.0368341Z     self.model.train(np.array(x_arr), np.array(self.y), do_optimize=True)
2022-01-14T07:46:47.0369244Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pybnn/base_model.py:71: in func_wrapper
2022-01-14T07:46:47.0369878Z     return func(self, X, y, *args, **kwargs)
2022-01-14T07:46:47.0370735Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pybnn/dngo.py:246: in train
2022-01-14T07:46:47.0371364Z     res = optimize.fmin(self.negative_mll, p0)
2022-01-14T07:46:47.0372308Z /home/vsts/.local/lib/python3.9/site-packages/scipy-1.8.0rc2-py3.9-linux-x86_64.egg/scipy/optimize/_optimize.py:622: in fmin
2022-01-14T07:46:47.0373028Z     res = _minimize_neldermead(func, x0, args, callback=callback, **opts)
2022-01-14T07:46:47.0374017Z /home/vsts/.local/lib/python3.9/site-packages/scipy-1.8.0rc2-py3.9-linux-x86_64.egg/scipy/optimize/_optimize.py:793: in _minimize_neldermead
2022-01-14T07:46:47.0374718Z     fsim[k] = func(sim[k])
2022-01-14T07:46:47.0375559Z /home/vsts/.local/lib/python3.9/site-packages/scipy-1.8.0rc2-py3.9-linux-x86_64.egg/scipy/optimize/_optimize.py:496: in function_wrapper
2022-01-14T07:46:47.0376186Z     fx = function(np.copy(x), *(wrapper_args + args))
2022-01-14T07:46:47.0377031Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pybnn/dngo.py:321: in negative_mll
2022-01-14T07:46:47.0377856Z     nll = -self.marginal_log_likelihood(theta)
2022-01-14T07:46:47.0379570Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pybnn/dngo.py:299: in marginal_log_likelihood
2022-01-14T07:46:47.0380574Z     mll -= beta / 2. * np.linalg.norm(self.y - np.dot(self.Theta, m), 2)
2022-01-14T07:46:47.0381162Z <__array_function__ internals>:5: in norm
2022-01-14T07:46:47.0381646Z     ???
2022-01-14T07:46:47.0382490Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/numpy/linalg/linalg.py:2579: in norm
2022-01-14T07:46:47.0383439Z     ret =  _multi_svd_norm(x, row_axis, col_axis, amax)
2022-01-14T07:46:47.0384372Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/numpy/linalg/linalg.py:2355: in _multi_svd_norm
2022-01-14T07:46:47.0385498Z     result = op(svd(y, compute_uv=False), axis=-1)
2022-01-14T07:46:47.0386105Z <__array_function__ internals>:5: in svd
2022-01-14T07:46:47.0386542Z     ???
2022-01-14T07:46:47.0387350Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/numpy/linalg/linalg.py:1672: in svd
2022-01-14T07:46:47.0388142Z     s = gufunc(a, signature=signature, extobj=extobj)
2022-01-14T07:46:47.0388637Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2022-01-14T07:46:47.0388911Z 
2022-01-14T07:46:47.0389446Z err = 'invalid value', flag = 8
2022-01-14T07:46:47.0389715Z 
2022-01-14T07:46:47.0390159Z     def _raise_linalgerror_svd_nonconvergence(err, flag):
2022-01-14T07:46:47.0390719Z >       raise LinAlgError("SVD did not converge")
2022-01-14T07:46:47.0391249Z E       numpy.linalg.LinAlgError: SVD did not converge
2022-01-14T07:46:47.0391569Z 
2022-01-14T07:46:47.0392375Z /opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/numpy/linalg/linalg.py:97: LinAlgError
```