### PR TITLE
Make TPE import data more robust

### DIFF
--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy.special import erf  # pylint: disable=no-name-in-module
 from typing_extensions import Literal
 
+import nni
 from nni.common.hpo_utils import Deduplicator, OptimizeMode, format_search_space, deformat_parameters, format_parameters
 from nni.tuner import Tuner
 from nni.utils import extract_scalar_reward
@@ -201,9 +202,15 @@ class TpeTuner(Tuner):
         self._running_params.pop(parameter_id, None)
 
     def import_data(self, data):  # for resuming experiment
+        if isinstance(data, str):
+            data = nni.load(data)
         for trial in data:
+            if isinstance(trial, str):
+                trial = nni.load(trial)
             param = format_parameters(trial['parameter'], self.space)
             loss = trial['value']
+            if isinstance(loss, dict) and 'default' in loss:
+                loss = loss['default']
             if self.optimize_mode is OptimizeMode.Maximize:
                 loss = -trial['value']
             for key, value in param.items():

--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -212,7 +212,7 @@ class TpeTuner(Tuner):
             if isinstance(loss, dict) and 'default' in loss:
                 loss = loss['default']
             if self.optimize_mode is OptimizeMode.Maximize:
-                loss = -trial['value']
+                loss = -loss
             for key, value in param.items():
                 self._history[key].append(Record(value, loss))
         _logger.info(f'Replayed {len(data)} trials')


### PR DESCRIPTION
### Description ###

The exported data format and/or resuming metrics format has changed sometime before and they are mismatch now.

I really don't want to investigate into those messy stuffs. So make TPE tolerate any metrics format.

It seems this problem applies to other tuners as well. But I don't want to touch them before a systematic refactor.

### Checklist ###
  - ~~test case~~
  - ~~doc~~

### How to test ###

Run an HPO experiment. Export then import.
