### PR TITLE
[Compression] support expand_as

### DIFF
--- a/nni/common/graph_utils.py
+++ b/nni/common/graph_utils.py
@@ -775,7 +775,7 @@ class TorchModuleGraph(TorchGraph):
         """
         # extract the input & output shape for the view and flatten
         for node_group in self.nodes_py.nodes_op:
-            if node_group.op_type in ['aten::view', 'aten::flatten', 'aten::mean', 'aten::reshape']:
+            if node_group.op_type in ['aten::view', 'aten::flatten', 'aten::mean', 'aten::reshape', 'aten::expand_as']:
                 # get shape infor for view (aten::view) func
                 cpp_node = list(filter(lambda x: x.kind() == node_group.op_type,
                                        node_group.node_cpps))[0]

--- a/nni/compression/pytorch/speedup/jit_translate.py
+++ b/nni/compression/pytorch/speedup/jit_translate.py
@@ -537,6 +537,13 @@ def cat_python(node, speedup):
     return CatModule(dim)
 
 
+def expandas_python(node, speedup):
+    class ExpandasModule(torch.nn.Module):
+        def forward(self, x, y):
+            return x.expand_as(y).clone()
+    return ExpandasModule()
+
+
 trans_from_jit_to_python = {
     'aten::add': add_python,
     'aten::add_': add_python,
@@ -581,11 +588,11 @@ trans_from_jit_to_python = {
     'aten::unsqueeze': unsqueeze_python,
     'aten::constant_pad_nd': constant_pad_nd_python,
     'aten::silu': silu_python,
+    'aten::expand_as': expandas_python,
     'prim::TupleUnpack': tupleunpack_python,
     'prim::ListUnpack': tupleunpack_python,
     'prim::NumToTensor': num2tensor_python,
     'prim::GetAttr': getattr_python
-
 }
 
 

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -20,7 +20,7 @@ MUL_TYPES = ['aten::mul', 'atem::mul_']
 CAT_TYPE = 'aten::cat'
 logger = logging.getLogger('Shape_Dependency')
 RESHAPE_OPS = [CAT_TYPE, 'aten::view',
-               'aten::reshape', 'aten::flatten', 'aten::mean']
+               'aten::reshape', 'aten::flatten', 'aten::mean', 'aten::expand_as']
 
 
 def lcm_list(L):


### PR DESCRIPTION
### Description ###
The following problem has done.
~This can work but infer mask might lead an unexcepted masks (the dependence between fc1 and expand_as outputs).~

~The following can reproduce this situation. `fc1.weight` cannot replace to a smaller one during speedup, but actually it should replace.~
```
import torch
from nni.compression.pytorch.pruning import L1NormPruner
from nni.compression.pytorch.speedup import ModelSpeedup


class TestModel(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.fc1 = torch.nn.Linear(10, 5)
        self.fc2 = torch.nn.Linear(10, 1)
        self.fc3 = torch.nn.Linear(5, 2)

    def forward(self, x):
        a = self.fc1(x)
        b = self.fc2(x).expand_as(a)
        return self.fc3(a + b)


model = TestModel()
pruner = L1NormPruner(model, [{'op_names': ['fc1'], 'sparsity': 0.5}])
_, masks = pruner.compress()
pruner._unwrap_model()
print(masks)
ModelSpeedup(model, torch.rand(10, 10), masks).speedup_model()
print(model)

```

### Checklist ###
~- [ ] test case~
~- [ ] doc~

### How to test ###
Run above code.

