### PR TITLE
Cleanup useless messages on pipeline

### DIFF
--- a/pipelines/fast-test.yml
+++ b/pipelines/fast-test.yml
@@ -25,12 +25,12 @@ stages:
 
     - script: |
         cd docs
-        make -e SPHINXOPTS="-W --keep-going -T" html
+        make -e SPHINXOPTS="-W --keep-going -T -q" html
       displayName: Sphinx sanity check
 
     - script: |
         cd docs
-        make -e SPHINXOPTS="-W --keep-going -T -D language='zh'" html
+        make -e SPHINXOPTS="-W --keep-going -T -q -D language='zh'" html
       displayName: Sphinx sanity check (Chinese)
 
     - script: |

--- a/pipelines/templates/install-dependencies.yml
+++ b/pipelines/templates/install-dependencies.yml
@@ -65,3 +65,7 @@ steps:
 - script: |
     python test/vso_tools/interim_patch.py
   displayName: Torch utils tensorboard interim patch
+
+- script: |
+    pip list
+  displayName: List pip dependencies

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 addopts = --cov=nni --cov-config=.coveragerc --junitxml=junit/test-results.xml --cov-report=xml --cov-report=html --cov-config=.coveragerc
+filterwarnings =
+    ignore:Using key to access the identifier of:DeprecationWarning
+    ignore:layer_choice.choices is deprecated.:DeprecationWarning
+    ignore:The truth value of an empty array is ambiguous.:DeprecationWarning
+    ignore:nni.retiarii.serialize is deprecated and will be removed in future release.:DeprecationWarning


### PR DESCRIPTION
One major complaint about pipelines is: there are too much useless information in logs. As a result, we have trouble finding the root cause of failure; we might even miss out important warnings because they are flooded by tons of messages.

This PR cleans up useless information on pipelines, and highlight the important ones:

1. Suppress major (but useless) warnings. These warnings are mainly DeprecationWarning. It doesn't really matter, because pipelines will raise error anyway in case of API change.
2. Mute the documentation building progress bar.
3. List pip dependencies so that we can easily inspect the python environment on pipeline machines.
