### PR TITLE
Fix: experiment.list_trial_jobs requires logPath & message

### DIFF
--- a/nni/experiment/data.py
+++ b/nni/experiment/data.py
@@ -111,6 +111,8 @@ class TrialJob:
         Stderr log path.
     sequenceId: int
         Sequence Id.
+    message: str
+        Message including platform/environment.
     """
     trialJobId: str
     status: str
@@ -121,9 +123,11 @@ class TrialJob:
     finalMetricData: List[TrialMetricData]
     stderrPath: str
     sequenceId: int
+    message: str
 
-    def __init__(self, trialJobId: str, status: str, logPath: str, startTime: int, sequenceId: int,
-                 endTime: int = -1, stderrPath: str = '', hyperParameters: List = [], finalMetricData: List = []):
+    def __init__(self, trialJobId: str, status: str, startTime: int, sequenceId: int, logPath: str = '',
+                 endTime: int = -1, stderrPath: str = '', hyperParameters: List = [], finalMetricData: List = [],
+                 message: str = '--'):
         self.trialJobId = trialJobId
         self.status = status
         self.hyperParameters = [TrialHyperParameters(**json.loads(e)) for e in hyperParameters]
@@ -133,3 +137,4 @@ class TrialJob:
         self.finalMetricData = [TrialMetricData(**e) for e in finalMetricData]
         self.stderrPath = stderrPath
         self.sequenceId = sequenceId
+        self.message = message


### PR DESCRIPTION
### Description ###
Add a member to TrialJob, and add a default value to TrialJob.logPath.

Details:
After experiment started by nnictl, 
1. before environment is ready, `logPath` field is missing from '/trial-jobs' response
    fix: add default value for logPath, to allow the list_trial_jobs() return results
2. after environments are created, `message` field is returned from  '/trial-jobs' response, however, TrialJob does NOT have this field.
    fix: add a message field for TrialJob, to align with TrialJobInfo in *.ts code.

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
from nni.experiment import Experiment
experiment = Experiment.connect(8080)
// before environment is ready
experiment.list_trial_jobs()
// after environments are created
experiment.list_trial_jobs()

