### PR TITLE
fix: model is not synced to device when not using CPU

### DIFF
--- a/examples/nas/multi-trial/mnist/search.py
+++ b/examples/nas/multi-trial/mnist/search.py
@@ -107,6 +107,7 @@ def evaluate_model(model_cls):
 
     device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
 
+    model.to(device)
     for epoch in range(3):
         # train the model for one epoch
         train_epoch(model, device, train_loader, optimizer, epoch)


### PR DESCRIPTION
### Description ###

The nas example of minist has a bug that when user choose to use GPU.

Model has not been synced to GPU device（or TPU and others), so PyTorch will fail when compute  net(input).

This problem will not occur if user choose to use CPU. 

### Checklist ###
  - [x] test case
  - [x] doc

### How to test ###

change: exp_config.training_service.use_active_gpu = False to :
```
exp_config.training_service.use_active_gpu = True
exp_config.trial_gpu_number = 1
```
