### PR TITLE
fix TrialsDetail className typo

### DIFF
--- a/ts/webui/src/components/TrialsDetail.tsx
+++ b/ts/webui/src/components/TrialsDetail.tsx
@@ -45,7 +45,7 @@ class TrialsDetail extends React.Component<{}, TrialDetailState> {
                         <div className='trial' id='tabsty'>
                             <Pivot
                                 defaultSelectedKey={'0'}
-                                className='detial-title'
+                                className='detail-title'
                                 onLinkClick={this.handleWhichTabs}
                                 selectedKey={whichChart}
                             >

--- a/ts/webui/src/static/style/trialsDetail.scss
+++ b/ts/webui/src/static/style/trialsDetail.scss
@@ -114,7 +114,7 @@
     }
 }
 
-.detial-title {
+.detail-title {
     .ms-Button {
         i {
             font-size: 22px;


### PR DESCRIPTION
### Description ###
rename Pivot's className inside `TrialsDetail` to `detail-title`


### Checklist ###
  - [x] test case:  visit `/detail` on Web UI, check TrialsDetail component and its style.
  - [x] doc: N/A

### How to test ###

1. create a local trial example: `nnictl create --config nni/examples/trials/mnist-pytorch/config.yml`
2. go to http://127.0.0.1:8080/detail
3. check component style
