### PR TITLE
Bug: reduce liveEnvironmentsCount after environment is stopped

### DIFF
--- a/ts/nni_manager/training_service/reusable/trialDispatcher.ts
+++ b/ts/nni_manager/training_service/reusable/trialDispatcher.ts
@@ -507,6 +507,7 @@ class TrialDispatcher implements TrainingService {
                                 throw new Error(`${environment.id} does not has environment service!`);
                             }
                             await environment.environmentService.stopEnvironment(environment);
+                            liveEnvironmentsCount--;
                             continue;
                         }
 


### PR DESCRIPTION
### Description ###
liveEnvironmentsCount failed to reduce after existing live environment is stopped.

### Checklist ###
  - [ ] test case
  - [ ] doc


### How to test ###
Create a reuseable training service and set the reuseMode=False.
Environments will be created and stop after use, new environment will be created.


