### PR TITLE
Fix two bugs introduced in this sprint

### DIFF
--- a/nni/experiment/experiment.py
+++ b/nni/experiment/experiment.py
@@ -163,16 +163,19 @@ class Experiment:
         self.start(port, debug)
         if wait_completion:
             try:
-                while True:
-                    time.sleep(10)
-                    status = self.get_status()
-                    if status == 'DONE' or status == 'STOPPED':
-                        return True
-                    if status == 'ERROR':
-                        return False
+                self._wait_completion()
             except KeyboardInterrupt:
                 _logger.warning('KeyboardInterrupt detected')
                 self.stop()
+
+    def _wait_completion(self) -> bool:
+        while True:
+            time.sleep(10)
+            status = self.get_status()
+            if status == 'DONE' or status == 'STOPPED':
+                return True
+            if status == 'ERROR':
+                return False
 
     @classmethod
     def connect(cls, port: int):

--- a/nni/experiment/experiment.py
+++ b/nni/experiment/experiment.py
@@ -185,15 +185,6 @@ class Experiment:
                 _logger.warning('KeyboardInterrupt detected')
                 self.stop()
 
-    def _wait_completion(self) -> bool:
-        while True:
-            time.sleep(10)
-            status = self.get_status()
-            if status == 'DONE' or status == 'STOPPED':
-                return True
-            if status == 'ERROR':
-                return False
-
     @classmethod
     def connect(cls, port: int):
         """

--- a/nni/tools/nnictl/launcher.py
+++ b/nni/tools/nnictl/launcher.py
@@ -90,7 +90,8 @@ def create_experiment(args):
     exp.url_prefix = url_prefix
 
     if foreground:
-        exp.run(port, debug=debug)
+        exp.start(port, debug, RunMode.Foreground)
+        exp._wait_completion()
 
     else:
         exp.start(port, debug, RunMode.Detach)

--- a/ts/nni_manager/common/utils.ts
+++ b/ts/nni_manager/common/utils.ts
@@ -105,10 +105,10 @@ function randomSelect<T>(a: T[]): T {
  * @param expParams: experiment startup parameters
  *
  */
-function getMsgDispatcherCommand(expParams: ExperimentConfig): string {
+function getMsgDispatcherCommand(expParams: ExperimentConfig): string[] {
     const clonedParams = Object.assign({}, expParams);
     delete clonedParams.searchSpace;
-    return `${globals.args.pythonInterpreter} -m nni --exp_params ${Buffer.from(JSON.stringify(clonedParams)).toString('base64')}`;
+    return [ globals.args.pythonInterpreter, '-m', 'nni', '--exp_params', Buffer.from(JSON.stringify(clonedParams)).toString('base64') ];
 }
 
 /**
@@ -249,16 +249,13 @@ async function getVersion(): Promise<string> {
 /**
  * run command as ChildProcess
  */
-function getTunerProc(command: string, stdio: StdioOptions, newCwd: string, newEnv: any, newShell: boolean = true, isDetached: boolean = false): ChildProcess {
-    let cmd: string = command;
-    let arg: string[] = [];
+function getTunerProc(command: string[], stdio: StdioOptions, newCwd: string, newEnv: any, newShell: boolean = true, isDetached: boolean = false): ChildProcess {
+    // FIXME: TensorBoard has no reason to use get TUNER proc
     if (process.platform === "win32") {
-        cmd = command.split(" ", 1)[0];
-        arg = command.substr(cmd.length + 1).split(" ");
         newShell = false;
         isDetached = true;
     }
-    const tunerProc: ChildProcess = spawn(cmd, arg, {
+    const tunerProc: ChildProcess = spawn(command[0], command.slice(1), {
         stdio,
         cwd: newCwd,
         env: newEnv,

--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -178,7 +178,7 @@ class NNIManager implements Manager {
         }
 
         this.log.info('Setup tuner...');
-        const dispatcherCommand: string = getMsgDispatcherCommand(config);
+        const dispatcherCommand: string[] = getMsgDispatcherCommand(config);
         this.log.debug(`dispatcher command: ${dispatcherCommand}`);
         const checkpointDir: string = await this.createCheckpointDir();
         await this.setupTuner(dispatcherCommand, undefined, 'start', checkpointDir);
@@ -211,7 +211,7 @@ class NNIManager implements Manager {
         }
 
         this.log.info('Setup tuner...');
-        const dispatcherCommand: string = getMsgDispatcherCommand(config);
+        const dispatcherCommand: string[] = getMsgDispatcherCommand(config);
         this.log.debug(`dispatcher command: ${dispatcherCommand}`);
         const checkpointDir: string = await this.createCheckpointDir();
         await this.setupTuner(dispatcherCommand, undefined, 'resume', checkpointDir);
@@ -454,7 +454,7 @@ class NNIManager implements Manager {
         }
     }
 
-    private async setupTuner(command: string, cwd: string | undefined, mode: 'start' | 'resume', dataDirectory: string): Promise<void> {
+    private async setupTuner(command: string[], cwd: string | undefined, mode: 'start' | 'resume', dataDirectory: string): Promise<void> {
         if (this.dispatcher !== undefined) {
             return;
         }

--- a/ts/nni_manager/extensions/nniTensorboardManager.ts
+++ b/ts/nni_manager/extensions/nniTensorboardManager.ts
@@ -81,7 +81,7 @@ class NNITensorboardManager implements TensorboardManager {
         return tensorboardTask;
     }
 
-    private async getTensorboardStartCommand(trialJobIdList: string[], trialLogDirectoryList: string[], port: number): Promise<string> {
+    private async getTensorboardStartCommand(trialJobIdList: string[], trialLogDirectoryList: string[], port: number): Promise<string[]> {
         if (this.tensorboardVersion === undefined) {
             this.setTensorboardVersion();
             if (this.tensorboardVersion === undefined) {
@@ -105,9 +105,8 @@ class NNITensorboardManager implements TensorboardManager {
                 const trialJob = await this.nniManager.getTrialJob(trialJobIdList[idx]);
                 logRealPaths.push(`${trialJob.sequenceId}-${trialJobIdList[idx]}:${realPath}`);
             }
-            const command = `tensorboard ${logdirCmd}=${logRealPaths.join(',')} --port=${port}`;
-            return command;
-        } catch (error){
+            return [ 'tensorboard', `${logdirCmd}=${logRealPaths.join(',')}`, `--port=${port}` ];
+        } catch (error) {
             throw new Error(`${error.message}`);
         }
     }

--- a/ts/nni_manager/test/core/ipcInterface.test.ts
+++ b/ts/nni_manager/test/core/ipcInterface.test.ts
@@ -22,7 +22,7 @@ async function runProcess(): Promise<Error | null> {
 
     // create fake assessor process
     const stdio: StdioOptions = ['ignore', 'pipe', process.stderr, 'pipe', 'pipe'];
-    const command: string = 'python assessor.py';
+    const command: string[] = [ 'python',  'assessor.py' ];
     const proc: ChildProcess = getTunerProc(command, stdio,  'core/test', process.env);
     // record its sent/received commands on exit
     proc.on('error', (error: Error): void => { deferred.resolve(error); });

--- a/ts/nni_manager/test/core/ipcInterfaceTerminate.test.ts
+++ b/ts/nni_manager/test/core/ipcInterfaceTerminate.test.ts
@@ -18,7 +18,7 @@ async function startProcess(): Promise<void> {
     // create fake assessor process
     const stdio: StdioOptions = ['ignore', 'pipe', process.stderr, 'pipe', 'pipe'];
 
-    const dispatcherCmd: string = getMsgDispatcherCommand(
+    const dispatcherCmd: string[] = getMsgDispatcherCommand(
         // Mock tuner config
         <any>{
             experimentName: 'exp1',


### PR DESCRIPTION
### Description ###

Bug 1: `sys.executable` can include spaces. NNI manager cannot handle this type of commands before.

Bug 2: Forgot to wait completion in `nnictl create --foreground`.


