### PR TITLE
Fix NNI manager argparse bug for v1 config

### DIFF
--- a/nni/tools/nnictl/legacy_launcher.py
+++ b/nni/tools/nnictl/legacy_launcher.py
@@ -69,7 +69,7 @@ def start_rest_server(port, platform, mode, experiment_id, foreground=False, log
     else:
         node_command = os.path.join(entry_dir, 'node')
     cmds = [node_command, '--max-old-space-size=4096', entry_file, '--port', str(port), '--mode', platform, \
-            '--experiment_id', experiment_id]
+            '--experiment-id', experiment_id]
     cmds += ['--action', mode]
     if log_dir is not None:
         cmds += ['--experiments-directory', log_dir]

--- a/ts/nni_manager/common/globals/arguments.ts
+++ b/ts/nni_manager/common/globals/arguments.ts
@@ -35,7 +35,7 @@ export interface NniManagerArgs {
 }
 
 export function parseArgs(rawArgs: string[]): NniManagerArgs {
-    const parser = yargs(rawArgs).options(yargsOptions).strict().fail((_msg, err, _yargs) => { throw err; });
+    const parser = yargs(rawArgs).options(yargsOptions).strict().fail(false);
     const parsedArgs: NniManagerArgs = parser.parseSync();
 
     // strip yargs leftovers


### PR DESCRIPTION
### Description ###

The NNI manager command line args for v1 config is incorrect. An underscore was forgotten to change to hyphen.

And the error handling is problematic. Exception thrown in callback cannot be caught.
It was originally designed to invoke `ShutdownManager.criticalError()`, but that PR has not been merged.

### Checklist ###
  - ~~test case~~
  - ~~doc~~

### How to test ###

IT will test it.