### PR TITLE
Retry logic for getting experiment metadata failed

### DIFF
--- a/nni/tools/nnictl/nnictl_utils.py
+++ b/nni/tools/nnictl/nnictl_utils.py
@@ -222,6 +222,7 @@ def stop_experiment(args):
     if experiment_id_list:
         for experiment_id in experiment_id_list:
             print_normal('Stopping experiment %s' % experiment_id)
+            # FIXME: Retry should be placed to `Experiments`, need review both python and ts code.
             # retry up to 10 times to get the experiment metadata
             for i in range(1, 11):
                 experiments_dict = Experiments().get_all_experiments()

--- a/nni/tools/nnictl/nnictl_utils.py
+++ b/nni/tools/nnictl/nnictl_utils.py
@@ -222,9 +222,18 @@ def stop_experiment(args):
     if experiment_id_list:
         for experiment_id in experiment_id_list:
             print_normal('Stopping experiment %s' % experiment_id)
-            experiments_config = Experiments()
-            experiments_dict = experiments_config.get_all_experiments()
-            rest_pid = experiments_dict.get(experiment_id).get('pid')
+            # retry up to 10 times to get the experiment metadata
+            for i in range(1, 11):
+                experiments_dict = Experiments().get_all_experiments()
+                experiment_info = experiments_dict.get(experiment_id)
+                if experiment_info is None:
+                    print_warning('Get experiment {} metadata failed, {} time retry...'.format(experiment_id, i))
+                else:
+                    break
+            if experiment_info is None:
+                print_error('Experiment {} metadata getting failed, please manually check its status in `~/nni-experiments/.experiment`.')
+                exit(1)
+            rest_pid = experiment_info.get('pid')
             if rest_pid:
                 kill_command(rest_pid)
             print_normal('Stop experiment success.')

--- a/nni/tools/nnictl/nnictl_utils.py
+++ b/nni/tools/nnictl/nnictl_utils.py
@@ -228,10 +228,13 @@ def stop_experiment(args):
                 experiment_info = experiments_dict.get(experiment_id)
                 if experiment_info is None:
                     print_warning('Get experiment {} metadata failed, {} time retry...'.format(experiment_id, i))
+                    time.sleep(0.5)
                 else:
                     break
             if experiment_info is None:
-                print_error('Experiment {} metadata getting failed, please manually check its status in `~/nni-experiments/.experiment`.')
+                print_error('Experiment {} metadata getting failed.'.format(experiment_id))
+                print_error('The experiments metadata in `.experiment` is:')
+                print_error(json.dumps(Experiments().get_all_experiments(), indent=4))
                 exit(1)
             rest_pid = experiment_info.get('pid')
             if rest_pid:


### PR DESCRIPTION
### Description ###
Sometimes, `nnictl stop --all` failed in the unit test.

https://msrasrg.visualstudio.com/NNIOpenSource/_build/results?buildId=32629&view=logs&jobId=95b93358-fda6-5c72-3eb7-ee58b0085220&j=95b93358-fda6-5c72-3eb7-ee58b0085220&t=6d99b3d4-eb6f-53b7-dead-77c8a6940a44&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e

Two reasons may cause getting experiment metadata failed from `~/nni-experiments/.experiment`.
1. metadata does not exist
2. read `.experiment` failed

This issue is hard to reproduce, so just retry for now.

### How to test ###
Create several experiments and `nnictl stop --all`.

