### PR TITLE
Bump Python version to 3.7~3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Within the following table, we summarized the current NNI capabilities, we are g
 
 ### **Install**
 
-NNI supports and is tested on Ubuntu >= 18.04, Windows 21H2, and macOS >= 11.
+NNI supports and is tested on Ubuntu >= 18.04, Windows 10 >= 21H2, and macOS >= 11.
 Simply run the following `pip install` in an environment that has `python 64-bit >= 3.7`.
 
 Linux or macOS

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ Within the following table, we summarized the current NNI capabilities, we are g
 
 ### **Install**
 
-NNI supports and is tested on Ubuntu >= 16.04, macOS >= 10.14.1, and Windows 10 >= 1809. Simply run the following `pip install` in an environment that has `python 64-bit >= 3.6`.
+NNI supports and is tested on Ubuntu >= 18.04, Windows 21H2, and macOS >= 11.
+Simply run the following `pip install` in an environment that has `python 64-bit >= 3.7`.
 
 Linux or macOS
 

--- a/dependencies/recommended.txt
+++ b/dependencies/recommended.txt
@@ -1,8 +1,8 @@
 # Recommended because some non-commonly-used modules/examples depend on those packages.
 
 -f https://download.pytorch.org/whl/torch_stable.html
-tensorflow == 2.7.0
-tensorboard == 2.7.0
+tensorflow >= 2.7.0
+tensorboard >= 2.7.0
 torch == 1.10.0+cpu ; sys_platform != "darwin"
 torch == 1.10.0 ; sys_platform == "darwin"
 torchvision == 0.11.1+cpu ; sys_platform != "darwin"

--- a/dependencies/recommended_gpu.txt
+++ b/dependencies/recommended_gpu.txt
@@ -2,7 +2,6 @@
 
 -f https://download.pytorch.org/whl/torch_stable.html
 tensorflow
-keras == 2.4.3
 torch == 1.10.0+cu111
 torchvision == 0.11.1+cu111
 pytorch-lightning >= 1.5.0

--- a/dependencies/recommended_legacy.txt
+++ b/dependencies/recommended_legacy.txt
@@ -1,5 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-tensorflow == 1.15.4
 torch == 1.7.1+cpu
 torchvision == 0.8.2+cpu
 
@@ -8,10 +7,13 @@ torchvision == 0.8.2+cpu
 pytorch-lightning
 torchmetrics
 
-keras == 2.1.6
 onnx
 peewee
 graphviz
 gym
 tianshou >= 0.4.1
-matplotlib < 3.4
+matplotlib
+
+# TODO: time to drop tensorflow 1.x
+keras
+tensorflow < 2.0

--- a/dependencies/recommended_legacy.txt
+++ b/dependencies/recommended_legacy.txt
@@ -4,7 +4,7 @@ torchvision == 0.8.2+cpu
 
 # It will install pytorch-lightning 0.8.x and unit tests won't work.
 # Latest version has conflict with tensorboard and tensorflow 1.x.
-pytorch-lightning
+#pytorch-lightning
 torchmetrics
 
 onnx

--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -1,28 +1,21 @@
 astor
+cloudpickle
+colorama
+filelock
 hyperopt == 0.1.2
 json_tricks >= 3.15.5
+numpy < 1.22 ; python_version < "3.8"
+numpy ; python_version >= "3.8"
+pandas
+prettytable
 psutil
+PythonWebHDFS
 pyyaml >= 5.4
 requests
 responses
 schema
+scikit-learn >= 0.24.1
+scipy
 typeguard
-PythonWebHDFS
-colorama
-scikit-learn >= 0.24.1 ; python_version >= "3.7"
-scikit-learn < 1.0 ; python_version < "3.7"
-websockets >= 10.1 ; python_version >= "3.7"
-websockets <= 10.0 ; python_version < "3.7"
-filelock ; python_version >= "3.7"
-filelock < 3.4 ; python_version < "3.7"
-prettytable
-cloudpickle
-dataclasses ; python_version < "3.7"
 typing_extensions ; python_version < "3.8"
-numpy < 1.19.4 ; sys_platform == "win32"
-numpy < 1.20 ; sys_platform != "win32" and python_version < "3.7"
-numpy ; sys.platform != "win32" and python_version >= "3.7"
-scipy < 1.6 ; python_version < "3.7"
-scipy ; python_version >= "3.7"
-pandas < 1.2 ; python_version < "3.7"
-pandas ; python_version >= "3.7"
+websockets >= 10.1

--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -16,7 +16,7 @@ responses
 schema
 scikit-learn >= 0.24.1
 scipy < 1.8 ; python_version < "3.8"
-scipy ; python_version >= "3.8
+scipy ; python_version >= "3.8"
 typeguard
 typing_extensions ; python_version < "3.8"
 websockets >= 10.1

--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -15,7 +15,8 @@ requests
 responses
 schema
 scikit-learn >= 0.24.1
-scipy
+scipy < 1.8 ; python_version < "3.8"
+scipy ; python_version >= "3.8
 typeguard
 typing_extensions ; python_version < "3.8"
 websockets >= 10.1

--- a/dependencies/required_extra.txt
+++ b/dependencies/required_extra.txt
@@ -2,11 +2,11 @@
 # please follow the logic in setup.py.
 
 # SMAC
-ConfigSpaceNNI
+ConfigSpaceNNI>=0.4.7.3
 smac4nni
 
 # BOHB
-ConfigSpace==0.4.11
+ConfigSpace>=0.4.17
 statsmodels==0.12.0
 
 # PPOTuner

--- a/dependencies/setup.txt
+++ b/dependencies/setup.txt
@@ -1,3 +1,3 @@
-pip
-wheel
-setuptools
+pip < 21.4
+setuptools < 61
+wheel < 0.38

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -274,7 +274,7 @@ stages:
         cd dependencies
         python -m pip install -U -r setup.txt
         # FIXME: due to pip's limitation ConfigSpaceNNI will not build without this
-        python -m pip install 'numpy<1.22'
+        python -m pip install numpy==1.21.5
         # if we do not put them in one line, pip may implicitly downgrade previously installed packages
         # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
         echo '========================================'
@@ -299,6 +299,8 @@ stages:
         python -m pip install -r recommended_legacy.txt
         echo '========================================'
         echo '# 5'
+        python -m pip show numpy
+        python -m pip install numpy==1.21.5
         python -m pip show numpy
         echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
       displayName: Install Python dependencies

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -2,230 +2,230 @@
 # so that a bug in any module will cause at least one platform to fail quickly.
 
 stages:
-  #- stage: lint
-  #  jobs:
-  #  - job: docs
-  #    pool:
-  #      vmImage: ubuntu-latest
-  #    variables:
-  #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-  #    steps:
-  #    - task: UsePythonVersion@0
-  #      inputs:
-  #        versionSpec: 3.9
-  #      displayName: Configure Python version
-  #    - script: |
-  #        sudo apt-get install -y pandoc
-  #        sudo apt-get remove swig -y
-  #        sudo apt-get install swig3.0 -y
-  #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-  #      displayName: Install apt packages
-  #    - task: Cache@2
-  #      inputs:
-  #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-  #        restoreKeys: | 
-  #          python | "$(Agent.OS)"
-  #          python
-  #        path: $(PIP_CACHE_DIR)
-  #      displayName: Cache pip packages
-  #    - script: |
-  #        set -e
-  #        python -m pip install -U -r dependencies/setup.txt
-  #        python -m pip install -r dependencies/develop.txt
-  #        python -m pip install -r dependencies/required.txt
-  #        python -m pip install -r dependencies/recommended.txt
-  #        python -m pip install -r dependencies/required_extra.txt
-  #      displayName: Install requirements
-  #    - script: |
-  #        python test/vso_tools/interim_patch.py
-  #      displayName: Apply patch
-  #    - script: |
-  #        cd docs
-  #        python tools/chineselink.py check
-  #      displayName: Translation up-to-date
-  #    - script: |
-  #        cd docs/en_US
-  #        sphinx-build -M html . _build -W --keep-going -T
-  #      displayName: Sphinx  # TODO: rstcheck
-  #
-  #  - job: python
-  #    pool:
-  #      vmImage: ubuntu-latest
-  #    variables:
-  #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-  #    steps:
-  #    - task: UsePythonVersion@0
-  #      inputs:
-  #        versionSpec: 3.9
-  #      displayName: Configure Python version
-  #    - script: |
-  #        sudo apt-get remove swig -y
-  #        sudo apt-get install swig3.0 -y
-  #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-  #      displayName: Install apt packages
-  #    - task: Cache@2
-  #      inputs:
-  #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-  #        restoreKeys: | 
-  #          python | "$(Agent.OS)"
-  #          python
-  #        path: $(PIP_CACHE_DIR)
-  #      displayName: Cache pip packages
-  #    - script: |
-  #        set -e
-  #        python -m pip install -U -r dependencies/setup.txt
-  #        python -m pip install -r dependencies/develop.txt
-  #        python -m pip install -r dependencies/required.txt
-  #        python -m pip install -r dependencies/recommended.txt
-  #        python -m pip install -r dependencies/required_extra.txt
-  #        python -m pip install "typing-extensions>=3.10"  # pylint requires newer typing extension. Override requirements in tensorflow
-  #      displayName: Install requirements
-  #    - script: python -m pylint --rcfile pylintrc nni
-  #      displayName: pylint
-  #    - script: |
-  #        set -e
-  #        python -m flake8 nni --count --select=E9,F63,F72,F82 --show-source --statistics
-  #        EXCLUDES=examples/trials/mnist-nas/*/mnist*.py,examples/trials/nas_cifar10/src/cifar10/general_child.py
-  #        python -m flake8 examples --count --exclude=$EXCLUDES --select=E9,F63,F72,F82 --show-source --statistics
-  #      displayName: flake8
-  #
-  #  - job: typescript
-  #    pool:
-  #      vmImage: ubuntu-latest
-  #    variables:
-  #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-  #    steps:
-  #    - task: NodeTool@0
-  #      inputs:
-  #        versionSpec: 16.3.0
-  #      displayName: Configure Node.js version
-  #    - task: Cache@2
-  #      inputs:
-  #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-  #        restoreKeys: |
-  #          yarn | "$(Agent.OS)"
-  #        path: $(YARN_CACHE_FOLDER)
-  #      displayName: Cache yarn packages
-  #    - script: |
-  #        set -e
-  #        cd ts/nni_manager
-  #        yarn
-  #        yarn eslint
-  #      displayName: ESLint (NNI Manager)
-  #    - script: |
-  #        set -e
-  #        cd ts/webui
-  #        yarn
-  #        yarn eslint
-  #      displayName: ESLint (WebUI)
+- stage: lint
+  jobs:
+  - job: docs
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+      displayName: Configure Python version
+    - script: |
+        sudo apt-get install -y pandoc
+        sudo apt-get remove swig -y
+        sudo apt-get install swig3.0 -y
+        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+      displayName: Install apt packages
+    - task: Cache@2
+      inputs:
+        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        restoreKeys: | 
+          python | "$(Agent.OS)"
+          python
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+    - script: |
+        set -e
+        python -m pip install -U -r dependencies/setup.txt
+        python -m pip install -r dependencies/develop.txt
+        python -m pip install -r dependencies/required.txt
+        python -m pip install -r dependencies/recommended.txt
+        python -m pip install -r dependencies/required_extra.txt
+      displayName: Install requirements
+    - script: |
+        python test/vso_tools/interim_patch.py
+      displayName: Apply patch
+    - script: |
+        cd docs
+        python tools/chineselink.py check
+      displayName: Translation up-to-date
+    - script: |
+        cd docs/en_US
+        sphinx-build -M html . _build -W --keep-going -T
+      displayName: Sphinx  # TODO: rstcheck
+
+  - job: python
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+      displayName: Configure Python version
+    - script: |
+        sudo apt-get remove swig -y
+        sudo apt-get install swig3.0 -y
+        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+      displayName: Install apt packages
+    - task: Cache@2
+      inputs:
+        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        restoreKeys: | 
+          python | "$(Agent.OS)"
+          python
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+    - script: |
+        set -e
+        python -m pip install -U -r dependencies/setup.txt
+        python -m pip install -r dependencies/develop.txt
+        python -m pip install -r dependencies/required.txt
+        python -m pip install -r dependencies/recommended.txt
+        python -m pip install -r dependencies/required_extra.txt
+        python -m pip install "typing-extensions>=3.10"  # pylint requires newer typing extension. Override requirements in tensorflow
+      displayName: Install requirements
+    - script: python -m pylint --rcfile pylintrc nni
+      displayName: pylint
+    - script: |
+        set -e
+        python -m flake8 nni --count --select=E9,F63,F72,F82 --show-source --statistics
+        EXCLUDES=examples/trials/mnist-nas/*/mnist*.py,examples/trials/nas_cifar10/src/cifar10/general_child.py
+        python -m flake8 examples --count --exclude=$EXCLUDES --select=E9,F63,F72,F82 --show-source --statistics
+      displayName: flake8
+
+  - job: typescript
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+    steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 16.3.0
+      displayName: Configure Node.js version
+    - task: Cache@2
+      inputs:
+        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+        restoreKeys: |
+          yarn | "$(Agent.OS)"
+        path: $(YARN_CACHE_FOLDER)
+      displayName: Cache yarn packages
+    - script: |
+        set -e
+        cd ts/nni_manager
+        yarn
+        yarn eslint
+      displayName: ESLint (NNI Manager)
+    - script: |
+        set -e
+        cd ts/webui
+        yarn
+        yarn eslint
+      displayName: ESLint (WebUI)
 
 
 - stage: test
   jobs:
-    #  - job: ubuntu_latest
-    #    pool:
-    #      vmImage: ubuntu-latest
-    #    variables:
-    #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-    #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-    #
-    #    steps:
-    #    - task: UsePythonVersion@0
-    #      inputs:
-    #        versionSpec: 3.9
-    #      displayName: Configure Python version
-    #
-    #    - task: NodeTool@0
-    #      inputs:
-    #        versionSpec: 16.3.0
-    #      displayName: Configure Node.js version
-    #
-    #    - script: |
-    #        sudo apt-get install -y pandoc
-    #        sudo apt-get remove swig -y
-    #        sudo apt-get install swig3.0 -y
-    #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-    #      displayName: Install apt packages
-    #
-    #    - task: Cache@2
-    #      inputs:
-    #        key: 'python | "$(Agent.OS)" | latest | dependencies/*.txt'
-    #        restoreKeys: | 
-    #          python | "$(Agent.OS)"
-    #          python
-    #        path: $(PIP_CACHE_DIR)
-    #      displayName: Cache pip packages
-    #
-    #    - task: Cache@2
-    #      inputs:
-    #        key: 'yarn | "$(Agent.OS)" | latest | ts/**/yarn.lock, !**/node_modules/**'
-    #        restoreKeys: |
-    #          yarn | "$(Agent.OS)"
-    #        path: $(YARN_CACHE_FOLDER)
-    #      displayName: Cache yarn packages
-    #
-    #    - script: |
-    #        set -e
-    #        python -m pip install -U -r dependencies/setup.txt
-    #        python -m pip install -r dependencies/develop.txt
-    #        echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
-    #      displayName: Install Python tools
-    #
-    #    - script: |
-    #        python setup.py develop
-    #        mkdir -p coverage
-    #      displayName: Install NNI
-    #
-    #    - script: |
-    #        set -e
-    #        python -m pip install -r dependencies/recommended.txt
-    #        python -m pip install -e .[PPOTuner,DNGO]
-    #      displayName: Install extra dependencies
-    #
-    #    # Need del later
-    #    - script: |
-    #        python test/vso_tools/interim_patch.py
-    #      displayName: Torch utils tensorboard interim patch
-    #
-    #    - script: |
-    #        set -e
-    #        cd test
-    #        python -m pytest ut --cov-config=.coveragerc \
-    #          --ignore=ut/compression/v1/test_pruners.py \
-    #          --ignore=ut/compression/v1/test_compressor_tf.py \
-    #          --ignore=ut/compression/v1/test_compressor_torch.py \
-    #          --ignore=ut/compression/v1/test_model_speedup.py
-    #        python -m pytest ut/compression/v1/test_pruners.py --cov-config=.coveragerc --cov-append
-    #        python -m pytest ut/compression/v1/test_compressor_tf.py --cov-config=.coveragerc --cov-append
-    #        python -m pytest ut/compression/v1/test_compressor_torch.py --cov-config=.coveragerc --cov-append
-    #        python -m pytest ut/compression/v1/test_model_speedup.py --cov-config=.coveragerc --cov-append
-    #        cp coverage.xml ../coverage/python.xml
-    #      displayName: Python unit test
-    #
-    #    - script: |
-    #        set -e
-    #        cd ts/nni_manager
-    #        yarn test
-    #        cp coverage/cobertura-coverage.xml ../../coverage/typescript.xml
-    #      displayName: TypeScript unit test
-    #
-    #    - task: PublishTestResults@2
-    #      condition: succeededOrFailed()
-    #      inputs:
-    #        testResultsFiles: '$(System.DefaultWorkingDirectory)/**/test-*.xml'
-    #        testRunTitle: 'Publish test results for Python $(python.version)'
-    #      displayName: Publish test results
-    #
-    #    - task: PublishCodeCoverageResults@1
-    #      inputs:
-    #        codeCoverageTool: Cobertura
-    #        summaryFileLocation: coverage/*
-    #      displayName: Publish code coverage results
-    #
-    #    - script: |
-    #        cd test
-    #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-    #      displayName: Simple integration test
+  - job: ubuntu_latest
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+      displayName: Configure Python version
+
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 16.3.0
+      displayName: Configure Node.js version
+
+    - script: |
+        sudo apt-get install -y pandoc
+        sudo apt-get remove swig -y
+        sudo apt-get install swig3.0 -y
+        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+      displayName: Install apt packages
+
+    - task: Cache@2
+      inputs:
+        key: 'python | "$(Agent.OS)" | latest | dependencies/*.txt'
+        restoreKeys: | 
+          python | "$(Agent.OS)"
+          python
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+
+    - task: Cache@2
+      inputs:
+        key: 'yarn | "$(Agent.OS)" | latest | ts/**/yarn.lock, !**/node_modules/**'
+        restoreKeys: |
+          yarn | "$(Agent.OS)"
+        path: $(YARN_CACHE_FOLDER)
+      displayName: Cache yarn packages
+
+    - script: |
+        set -e
+        python -m pip install -U -r dependencies/setup.txt
+        python -m pip install -r dependencies/develop.txt
+        echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
+      displayName: Install Python tools
+
+    - script: |
+        python setup.py develop
+        mkdir -p coverage
+      displayName: Install NNI
+
+    - script: |
+        set -e
+        python -m pip install -r dependencies/recommended.txt
+        python -m pip install -e .[PPOTuner,DNGO]
+      displayName: Install extra dependencies
+
+    # Need del later
+    - script: |
+        python test/vso_tools/interim_patch.py
+      displayName: Torch utils tensorboard interim patch
+
+    - script: |
+        set -e
+        cd test
+        python -m pytest ut --cov-config=.coveragerc \
+          --ignore=ut/compression/v1/test_pruners.py \
+          --ignore=ut/compression/v1/test_compressor_tf.py \
+          --ignore=ut/compression/v1/test_compressor_torch.py \
+          --ignore=ut/compression/v1/test_model_speedup.py
+        python -m pytest ut/compression/v1/test_pruners.py --cov-config=.coveragerc --cov-append
+        python -m pytest ut/compression/v1/test_compressor_tf.py --cov-config=.coveragerc --cov-append
+        python -m pytest ut/compression/v1/test_compressor_torch.py --cov-config=.coveragerc --cov-append
+        python -m pytest ut/compression/v1/test_model_speedup.py --cov-config=.coveragerc --cov-append
+        cp coverage.xml ../coverage/python.xml
+      displayName: Python unit test
+
+    - script: |
+        set -e
+        cd ts/nni_manager
+        yarn test
+        cp coverage/cobertura-coverage.xml ../../coverage/typescript.xml
+      displayName: TypeScript unit test
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '$(System.DefaultWorkingDirectory)/**/test-*.xml'
+        testRunTitle: 'Publish test results for Python $(python.version)'
+      displayName: Publish test results
+
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: coverage/*
+      displayName: Publish code coverage results
+
+    - script: |
+        cd test
+        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+      displayName: Simple integration test
 
   - job: ubuntu_legacy
     pool:
@@ -273,35 +273,14 @@ stages:
         set -e
         cd dependencies
         python -m pip install -U -r setup.txt
-        # FIXME: due to pip's limitation ConfigSpaceNNI will not build without this
+        # FIXME: Version resolving is a complete mess. Now it works magically.
         python -m pip install numpy==1.21.5
-        # if we do not put them in one line, pip may implicitly downgrade previously installed packages
-        # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
-        echo '========================================'
-        echo '# 1'
-        python -m pip show numpy
-        echo '========================================'
         python -m pip install -r develop.txt
-        echo '========================================'
-        echo '# 2'
-        python -m pip show numpy
-        echo '========================================'
         python -m pip install -r required.txt
-        echo '========================================'
-        echo '# 3'
-        python -m pip show numpy
-        echo '========================================'
         python -m pip install -r required_extra.txt
-        echo '========================================'
-        echo '# 4'
-        python -m pip show numpy
-        echo '========================================'
         python -m pip install -r recommended_legacy.txt
-        echo '========================================'
-        echo '# 5'
-        python -m pip show numpy
         python -m pip install numpy==1.21.5
-        python -m pip show numpy
+        python -m pip install pytorch-lightning==1.5.9
         echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
       displayName: Install Python dependencies
 
@@ -334,158 +313,158 @@ stages:
         yarn test
       displayName: TypeScript unit test
 
-        #  - job: macos
-        #    pool:
-        #      vmImage: macOS-latest
-        #    variables:
-        #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-        #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-        #    timeoutInMinutes: 90  # macos test need extra time
-        #
-        #    steps:
-        #    - task: UsePythonVersion@0
-        #      inputs:
-        #        versionSpec: 3.9
-        #      displayName: Configure Python version
-        #
-        #    - task: NodeTool@0
-        #      inputs:
-        #        versionSpec: 16.3.0
-        #      displayName: Configure Node.js version
-        #
-        #    - script: |
-        #        brew install swig@3
-        #        rm -f /usr/local/bin/swig
-        #        ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
-        #      displayName: Install brew packages
-        #
-        #    - task: Cache@2
-        #      inputs:
-        #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        #        restoreKeys: | 
-        #          python | "$(Agent.OS)"
-        #          python
-        #        path: $(PIP_CACHE_DIR)
-        #      displayName: Cache pip packages
-        #
-        #    - task: Cache@2
-        #      inputs:
-        #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-        #        restoreKeys: |
-        #          yarn | "$(Agent.OS)"
-        #        path: $(YARN_CACHE_FOLDER)
-        #      displayName: Cache yarn packages
-        #
-        #    - script: |
-        #        set -e
-        #        python -m pip install -U -r dependencies/setup.txt
-        #        python -m pip install -r dependencies/develop.txt
-        #        echo "##vso[task.setvariable variable=PATH]${PATH}:${HOME}/.local/bin"
-        #      displayName: Install Python tools
-        #
-        #    - script: |
-        #        python setup.py develop
-        #      displayName: Install NNI
-        #
-        #    - script: |
-        #        set -e
-        #        export CI=true
-        #        (cd ts/nni_manager && yarn test --exclude test/core/nnimanager.test.ts)
-        #      displayName: TypeScript unit test
-        #
-        #    - script: |
-        #        set -e
-        #        python -m pip install -r dependencies/recommended.txt
-        #        python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
-        #      displayName: Install extra dependencies
-        #
-        #    # Need del later
-        #    - script: |
-        #        set -e
-        #        python test/vso_tools/interim_patch.py
-        #      displayName: Torch utils tensorboard interim patch
-        #
-        #    - script: |
-        #        cd test
-        #        python -m pytest ut
-        #      displayName: Python unit test
-        #
-        #    - script: |
-        #        cd test
-        #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-        #      displayName: Simple integration test
-        #
-        #  - job: windows
-        #    pool:
-        #      vmImage: windows-latest
-        #    variables:
-        #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-        #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-        #    timeoutInMinutes: 120  # windows test need extra time
-        #
-        #    steps:
-        #    - task: UsePythonVersion@0
-        #      inputs:
-        #        versionSpec: 3.9
-        #      displayName: Configure Python version
-        #
-        #    - task: NodeTool@0
-        #      inputs:
-        #        versionSpec: 16.3.0
-        #      displayName: Configure Node.js version
-        #
-        #    - task: Cache@2
-        #      inputs:
-        #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        #        restoreKeys: | 
-        #          python | "$(Agent.OS)"
-        #          python
-        #        path: $(PIP_CACHE_DIR)
-        #      displayName: Cache pip packages
-        #
-        #    - task: Cache@2
-        #      inputs:
-        #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-        #        restoreKeys: |
-        #          yarn | "$(Agent.OS)"
-        #        path: $(YARN_CACHE_FOLDER)
-        #      displayName: Cache yarn packages
-        #
-        #    - script: |
-        #        set -e
-        #        python -m pip install -U -r dependencies/setup.txt
-        #        python -m pip install -r dependencies/develop.txt
-        #      displayName: Install Python tools
-        #
-        #    - script: |
-        #        python setup.py develop --no-user
-        #      displayName: Install NNI
-        #
-        #    - script: |
-        #        python -m pip install -r dependencies/recommended.txt
-        #        python -m pip install -e .[DNGO]
-        #      displayName: Install extra dependencies
-        #
-        #    # Need del later
-        #    - script: |
-        #        set -e
-        #        python test/vso_tools/interim_patch.py
-        #      displayName: Torch utils tensorboard interim patch
-        #
-        #    - script: |
-        #        cd test
-        #        python -m pytest ut
-        #      displayName: Python unit test
-        #
-        #    - script: |
-        #        cd ts/nni_manager
-        #        yarn test
-        #      displayName: TypeScript unit test
-        #
-        #    - script: |
-        #        cd test
-        #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-        #      displayName: Simple integration test
+  - job: macos
+    pool:
+      vmImage: macOS-latest
+    variables:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+    timeoutInMinutes: 90  # macos test need extra time
+
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+      displayName: Configure Python version
+
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 16.3.0
+      displayName: Configure Node.js version
+
+    - script: |
+        brew install swig@3
+        rm -f /usr/local/bin/swig
+        ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
+      displayName: Install brew packages
+
+    - task: Cache@2
+      inputs:
+        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        restoreKeys: | 
+          python | "$(Agent.OS)"
+          python
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+
+    - task: Cache@2
+      inputs:
+        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+        restoreKeys: |
+          yarn | "$(Agent.OS)"
+        path: $(YARN_CACHE_FOLDER)
+      displayName: Cache yarn packages
+
+    - script: |
+        set -e
+        python -m pip install -U -r dependencies/setup.txt
+        python -m pip install -r dependencies/develop.txt
+        echo "##vso[task.setvariable variable=PATH]${PATH}:${HOME}/.local/bin"
+      displayName: Install Python tools
+
+    - script: |
+        python setup.py develop
+      displayName: Install NNI
+
+    - script: |
+        set -e
+        export CI=true
+        (cd ts/nni_manager && yarn test --exclude test/core/nnimanager.test.ts)
+      displayName: TypeScript unit test
+
+    - script: |
+        set -e
+        python -m pip install -r dependencies/recommended.txt
+        python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
+      displayName: Install extra dependencies
+
+    # Need del later
+    - script: |
+        set -e
+        python test/vso_tools/interim_patch.py
+      displayName: Torch utils tensorboard interim patch
+
+    - script: |
+        cd test
+        python -m pytest ut
+      displayName: Python unit test
+
+    - script: |
+        cd test
+        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+      displayName: Simple integration test
+
+  - job: windows
+    pool:
+      vmImage: windows-latest
+    variables:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+    timeoutInMinutes: 120  # windows test need extra time
+
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+      displayName: Configure Python version
+
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 16.3.0
+      displayName: Configure Node.js version
+
+    - task: Cache@2
+      inputs:
+        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        restoreKeys: | 
+          python | "$(Agent.OS)"
+          python
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+
+    - task: Cache@2
+      inputs:
+        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+        restoreKeys: |
+          yarn | "$(Agent.OS)"
+        path: $(YARN_CACHE_FOLDER)
+      displayName: Cache yarn packages
+
+    - script: |
+        set -e
+        python -m pip install -U -r dependencies/setup.txt
+        python -m pip install -r dependencies/develop.txt
+      displayName: Install Python tools
+
+    - script: |
+        python setup.py develop --no-user
+      displayName: Install NNI
+
+    - script: |
+        python -m pip install -r dependencies/recommended.txt
+        python -m pip install -e .[DNGO]
+      displayName: Install extra dependencies
+
+    # Need del later
+    - script: |
+        set -e
+        python test/vso_tools/interim_patch.py
+      displayName: Torch utils tensorboard interim patch
+
+    - script: |
+        cd test
+        python -m pytest ut
+      displayName: Python unit test
+
+    - script: |
+        cd ts/nni_manager
+        yarn test
+      displayName: TypeScript unit test
+
+    - script: |
+        cd test
+        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+      displayName: Simple integration test
 
 
 trigger:

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -273,7 +273,7 @@ stages:
         set -e
         python -m pip install -U -r dependencies/setup.txt
         python -m pip install -r dependencies/develop.txt
-        # setuptools develop is buggy and it's safer to install dependencies manually
+        # setuptools "develop" mode is buggy and it's safer to install dependencies manually
         python -m pip install -r dependencies/required.txt
         python -m pip install -r dependencies/required_extra.txt
         python -m pip install -r dependencies/recommended_legacy.txt
@@ -311,7 +311,7 @@ stages:
 
   - job: macos
     pool:
-      vmImage: macOS-10.15
+      vmImage: macOS-latest
     variables:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
       YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
@@ -392,7 +392,7 @@ stages:
 
   - job: windows
     pool:
-      vmImage: windows-2019
+      vmImage: windows-latest
     variables:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
       YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -12,7 +12,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
       displayName: Configure Python version
     - script: |
         sudo apt-get install -y pandoc
@@ -56,7 +56,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
       displayName: Configure Python version
     - script: |
         sudo apt-get remove swig -y
@@ -237,7 +237,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.6
+        versionSpec: 3.7
       displayName: Configure Python version
 
     - task: NodeTool@0
@@ -322,7 +322,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
       displayName: Configure Python version
 
     - task: NodeTool@0
@@ -403,7 +403,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
       displayName: Configure Python version
 
     - task: NodeTool@0

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -273,18 +273,16 @@ stages:
         set -e
         python -m pip install -U -r dependencies/setup.txt
         python -m pip install -r dependencies/develop.txt
+        # setuptools develop is buggy and it's safer to install dependencies manually
+        python -m pip install -r dependencies/required.txt
+        python -m pip install -r dependencies/required_extra.txt
+        python -m pip install -r dependencies/recommended_legacy.txt
         echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
-      displayName: Install Python tools
+      displayName: Install Python dependencies
 
     - script: |
         python setup.py develop
       displayName: Install NNI
-
-    - script: |
-        set -e
-        python -m pip install -r dependencies/recommended_legacy.txt
-        python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
-      displayName: Install extra dependencies
 
     # Need del later
     - script: |

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -273,6 +273,8 @@ stages:
         set -e
         cd dependencies
         python -m pip install -U -r setup.txt
+        # FIXME: due to pip's limitation ConfigSpaceNNI will not build without this
+        python -m pip install numpy<1.22
         # if we do not put them in one line, pip may implicitly downgrade previously installed packages
         # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
         python -m pip install -r develop.txt -r required.txt -r required_extra.txt -r recommended_legacy.txt

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -271,12 +271,11 @@ stages:
 
     - script: |
         set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-        # setuptools "develop" mode is buggy and it's safer to install dependencies manually
-        python -m pip install -r dependencies/required.txt
-        python -m pip install -r dependencies/required_extra.txt
-        python -m pip install -r dependencies/recommended_legacy.txt
+        cd dependencies
+        python -m pip install -U -r setup.txt
+        # if we do not put them in one line, pip may implicitly downgrade previously installed packages
+        # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
+        python -m pip install -r develop.txt -r required.txt -r required_extra.txt -r recommended_legacy.txt
         echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
       displayName: Install Python dependencies
 

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -2,230 +2,230 @@
 # so that a bug in any module will cause at least one platform to fail quickly.
 
 stages:
-- stage: lint
-  jobs:
-  - job: docs
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.9
-      displayName: Configure Python version
-    - script: |
-        sudo apt-get install -y pandoc
-        sudo apt-get remove swig -y
-        sudo apt-get install swig3.0 -y
-        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-      displayName: Install apt packages
-    - task: Cache@2
-      inputs:
-        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        restoreKeys: | 
-          python | "$(Agent.OS)"
-          python
-        path: $(PIP_CACHE_DIR)
-      displayName: Cache pip packages
-    - script: |
-        set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-        python -m pip install -r dependencies/required.txt
-        python -m pip install -r dependencies/recommended.txt
-        python -m pip install -r dependencies/required_extra.txt
-      displayName: Install requirements
-    - script: |
-        python test/vso_tools/interim_patch.py
-      displayName: Apply patch
-    - script: |
-        cd docs
-        python tools/chineselink.py check
-      displayName: Translation up-to-date
-    - script: |
-        cd docs/en_US
-        sphinx-build -M html . _build -W --keep-going -T
-      displayName: Sphinx  # TODO: rstcheck
-
-  - job: python
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.9
-      displayName: Configure Python version
-    - script: |
-        sudo apt-get remove swig -y
-        sudo apt-get install swig3.0 -y
-        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-      displayName: Install apt packages
-    - task: Cache@2
-      inputs:
-        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        restoreKeys: | 
-          python | "$(Agent.OS)"
-          python
-        path: $(PIP_CACHE_DIR)
-      displayName: Cache pip packages
-    - script: |
-        set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-        python -m pip install -r dependencies/required.txt
-        python -m pip install -r dependencies/recommended.txt
-        python -m pip install -r dependencies/required_extra.txt
-        python -m pip install "typing-extensions>=3.10"  # pylint requires newer typing extension. Override requirements in tensorflow
-      displayName: Install requirements
-    - script: python -m pylint --rcfile pylintrc nni
-      displayName: pylint
-    - script: |
-        set -e
-        python -m flake8 nni --count --select=E9,F63,F72,F82 --show-source --statistics
-        EXCLUDES=examples/trials/mnist-nas/*/mnist*.py,examples/trials/nas_cifar10/src/cifar10/general_child.py
-        python -m flake8 examples --count --exclude=$EXCLUDES --select=E9,F63,F72,F82 --show-source --statistics
-      displayName: flake8
-
-  - job: typescript
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-    steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: 16.3.0
-      displayName: Configure Node.js version
-    - task: Cache@2
-      inputs:
-        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-        restoreKeys: |
-          yarn | "$(Agent.OS)"
-        path: $(YARN_CACHE_FOLDER)
-      displayName: Cache yarn packages
-    - script: |
-        set -e
-        cd ts/nni_manager
-        yarn
-        yarn eslint
-      displayName: ESLint (NNI Manager)
-    - script: |
-        set -e
-        cd ts/webui
-        yarn
-        yarn eslint
-      displayName: ESLint (WebUI)
+  #- stage: lint
+  #  jobs:
+  #  - job: docs
+  #    pool:
+  #      vmImage: ubuntu-latest
+  #    variables:
+  #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+  #    steps:
+  #    - task: UsePythonVersion@0
+  #      inputs:
+  #        versionSpec: 3.9
+  #      displayName: Configure Python version
+  #    - script: |
+  #        sudo apt-get install -y pandoc
+  #        sudo apt-get remove swig -y
+  #        sudo apt-get install swig3.0 -y
+  #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+  #      displayName: Install apt packages
+  #    - task: Cache@2
+  #      inputs:
+  #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+  #        restoreKeys: | 
+  #          python | "$(Agent.OS)"
+  #          python
+  #        path: $(PIP_CACHE_DIR)
+  #      displayName: Cache pip packages
+  #    - script: |
+  #        set -e
+  #        python -m pip install -U -r dependencies/setup.txt
+  #        python -m pip install -r dependencies/develop.txt
+  #        python -m pip install -r dependencies/required.txt
+  #        python -m pip install -r dependencies/recommended.txt
+  #        python -m pip install -r dependencies/required_extra.txt
+  #      displayName: Install requirements
+  #    - script: |
+  #        python test/vso_tools/interim_patch.py
+  #      displayName: Apply patch
+  #    - script: |
+  #        cd docs
+  #        python tools/chineselink.py check
+  #      displayName: Translation up-to-date
+  #    - script: |
+  #        cd docs/en_US
+  #        sphinx-build -M html . _build -W --keep-going -T
+  #      displayName: Sphinx  # TODO: rstcheck
+  #
+  #  - job: python
+  #    pool:
+  #      vmImage: ubuntu-latest
+  #    variables:
+  #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+  #    steps:
+  #    - task: UsePythonVersion@0
+  #      inputs:
+  #        versionSpec: 3.9
+  #      displayName: Configure Python version
+  #    - script: |
+  #        sudo apt-get remove swig -y
+  #        sudo apt-get install swig3.0 -y
+  #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+  #      displayName: Install apt packages
+  #    - task: Cache@2
+  #      inputs:
+  #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+  #        restoreKeys: | 
+  #          python | "$(Agent.OS)"
+  #          python
+  #        path: $(PIP_CACHE_DIR)
+  #      displayName: Cache pip packages
+  #    - script: |
+  #        set -e
+  #        python -m pip install -U -r dependencies/setup.txt
+  #        python -m pip install -r dependencies/develop.txt
+  #        python -m pip install -r dependencies/required.txt
+  #        python -m pip install -r dependencies/recommended.txt
+  #        python -m pip install -r dependencies/required_extra.txt
+  #        python -m pip install "typing-extensions>=3.10"  # pylint requires newer typing extension. Override requirements in tensorflow
+  #      displayName: Install requirements
+  #    - script: python -m pylint --rcfile pylintrc nni
+  #      displayName: pylint
+  #    - script: |
+  #        set -e
+  #        python -m flake8 nni --count --select=E9,F63,F72,F82 --show-source --statistics
+  #        EXCLUDES=examples/trials/mnist-nas/*/mnist*.py,examples/trials/nas_cifar10/src/cifar10/general_child.py
+  #        python -m flake8 examples --count --exclude=$EXCLUDES --select=E9,F63,F72,F82 --show-source --statistics
+  #      displayName: flake8
+  #
+  #  - job: typescript
+  #    pool:
+  #      vmImage: ubuntu-latest
+  #    variables:
+  #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+  #    steps:
+  #    - task: NodeTool@0
+  #      inputs:
+  #        versionSpec: 16.3.0
+  #      displayName: Configure Node.js version
+  #    - task: Cache@2
+  #      inputs:
+  #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+  #        restoreKeys: |
+  #          yarn | "$(Agent.OS)"
+  #        path: $(YARN_CACHE_FOLDER)
+  #      displayName: Cache yarn packages
+  #    - script: |
+  #        set -e
+  #        cd ts/nni_manager
+  #        yarn
+  #        yarn eslint
+  #      displayName: ESLint (NNI Manager)
+  #    - script: |
+  #        set -e
+  #        cd ts/webui
+  #        yarn
+  #        yarn eslint
+  #      displayName: ESLint (WebUI)
 
 
 - stage: test
   jobs:
-  - job: ubuntu_latest
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.9
-      displayName: Configure Python version
-
-    - task: NodeTool@0
-      inputs:
-        versionSpec: 16.3.0
-      displayName: Configure Node.js version
-
-    - script: |
-        sudo apt-get install -y pandoc
-        sudo apt-get remove swig -y
-        sudo apt-get install swig3.0 -y
-        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
-      displayName: Install apt packages
-
-    - task: Cache@2
-      inputs:
-        key: 'python | "$(Agent.OS)" | latest | dependencies/*.txt'
-        restoreKeys: | 
-          python | "$(Agent.OS)"
-          python
-        path: $(PIP_CACHE_DIR)
-      displayName: Cache pip packages
-
-    - task: Cache@2
-      inputs:
-        key: 'yarn | "$(Agent.OS)" | latest | ts/**/yarn.lock, !**/node_modules/**'
-        restoreKeys: |
-          yarn | "$(Agent.OS)"
-        path: $(YARN_CACHE_FOLDER)
-      displayName: Cache yarn packages
-
-    - script: |
-        set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-        echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
-      displayName: Install Python tools
-
-    - script: |
-        python setup.py develop
-        mkdir -p coverage
-      displayName: Install NNI
-
-    - script: |
-        set -e
-        python -m pip install -r dependencies/recommended.txt
-        python -m pip install -e .[PPOTuner,DNGO]
-      displayName: Install extra dependencies
-
-    # Need del later
-    - script: |
-        python test/vso_tools/interim_patch.py
-      displayName: Torch utils tensorboard interim patch
-
-    - script: |
-        set -e
-        cd test
-        python -m pytest ut --cov-config=.coveragerc \
-          --ignore=ut/compression/v1/test_pruners.py \
-          --ignore=ut/compression/v1/test_compressor_tf.py \
-          --ignore=ut/compression/v1/test_compressor_torch.py \
-          --ignore=ut/compression/v1/test_model_speedup.py
-        python -m pytest ut/compression/v1/test_pruners.py --cov-config=.coveragerc --cov-append
-        python -m pytest ut/compression/v1/test_compressor_tf.py --cov-config=.coveragerc --cov-append
-        python -m pytest ut/compression/v1/test_compressor_torch.py --cov-config=.coveragerc --cov-append
-        python -m pytest ut/compression/v1/test_model_speedup.py --cov-config=.coveragerc --cov-append
-        cp coverage.xml ../coverage/python.xml
-      displayName: Python unit test
-
-    - script: |
-        set -e
-        cd ts/nni_manager
-        yarn test
-        cp coverage/cobertura-coverage.xml ../../coverage/typescript.xml
-      displayName: TypeScript unit test
-
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFiles: '$(System.DefaultWorkingDirectory)/**/test-*.xml'
-        testRunTitle: 'Publish test results for Python $(python.version)'
-      displayName: Publish test results
-
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: coverage/*
-      displayName: Publish code coverage results
-
-    - script: |
-        cd test
-        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-      displayName: Simple integration test
+    #  - job: ubuntu_latest
+    #    pool:
+    #      vmImage: ubuntu-latest
+    #    variables:
+    #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+    #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+    #
+    #    steps:
+    #    - task: UsePythonVersion@0
+    #      inputs:
+    #        versionSpec: 3.9
+    #      displayName: Configure Python version
+    #
+    #    - task: NodeTool@0
+    #      inputs:
+    #        versionSpec: 16.3.0
+    #      displayName: Configure Node.js version
+    #
+    #    - script: |
+    #        sudo apt-get install -y pandoc
+    #        sudo apt-get remove swig -y
+    #        sudo apt-get install swig3.0 -y
+    #        sudo ln -s /usr/bin/swig3.0 /usr/bin/swig
+    #      displayName: Install apt packages
+    #
+    #    - task: Cache@2
+    #      inputs:
+    #        key: 'python | "$(Agent.OS)" | latest | dependencies/*.txt'
+    #        restoreKeys: | 
+    #          python | "$(Agent.OS)"
+    #          python
+    #        path: $(PIP_CACHE_DIR)
+    #      displayName: Cache pip packages
+    #
+    #    - task: Cache@2
+    #      inputs:
+    #        key: 'yarn | "$(Agent.OS)" | latest | ts/**/yarn.lock, !**/node_modules/**'
+    #        restoreKeys: |
+    #          yarn | "$(Agent.OS)"
+    #        path: $(YARN_CACHE_FOLDER)
+    #      displayName: Cache yarn packages
+    #
+    #    - script: |
+    #        set -e
+    #        python -m pip install -U -r dependencies/setup.txt
+    #        python -m pip install -r dependencies/develop.txt
+    #        echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
+    #      displayName: Install Python tools
+    #
+    #    - script: |
+    #        python setup.py develop
+    #        mkdir -p coverage
+    #      displayName: Install NNI
+    #
+    #    - script: |
+    #        set -e
+    #        python -m pip install -r dependencies/recommended.txt
+    #        python -m pip install -e .[PPOTuner,DNGO]
+    #      displayName: Install extra dependencies
+    #
+    #    # Need del later
+    #    - script: |
+    #        python test/vso_tools/interim_patch.py
+    #      displayName: Torch utils tensorboard interim patch
+    #
+    #    - script: |
+    #        set -e
+    #        cd test
+    #        python -m pytest ut --cov-config=.coveragerc \
+    #          --ignore=ut/compression/v1/test_pruners.py \
+    #          --ignore=ut/compression/v1/test_compressor_tf.py \
+    #          --ignore=ut/compression/v1/test_compressor_torch.py \
+    #          --ignore=ut/compression/v1/test_model_speedup.py
+    #        python -m pytest ut/compression/v1/test_pruners.py --cov-config=.coveragerc --cov-append
+    #        python -m pytest ut/compression/v1/test_compressor_tf.py --cov-config=.coveragerc --cov-append
+    #        python -m pytest ut/compression/v1/test_compressor_torch.py --cov-config=.coveragerc --cov-append
+    #        python -m pytest ut/compression/v1/test_model_speedup.py --cov-config=.coveragerc --cov-append
+    #        cp coverage.xml ../coverage/python.xml
+    #      displayName: Python unit test
+    #
+    #    - script: |
+    #        set -e
+    #        cd ts/nni_manager
+    #        yarn test
+    #        cp coverage/cobertura-coverage.xml ../../coverage/typescript.xml
+    #      displayName: TypeScript unit test
+    #
+    #    - task: PublishTestResults@2
+    #      condition: succeededOrFailed()
+    #      inputs:
+    #        testResultsFiles: '$(System.DefaultWorkingDirectory)/**/test-*.xml'
+    #        testRunTitle: 'Publish test results for Python $(python.version)'
+    #      displayName: Publish test results
+    #
+    #    - task: PublishCodeCoverageResults@1
+    #      inputs:
+    #        codeCoverageTool: Cobertura
+    #        summaryFileLocation: coverage/*
+    #      displayName: Publish code coverage results
+    #
+    #    - script: |
+    #        cd test
+    #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+    #      displayName: Simple integration test
 
   - job: ubuntu_legacy
     pool:
@@ -277,7 +277,29 @@ stages:
         python -m pip install 'numpy<1.22'
         # if we do not put them in one line, pip may implicitly downgrade previously installed packages
         # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
-        python -m pip install -r develop.txt -r required.txt -r required_extra.txt -r recommended_legacy.txt
+        echo '========================================'
+        echo '# 1'
+        python -m pip show numpy
+        echo '========================================'
+        python -m pip install -r develop.txt
+        echo '========================================'
+        echo '# 2'
+        python -m pip show numpy
+        echo '========================================'
+        python -m pip install -r required.txt
+        echo '========================================'
+        echo '# 3'
+        python -m pip show numpy
+        echo '========================================'
+        python -m pip install -r required_extra.txt
+        echo '========================================'
+        echo '# 4'
+        python -m pip show numpy
+        echo '========================================'
+        python -m pip install -r recommended_legacy.txt
+        echo '========================================'
+        echo '# 5'
+        python -m pip show numpy
         echo "##vso[task.setvariable variable=PATH]${HOME}/.local/bin:${PATH}"
       displayName: Install Python dependencies
 
@@ -310,158 +332,158 @@ stages:
         yarn test
       displayName: TypeScript unit test
 
-  - job: macos
-    pool:
-      vmImage: macOS-latest
-    variables:
-      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-    timeoutInMinutes: 90  # macos test need extra time
-
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.9
-      displayName: Configure Python version
-
-    - task: NodeTool@0
-      inputs:
-        versionSpec: 16.3.0
-      displayName: Configure Node.js version
-
-    - script: |
-        brew install swig@3
-        rm -f /usr/local/bin/swig
-        ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
-      displayName: Install brew packages
-
-    - task: Cache@2
-      inputs:
-        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        restoreKeys: | 
-          python | "$(Agent.OS)"
-          python
-        path: $(PIP_CACHE_DIR)
-      displayName: Cache pip packages
-
-    - task: Cache@2
-      inputs:
-        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-        restoreKeys: |
-          yarn | "$(Agent.OS)"
-        path: $(YARN_CACHE_FOLDER)
-      displayName: Cache yarn packages
-
-    - script: |
-        set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-        echo "##vso[task.setvariable variable=PATH]${PATH}:${HOME}/.local/bin"
-      displayName: Install Python tools
-
-    - script: |
-        python setup.py develop
-      displayName: Install NNI
-
-    - script: |
-        set -e
-        export CI=true
-        (cd ts/nni_manager && yarn test --exclude test/core/nnimanager.test.ts)
-      displayName: TypeScript unit test
-
-    - script: |
-        set -e
-        python -m pip install -r dependencies/recommended.txt
-        python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
-      displayName: Install extra dependencies
-
-    # Need del later
-    - script: |
-        set -e
-        python test/vso_tools/interim_patch.py
-      displayName: Torch utils tensorboard interim patch
-
-    - script: |
-        cd test
-        python -m pytest ut
-      displayName: Python unit test
-
-    - script: |
-        cd test
-        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-      displayName: Simple integration test
-
-  - job: windows
-    pool:
-      vmImage: windows-latest
-    variables:
-      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-    timeoutInMinutes: 120  # windows test need extra time
-
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.9
-      displayName: Configure Python version
-
-    - task: NodeTool@0
-      inputs:
-        versionSpec: 16.3.0
-      displayName: Configure Node.js version
-
-    - task: Cache@2
-      inputs:
-        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
-        restoreKeys: | 
-          python | "$(Agent.OS)"
-          python
-        path: $(PIP_CACHE_DIR)
-      displayName: Cache pip packages
-
-    - task: Cache@2
-      inputs:
-        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
-        restoreKeys: |
-          yarn | "$(Agent.OS)"
-        path: $(YARN_CACHE_FOLDER)
-      displayName: Cache yarn packages
-
-    - script: |
-        set -e
-        python -m pip install -U -r dependencies/setup.txt
-        python -m pip install -r dependencies/develop.txt
-      displayName: Install Python tools
-
-    - script: |
-        python setup.py develop --no-user
-      displayName: Install NNI
-
-    - script: |
-        python -m pip install -r dependencies/recommended.txt
-        python -m pip install -e .[DNGO]
-      displayName: Install extra dependencies
-
-    # Need del later
-    - script: |
-        set -e
-        python test/vso_tools/interim_patch.py
-      displayName: Torch utils tensorboard interim patch
-
-    - script: |
-        cd test
-        python -m pytest ut
-      displayName: Python unit test
-
-    - script: |
-        cd ts/nni_manager
-        yarn test
-      displayName: TypeScript unit test
-
-    - script: |
-        cd test
-        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
-      displayName: Simple integration test
+        #  - job: macos
+        #    pool:
+        #      vmImage: macOS-latest
+        #    variables:
+        #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+        #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+        #    timeoutInMinutes: 90  # macos test need extra time
+        #
+        #    steps:
+        #    - task: UsePythonVersion@0
+        #      inputs:
+        #        versionSpec: 3.9
+        #      displayName: Configure Python version
+        #
+        #    - task: NodeTool@0
+        #      inputs:
+        #        versionSpec: 16.3.0
+        #      displayName: Configure Node.js version
+        #
+        #    - script: |
+        #        brew install swig@3
+        #        rm -f /usr/local/bin/swig
+        #        ln -s /usr/local/opt/swig\@3/bin/swig /usr/local/bin/swig
+        #      displayName: Install brew packages
+        #
+        #    - task: Cache@2
+        #      inputs:
+        #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        #        restoreKeys: | 
+        #          python | "$(Agent.OS)"
+        #          python
+        #        path: $(PIP_CACHE_DIR)
+        #      displayName: Cache pip packages
+        #
+        #    - task: Cache@2
+        #      inputs:
+        #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+        #        restoreKeys: |
+        #          yarn | "$(Agent.OS)"
+        #        path: $(YARN_CACHE_FOLDER)
+        #      displayName: Cache yarn packages
+        #
+        #    - script: |
+        #        set -e
+        #        python -m pip install -U -r dependencies/setup.txt
+        #        python -m pip install -r dependencies/develop.txt
+        #        echo "##vso[task.setvariable variable=PATH]${PATH}:${HOME}/.local/bin"
+        #      displayName: Install Python tools
+        #
+        #    - script: |
+        #        python setup.py develop
+        #      displayName: Install NNI
+        #
+        #    - script: |
+        #        set -e
+        #        export CI=true
+        #        (cd ts/nni_manager && yarn test --exclude test/core/nnimanager.test.ts)
+        #      displayName: TypeScript unit test
+        #
+        #    - script: |
+        #        set -e
+        #        python -m pip install -r dependencies/recommended.txt
+        #        python -m pip install -e .[SMAC,BOHB,PPOTuner,DNGO]
+        #      displayName: Install extra dependencies
+        #
+        #    # Need del later
+        #    - script: |
+        #        set -e
+        #        python test/vso_tools/interim_patch.py
+        #      displayName: Torch utils tensorboard interim patch
+        #
+        #    - script: |
+        #        cd test
+        #        python -m pytest ut
+        #      displayName: Python unit test
+        #
+        #    - script: |
+        #        cd test
+        #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+        #      displayName: Simple integration test
+        #
+        #  - job: windows
+        #    pool:
+        #      vmImage: windows-latest
+        #    variables:
+        #      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+        #      YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+        #    timeoutInMinutes: 120  # windows test need extra time
+        #
+        #    steps:
+        #    - task: UsePythonVersion@0
+        #      inputs:
+        #        versionSpec: 3.9
+        #      displayName: Configure Python version
+        #
+        #    - task: NodeTool@0
+        #      inputs:
+        #        versionSpec: 16.3.0
+        #      displayName: Configure Node.js version
+        #
+        #    - task: Cache@2
+        #      inputs:
+        #        key: 'python | "$(Agent.OS)" | dependencies/*.txt'
+        #        restoreKeys: | 
+        #          python | "$(Agent.OS)"
+        #          python
+        #        path: $(PIP_CACHE_DIR)
+        #      displayName: Cache pip packages
+        #
+        #    - task: Cache@2
+        #      inputs:
+        #        key: 'yarn | "$(Agent.OS)" | ts/**/yarn.lock, !**/node_modules/**'
+        #        restoreKeys: |
+        #          yarn | "$(Agent.OS)"
+        #        path: $(YARN_CACHE_FOLDER)
+        #      displayName: Cache yarn packages
+        #
+        #    - script: |
+        #        set -e
+        #        python -m pip install -U -r dependencies/setup.txt
+        #        python -m pip install -r dependencies/develop.txt
+        #      displayName: Install Python tools
+        #
+        #    - script: |
+        #        python setup.py develop --no-user
+        #      displayName: Install NNI
+        #
+        #    - script: |
+        #        python -m pip install -r dependencies/recommended.txt
+        #        python -m pip install -e .[DNGO]
+        #      displayName: Install extra dependencies
+        #
+        #    # Need del later
+        #    - script: |
+        #        set -e
+        #        python test/vso_tools/interim_patch.py
+        #      displayName: Torch utils tensorboard interim patch
+        #
+        #    - script: |
+        #        cd test
+        #        python -m pytest ut
+        #      displayName: Python unit test
+        #
+        #    - script: |
+        #        cd ts/nni_manager
+        #        yarn test
+        #      displayName: TypeScript unit test
+        #
+        #    - script: |
+        #        cd test
+        #        python nni_test/nnitest/run_tests.py --config config/pr_tests.yml
+        #      displayName: Simple integration test
 
 
 trigger:

--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -274,7 +274,7 @@ stages:
         cd dependencies
         python -m pip install -U -r setup.txt
         # FIXME: due to pip's limitation ConfigSpaceNNI will not build without this
-        python -m pip install numpy<1.22
+        python -m pip install 'numpy<1.22'
         # if we do not put them in one line, pip may implicitly downgrade previously installed packages
         # this caused ConfigSpaceNNI to have incompatible numpy versions at compile-time and runtime
         python -m pip install -r develop.txt -r required.txt -r required_extra.txt -r recommended_legacy.txt

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ def _setup():
 
         data_files = _get_data_files(),
 
-        python_requires = '>=3.6',
+        python_requires = '>=3.7',
         install_requires = _read_requirements_txt('dependencies/required.txt'),
         extras_require = {
             'SMAC': _read_requirements_txt('dependencies/required_extra.txt', 'SMAC'),


### PR DESCRIPTION
### Description ###

Python 3.6 is dead.
PyTorch has not yet supported Python 3.10.

Need to upgrade Python on k8s IT client node.

Version resolving of Python packages on ubuntu-legacy is a complete mess now.
This will be fixed with [cache refactor](https://github.com/microsoft/nni/tree/dev-pipeline-cache).

### Checklist ###
  - ~~test case~~
  - ~~doc~~

### How to test ###

No need.