### PR TITLE
Fix a bug that new TPE does not support dict metrics

### DIFF
--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -22,6 +22,7 @@ from scipy.special import erf  # pylint: disable=no-name-in-module
 
 from nni.tuner import Tuner
 from nni.common.hpo_utils import OptimizeMode, format_search_space, deformat_parameters, format_parameters
+from nni.utils import extract_scalar_reward
 from . import random_tuner
 
 _logger = logging.getLogger('nni.tuner.tpe')
@@ -126,11 +127,11 @@ class TpeTuner(Tuner):
         self._running_params[parameter_id] = params
         return deformat_parameters(params, self.space)
 
-    def receive_trial_result(self, parameter_id, _parameters, loss, **kwargs):
-        if isinstance(loss, dict):
-            loss = loss['default']
-        if self.optimize_mode is OptimizeMode.Maximize:
-            loss = -loss
+    def receive_trial_result(self, parameter_id, _parameters, value, **kwargs):
+        if self.optimize_mode is OptimizeMode.Minimize:
+            loss = extract_scalar_reward(value)
+        else:
+            loss = -extract_scalar_reward(value)
         if self.liar:
             self.liar.update(loss)
         params = self._running_params.pop(parameter_id)

--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -127,6 +127,8 @@ class TpeTuner(Tuner):
         return deformat_parameters(params, self.space)
 
     def receive_trial_result(self, parameter_id, _parameters, loss, **kwargs):
+        if isinstance(loss, dict):
+            loss = loss['default']
         if self.optimize_mode is OptimizeMode.Maximize:
             loss = -loss
         if self.liar:

--- a/test/ut/sdk/test_builtin_tuners.py
+++ b/test/ut/sdk/test_builtin_tuners.py
@@ -58,6 +58,8 @@ class BuiltinTunersTestCase(TestCase):
         return receive
 
     def send_trial_result(self, tuner, parameter_id, parameters, metrics):
+        if parameter_id % 2 == 1:
+            metrics = {'default': metrics, 'extra': 'hello'}
         tuner.receive_trial_result(parameter_id, parameters, metrics)
         tuner.trial_end(parameter_id, True)
 


### PR DESCRIPTION
### Description ###

Reported by a user.
`nni.report_final_result()` accepts "a dict with key 'default'" and it's tuner's responsibility to extract the value. The refactored TPE did not implement this logic.

TODO: Add type hints and check in pipeline so "protocol mismatch" bugs like this can be reliably detected.

### Checklist ###
  - [x] test case
  - ~~doc~~

### How to test ###

Run an HPO experiment using TPE tuner and pass dict metrics to `report_final_result()`.
