### PR TITLE
Fix seed when test apoz pruner

### DIFF
--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -177,7 +177,7 @@ stages:
   - job: windows
     pool:
       vmImage: windows-latest
-    timeoutInMinutes: 70
+    timeoutInMinutes: 75
 
     steps:
     - template: templates/install-dependencies.yml


### PR DESCRIPTION
### Description ###
Based on pruning by the threshold, we may have this situation, metrics = [0, 0, 1, 1, 2, 2], pruning 50%, then threshold=1 and 4 position will be masked, the real sparsity is 66.7%.

Apoz is easy to have repeated values in metrics when layer weight size is small.

To fix this issue by fixing seed.

TODO: Pruner needs to handle the metric equal to threshold more carefully.


