### PR TITLE
Add args optimize_mode to random and grid search tuner

### DIFF
--- a/nni/algorithms/hpo/gridsearch_tuner.py
+++ b/nni/algorithms/hpo/gridsearch_tuner.py
@@ -88,7 +88,7 @@ class GridSearchTuner(Tuner):
         config.tuner.name = 'GridSearch'
     """
 
-    def __init__(self):
+    def __init__(self, optimize_mode=None):
         self.space = None
 
         # the grid to search in this epoch
@@ -115,6 +115,9 @@ class GridSearchTuner(Tuner):
 
         # dumped JSON string of all tried parameters
         self.history = set()
+
+        if optimize_mode is not None:
+            _logger.info(f'Ignored optimize_mode "{optimize_mode}"')
 
     def update_search_space(self, space):
         self.space = format_search_space(space)

--- a/nni/algorithms/hpo/random_tuner.py
+++ b/nni/algorithms/hpo/random_tuner.py
@@ -42,13 +42,15 @@ class RandomTuner(Tuner):
         The random seed.
     """
 
-    def __init__(self, seed: int | None = None):
+    def __init__(self, seed: int | None = None, optimize_mode: str | None = None):
         self.space = None
         if seed is None:  # explicitly generate a seed to make the experiment reproducible
             seed = np.random.default_rng().integers(2 ** 31)
         self.rng = np.random.default_rng(seed)
         self.dedup = None
         _logger.info(f'Using random seed {seed}')
+        if optimize_mode is not None:
+            _logger.info(f'Ignored optimize_mode "{optimize_mode}"')
 
     def update_search_space(self, space):
         self.space = format_search_space(space)
@@ -64,7 +66,10 @@ class RandomTuner(Tuner):
 
 class RandomClassArgsValidator(ClassArgsValidator):
     def validate_class_args(self, **kwargs):
-        schema.Schema({schema.Optional('seed'): int}).validate(kwargs)
+        schema.Schema({
+            schema.Optional('optimize_mode'): str,
+            schema.Optional('seed'): int,
+        }).validate(kwargs)
 
 def suggest(rng, space):
     params = {}


### PR DESCRIPTION
### Description ###

Add optional arguments `optimize_mode` to random tuner and grid search tuner.

The value will be used by web portal to sort trials: #4839

### Checklist ###
  - ~~test case~~
  - ~~doc~~

### How to test ###

Create experiment with random tuner in different optimize modes. Check that web portal sorts the trials in correct order.