### PR TITLE
Fix issue 4810

### DIFF
--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -171,7 +171,7 @@ class TpeTuner(Tuner):
     def generate_parameters(self, parameter_id, **kwargs):
         if self.liar and self._running_params:
             # give a fake loss for each concurrently running paramater set
-            history = {key: records.copy() for key, records in self._history.items()}  # copy history
+            history = defaultdict(list, {key: records.copy() for key, records in self._history.items()})  # copy history
             lie = self.liar.lie()
             for param in self._running_params.values():
                 for key, value in param.items():

--- a/nni/common/serializer.py
+++ b/nni/common/serializer.py
@@ -393,7 +393,7 @@ def _dump(*, obj: Any, fp: Optional[Any], use_trace: bool, pickle_size_limit: in
 
 
 def load(string: Optional[str] = None, *, fp: Optional[Any] = None,
-         preserve_order=False, ignore_comments: bool = True, **json_tricks_kwargs) -> Any:
+         preserve_order: bool = False, ignore_comments: bool = True, **json_tricks_kwargs) -> Any:
     """
     Load the string or from file, and convert it to a complex data structure.
     At least one of string or fp has to be not none.
@@ -404,7 +404,7 @@ def load(string: Optional[str] = None, *, fp: Optional[Any] = None,
         JSON string to parse. Can be set to none if fp is used.
     fp : str
         File path to load JSON from. Can be set to none if string is used.
-    preserve_order: bool
+    preserve_order : bool
         Use ``OrderedDict`` instead of ``dict``. Note that the order is always preserved even when this is False.
     ignore_comments : bool
         Remove comments (starting with ``#`` or ``//``). Default is true.

--- a/nni/common/serializer.py
+++ b/nni/common/serializer.py
@@ -405,7 +405,9 @@ def load(string: Optional[str] = None, *, fp: Optional[Any] = None,
     fp : str
         File path to load JSON from. Can be set to none if string is used.
     preserve_order : bool
-        Use ``OrderedDict`` instead of ``dict``. Note that the order is always preserved even when this is False.
+        `json_tricks parameter <https://json-tricks.readthedocs.io/en/latest/#order>`_
+        to use ``OrderedDict`` instead of ``dict``.
+        The order is in fact always preserved even when this is False.
     ignore_comments : bool
         Remove comments (starting with ``#`` or ``//``). Default is true.
 

--- a/nni/common/serializer.py
+++ b/nni/common/serializer.py
@@ -392,7 +392,8 @@ def _dump(*, obj: Any, fp: Optional[Any], use_trace: bool, pickle_size_limit: in
         return json_tricks.dumps(obj, obj_encoders=encoders, **json_tricks_kwargs)
 
 
-def load(string: Optional[str] = None, *, fp: Optional[Any] = None, ignore_comments: bool = True, **json_tricks_kwargs) -> Any:
+def load(string: Optional[str] = None, *, fp: Optional[Any] = None,
+         preserve_order=False, ignore_comments: bool = True, **json_tricks_kwargs) -> Any:
     """
     Load the string or from file, and convert it to a complex data structure.
     At least one of string or fp has to be not none.
@@ -403,6 +404,8 @@ def load(string: Optional[str] = None, *, fp: Optional[Any] = None, ignore_comme
         JSON string to parse. Can be set to none if fp is used.
     fp : str
         File path to load JSON from. Can be set to none if string is used.
+    preserve_order: bool
+        Use ``OrderedDict`` instead of ``dict``. Note that the order is always preserved even when this is False.
     ignore_comments : bool
         Remove comments (starting with ``#`` or ``//``). Default is true.
 
@@ -427,6 +430,8 @@ def load(string: Optional[str] = None, *, fp: Optional[Any] = None, ignore_comme
         _json_tricks_any_object_decode
     ]
 
+    # there was an issue that the user code does not accept ordered dict, and 3.7+ dict has guaranteed order
+    json_tricks_kwargs['preserve_order'] = preserve_order
     # to bypass a deprecation warning in json-tricks
     json_tricks_kwargs['ignore_comments'] = ignore_comments
 

--- a/nni/runtime/platform/local.py
+++ b/nni/runtime/platform/local.py
@@ -53,7 +53,7 @@ def get_next_parameter():
     while not (os.path.isfile(params_filepath) and os.path.getsize(params_filepath) > 0):
         time.sleep(3)
     params_file = open(params_filepath, 'r')
-    params = load(fp=params_file)
+    params = load(fp=params_file, preserve_order=False)
     _param_index += 1
     return params
 

--- a/nni/runtime/platform/local.py
+++ b/nni/runtime/platform/local.py
@@ -53,7 +53,7 @@ def get_next_parameter():
     while not (os.path.isfile(params_filepath) and os.path.getsize(params_filepath) > 0):
         time.sleep(3)
     params_file = open(params_filepath, 'r')
-    params = load(fp=params_file, preserve_order=False)
+    params = load(fp=params_file)
     _param_index += 1
     return params
 

--- a/test/ut/sdk/test_serializer.py
+++ b/test/ut/sdk/test_serializer.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import math
 import os
 import pickle
@@ -22,6 +23,18 @@ if True:  # prevent auto formatting
     # this test cannot be directly put in this file. It will cause syntax error for python <= 3.7.
     if tuple(sys.version_info) >= (3, 8):
         from imported._test_serializer_py38 import test_positional_only
+
+
+def test_ordered_json():
+    items = [
+        ('a', 1),
+        ('c', 3),
+        ('b', 2),
+    ]
+    orig = OrderedDict(items)
+    json = nni.dump(orig)
+    loaded = nni.load(json)
+    assert list(loaded.items()) == items
 
 
 @nni.trace


### PR DESCRIPTION
### Description ###

Issue 4810 reported a bug. The user said it's about TPE nested search space.

It was in fact caused by parameter deserialization. For some reason the trial code requires the parameter to be a plain dict, but in current version it will be `OrderedDict`.

During investigating this problem, however, I did find a bug in TPE nested search space. 🤔

### Checklist ###
  - ~~test case~~
  - ~~doc~~

### How to test ###

Check the search space and trial code in issue 4810.
