### PR TITLE
[Model Compression] attention mode

### DIFF
--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -184,6 +184,11 @@ class NormPruner(BasicPruner):
         harvest the speed benefit from the pruned model. Note that, if set 'dependency_aware'
         , the dummy_input cannot be None, because the pruner needs a dummy input to trace the
         dependency between the conv layers.
+
+        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
+        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
+        In this mode, NNI will find these three Linear layers in each attention,
+        then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.
@@ -245,6 +250,11 @@ class L1NormPruner(NormPruner):
         harvest the speed benefit from the pruned model. Note that, if set 'dependency_aware'
         , the dummy_input cannot be None, because the pruner needs a dummy input to trace the
         dependency between the conv layers.
+
+        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
+        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
+        In this mode, NNI will find these three Linear layers in each attention,
+        then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.
@@ -278,6 +288,11 @@ class L2NormPruner(NormPruner):
         harvest the speed benefit from the pruned model. Note that, if set 'dependency_aware'
         , the dummy_input cannot be None, because the pruner needs a dummy input to trace the
         dependency between the conv layers.
+
+        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
+        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
+        In this mode, NNI will find these three Linear layers in each attention,
+        then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.
@@ -651,6 +666,11 @@ class TaylorFOWeightPruner(BasicPruner):
         If prune the model in a global way, all layer weights with same config will be considered uniformly.
         That means a single layer may not reach or exceed the sparsity setting in config,
         but the total pruned weights meet the sparsity setting.
+
+        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
+        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
+        In this mode, NNI will find these three Linear layers in each attention,
+        then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -185,10 +185,10 @@ class NormPruner(BasicPruner):
         , the dummy_input cannot be None, because the pruner needs a dummy input to trace the
         dependency between the conv layers.
 
-        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
-        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
-        In this mode, NNI will find these three Linear layers in each attention,
-        then apply the mask on the same position among three layers as possible.
+        If prune the model in an attention way, make sure you have (self-attention-like, O(matmul(matmul(Q, K), V)),
+        O is not required) structure in your model, and `QKVO` are implemented with `torch.nn.Linear` and `matmul` is
+        implemented with `torch.matmul` (like Bert implemented in huggingface). In this mode, NNI will find `QKV`
+        Linear layers in each attention, then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.
@@ -667,10 +667,10 @@ class TaylorFOWeightPruner(BasicPruner):
         That means a single layer may not reach or exceed the sparsity setting in config,
         but the total pruned weights meet the sparsity setting.
 
-        If prune the model in an attention way, make sure you have (self-attention-like, QKV projection) structure in your model,
-        and they are implemented with `torch.nn.Linear` (like Bert implemented in hugging face).
-        In this mode, NNI will find these three Linear layers in each attention,
-        then apply the mask on the same position among three layers as possible.
+        If prune the model in an attention way, make sure you have (self-attention-like, O(matmul(matmul(Q, K), V)),
+        O is not required) structure in your model, and `QKVO` are implemented with `torch.nn.Linear` and `matmul` is
+        implemented with `torch.matmul` (like Bert implemented in huggingface). In this mode, NNI will find `QKV`
+        Linear layers in each attention, then apply the mask on the same position among three layers as possible.
     dummy_input : Optional[torch.Tensor]
         The dummy input to analyze the topology constraints. Note that, the dummy_input
         should on the same device with the model.

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -37,7 +37,8 @@ from .tools import (
     SparsityAllocator,
     NormalSparsityAllocator,
     GlobalSparsityAllocator,
-    Conv2dDependencyAwareAllocator
+    Conv2dDependencyAwareAllocator,
+    AttentionSparsityAllocator
 )
 
 _logger = logging.getLogger(__name__)
@@ -175,7 +176,7 @@ class NormPruner(BasicPruner):
     p : int
         The order of norm.
     mode : str
-        'normal' or 'dependency_aware'.
+        'normal' or 'dependency_aware' or 'attention'.
         If prune the model in a dependency-aware way, this pruner will
         prune the model according to the norm of weights and the channel-dependency or
         group-dependency of the model. In this way, the pruner will force the conv layers
@@ -215,8 +216,10 @@ class NormPruner(BasicPruner):
                 self.sparsity_allocator = NormalSparsityAllocator(self, dim=0)
             elif self.mode == 'dependency_aware':
                 self.sparsity_allocator = Conv2dDependencyAwareAllocator(self, 0, self.dummy_input)
+            elif self.mode == 'attention':
+                self.sparsity_allocator = AttentionSparsityAllocator(self, 0, self.dummy_input)
             else:
-                raise NotImplementedError('Only support mode `normal` and `dependency_aware`')
+                raise NotImplementedError('Only support mode `normal`, `dependency_aware`, `attention`')
 
 
 class L1NormPruner(NormPruner):
@@ -635,7 +638,7 @@ class TaylorFOWeightPruner(BasicPruner):
     training_batches : int
         The batch number used to collect activations.
     mode : str
-        'normal', 'dependency_aware' or 'global'.
+        'normal', 'dependency_aware', 'global', 'attention'.
 
         If prune the model in a dependency-aware way, this pruner will
         prune the model according to the taylorFO and the channel-dependency or
@@ -715,8 +718,10 @@ class TaylorFOWeightPruner(BasicPruner):
                 self.sparsity_allocator = GlobalSparsityAllocator(self, dim=0)
             elif self.mode == 'dependency_aware':
                 self.sparsity_allocator = Conv2dDependencyAwareAllocator(self, 0, self.dummy_input)
+            elif self.mode == 'attention':
+                self.sparsity_allocator = AttentionSparsityAllocator(self, 0, self.dummy_input)
             else:
-                raise NotImplementedError('Only support mode `normal`, `global` and `dependency_aware`')
+                raise NotImplementedError('Only support mode `normal`, `global`, `dependency_aware`, `attention`')
 
 
 class ADMMPruner(BasicPruner):

--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/__init__.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/__init__.py
@@ -21,7 +21,8 @@ from .metrics_calculator import (
 from .sparsity_allocator import (
     NormalSparsityAllocator,
     GlobalSparsityAllocator,
-    Conv2dDependencyAwareAllocator
+    Conv2dDependencyAwareAllocator,
+    AttentionSparsityAllocator
 )
 from .task_generator import (
     AGPTaskGenerator,

--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/sparsity_allocator.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/sparsity_allocator.py
@@ -240,14 +240,13 @@ class AttentionSparsityAllocator(SparsityAllocator):
 
             # Special rule based output layer mask generation.
             output_layer_name = self.attention_name_groups[idx][-1]
-            if output_layer_name in metrics and len(self.dim) == 1 and self.dim[0] == 1:
+            if output_layer_name in metrics and self.dim and len(self.dim) == 1 and self.dim[0] == 0:
                 # Don't use colculated metric, use group metric.
                 metrics[output_layer_name] = None
                 metric = group_metric
                 wrapper = self.pruner.get_modules_wrapper()[output_layer_name]
                 prune_num = int(wrapper.config['total_sparsity'] * metric.numel())
                 head_width = int(wrapper.module.weight.size(1) / metric.size(0))
-                prune_num = int(wrapper.config['total_sparsity'] * metric.numel())
                 if prune_num == 0:
                     threshold = metric.min() - 1
                 else:

--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/sparsity_allocator.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/sparsity_allocator.py
@@ -3,9 +3,7 @@
 
 from collections import OrderedDict
 import math
-from tkinter import N
 from typing import Any, Dict, List, Tuple, Union
-from datasets import metric
 
 import numpy as np
 import torch


### PR DESCRIPTION
### Description ###
Add a new sparsity allocator. Add mode `attention` to `L1NormPruner`, `L2NormPruner`, `TaylorFOWeightPruner`.

This allocator is for pruning Q K V projection. Q K V need to be implemented as `torch.nn.Linear` layers, and their weights should have the same size. Then this allocator will sum their weight metric and apply the same masks to these three layers in one attention head.

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


