### PR TITLE
fix: Missing comma

### DIFF
--- a/nni/tools/nnictl/ts_management.py
+++ b/nni/tools/nnictl/ts_management.py
@@ -9,7 +9,7 @@ _builtin_training_services = [
     'remote',
     'openpai', 'pai',
     'aml',
-    'dlc'
+    'dlc',
     'kubeflow',
     'frameworkcontroller',
     'adl',


### PR DESCRIPTION
* Add missing comma in `_builtin_training_services`
