### PR TITLE
supported output_padding for convtranspose2d in model speedup

### DIFF
--- a/nni/compression/pytorch/speedup/compress_modules.py
+++ b/nni/compression/pytorch/speedup/compress_modules.py
@@ -512,6 +512,7 @@ def replace_convtranspose2d(convtrans, masks):
                                              kernel_size=convtrans.kernel_size,
                                              stride=convtrans.stride,
                                              padding=convtrans.padding,
+                                             output_padding=convtrans.output_padding,
                                              dilation=convtrans.dilation,
                                              groups=new_groups,
                                              bias=convtrans.bias is not None,


### PR DESCRIPTION
### Description ###
supported the output_padding argument of torch.nn.ConvTranspose2d in model speedup, which is mentioned in #4798.

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
call torch.nn.ConvTranspose2d with output_padding and do model speedup

