### PR TITLE
Allow postponed annotations for config classes

### DIFF
--- a/nni/experiment/config/base.py
+++ b/nni/experiment/config/base.py
@@ -84,7 +84,7 @@ class ConfigBase:
         """
         self._base_path = utils.get_base_path()
         args = {utils.case_insensitive(key): value for key, value in kwargs.items()}
-        for field in dataclasses.fields(self):
+        for field in utils.fields(self):
             value = args.pop(utils.case_insensitive(field.name), field.default)
             setattr(self, field.name, value)
         if args:  # maybe a key is misspelled
@@ -93,7 +93,7 @@ class ConfigBase:
             raise AttributeError(f'{class_name} does not have field(s) {fields}')
 
         # try to unpack nested config
-        for field in dataclasses.fields(self):
+        for field in utils.fields(self):
             value = getattr(self, field.name)
             if utils.is_instance(value, field.type):
                 continue  # already accepted by subclass, don't touch it
@@ -209,7 +209,7 @@ class ConfigBase:
             For example local training service's ``trialGpuNumber`` will be copied from top level when not set,
             in this case it will be invoked like ``localConfig._canonicalize([experimentConfig])``.
         """
-        for field in dataclasses.fields(self):
+        for field in utils.fields(self):
             value = getattr(self, field.name)
             if isinstance(value, (Path, str)) and utils.is_path_like(field.type):
                 setattr(self, field.name, utils.resolve_path(value, self._base_path))
@@ -230,7 +230,7 @@ class ConfigBase:
         2. Call ``_validate_canonical()`` on children config objects, including those inside list and dict
         """
         utils.validate_type(self)
-        for field in dataclasses.fields(self):
+        for field in utils.fields(self):
             value = getattr(self, field.name)
             _recursive_validate_child(value)
 
@@ -242,7 +242,7 @@ class ConfigBase:
         if hasattr(self, name) or name.startswith('_'):
             super().__setattr__(name, value)
             return
-        if name in [field.name for field in dataclasses.fields(self)]:  # might happend during __init__
+        if name in [field.name for field in utils.fields(self)]:  # might happend during __init__
             super().__setattr__(name, value)
             return
         raise AttributeError(f'{type(self).__name__} does not have field {name}')

--- a/nni/experiment/config/training_service.py
+++ b/nni/experiment/config/training_service.py
@@ -52,7 +52,6 @@ class TrainingServiceConfig(ConfigBase):
     def _validate_canonical(self):
         super()._validate_canonical()
         cls = type(self)
-        assert self.platform == cls.platform
         if not Path(self.trial_code_directory).is_dir():
             raise ValueError(f'{cls.__name__}: trial_code_directory "{self.trial_code_directory}" is not a directory')
         assert self.trial_gpu_number is None or self.trial_gpu_number >= 0

--- a/nni/experiment/config/training_services/aml.py
+++ b/nni/experiment/config/training_services/aml.py
@@ -18,11 +18,13 @@ __all__ = ['AmlConfig']
 
 from dataclasses import dataclass
 
+from typing_extensions import Literal
+
 from ..training_service import TrainingServiceConfig
 
 @dataclass(init=False)
 class AmlConfig(TrainingServiceConfig):
-    platform: str = 'aml'
+    platform: Literal['aml'] = 'aml'
     subscription_id: str
     resource_group: str
     workspace_name: str

--- a/nni/experiment/config/training_services/dlc.py
+++ b/nni/experiment/config/training_services/dlc.py
@@ -4,13 +4,15 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from typing_extensions import Literal
+
 from ..training_service import TrainingServiceConfig
 
 __all__ = ['DlcConfig']
 
 @dataclass(init=False)
 class DlcConfig(TrainingServiceConfig):
-    platform: str = 'dlc'
+    platform: Literal['dlc'] = 'dlc'
     type: str = 'Worker'
     image: str # 'registry-vpc.{region}.aliyuncs.com/pai-dlc/tensorflow-training:1.15.0-cpu-py36-ubuntu18.04',
     job_type: str = 'TFJob'

--- a/nni/experiment/config/training_services/frameworkcontroller.py
+++ b/nni/experiment/config/training_services/frameworkcontroller.py
@@ -19,6 +19,8 @@ __all__ = ['FrameworkControllerConfig', 'FrameworkControllerRoleConfig', 'Framew
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
+from typing_extensions import Literal
+
 from ..base import ConfigBase
 from ..training_service import TrainingServiceConfig
 from .k8s_storage import K8sStorageConfig
@@ -41,7 +43,7 @@ class FrameworkControllerRoleConfig(ConfigBase):
 
 @dataclass(init=False)
 class FrameworkControllerConfig(TrainingServiceConfig):
-    platform: str = 'frameworkcontroller'
+    platform: Literal['frameworkcontroller'] = 'frameworkcontroller'
     storage: K8sStorageConfig
     service_account_name: Optional[str]
     task_roles: List[FrameworkControllerRoleConfig]

--- a/nni/experiment/config/training_services/k8s_storage.py
+++ b/nni/experiment/config/training_services/k8s_storage.py
@@ -10,6 +10,8 @@ __all__ = ['K8sStorageConfig', 'K8sAzureStorageConfig', 'K8sNfsConfig']
 from dataclasses import dataclass
 from typing import Optional
 
+from typing_extensions import Literal
+
 from ..base import ConfigBase
 
 @dataclass(init=False)
@@ -34,13 +36,13 @@ class K8sStorageConfig(ConfigBase):
 
 @dataclass(init=False)
 class K8sNfsConfig(K8sStorageConfig):
-    storage: str = 'nfs'
+    storage: Literal['nfs'] = 'nfs'
     server: str
     path: str
 
 @dataclass(init=False)
 class K8sAzureStorageConfig(K8sStorageConfig):
-    storage: str = 'azureStorage'
+    storage: Literal['azureStorage'] = 'azureStorage'
     azure_account: str
     azure_share: str
     key_vault_name: str

--- a/nni/experiment/config/training_services/kubeflow.py
+++ b/nni/experiment/config/training_services/kubeflow.py
@@ -19,6 +19,8 @@ __all__ = ['KubeflowConfig', 'KubeflowRoleConfig']
 from dataclasses import dataclass
 from typing import Optional, Union
 
+from typing_extensions import Literal
+
 from ..base import ConfigBase
 from ..training_service import TrainingServiceConfig
 from .k8s_storage import K8sStorageConfig
@@ -35,7 +37,7 @@ class KubeflowRoleConfig(ConfigBase):
 
 @dataclass(init=False)
 class KubeflowConfig(TrainingServiceConfig):
-    platform: str = 'kubeflow'
+    platform: Literal['kubeflow'] = 'kubeflow'
     operator: str
     api_version: str
     storage: K8sStorageConfig

--- a/nni/experiment/config/training_services/local.py
+++ b/nni/experiment/config/training_services/local.py
@@ -19,12 +19,14 @@ __all__ = ['LocalConfig']
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
+from typing_extensions import Literal
+
 from ..training_service import TrainingServiceConfig
 from .. import utils
 
 @dataclass(init=False)
 class LocalConfig(TrainingServiceConfig):
-    platform: str = 'local'
+    platform: Literal['local'] = 'local'
     use_active_gpu: Optional[bool] = None
     max_trial_number_per_gpu: int = 1
     gpu_indices: Union[List[int], int, str, None] = None

--- a/nni/experiment/config/training_services/openpai.py
+++ b/nni/experiment/config/training_services/openpai.py
@@ -20,12 +20,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+from typing_extensions import Literal
+
 from ..training_service import TrainingServiceConfig
 from ..utils import PathLike
 
 @dataclass(init=False)
 class OpenpaiConfig(TrainingServiceConfig):
-    platform: str = 'openpai'
+    platform: Literal['openpai'] = 'openpai'
     host: str
     username: str
     token: str

--- a/nni/experiment/config/training_services/remote.py
+++ b/nni/experiment/config/training_services/remote.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import List, Optional, Union
 import warnings
 
+from typing_extensions import Literal
+
 from ..base import ConfigBase
 from ..training_service import TrainingServiceConfig
 from .. import utils
@@ -60,7 +62,7 @@ class RemoteMachineConfig(ConfigBase):
 
 @dataclass(init=False)
 class RemoteConfig(TrainingServiceConfig):
-    platform: str = 'remote'
+    platform: Literal['remote'] = 'remote'
     machine_list: List[RemoteMachineConfig]
     reuse_mode: bool = True
 


### PR DESCRIPTION
### Description ###

Previously config classes do not support `from __future__ import annotations`, in which case `Field.type` will be strings and cannot be checked by `typeguard`.

Other changes:
  - Add type hints to an internal util module
  - Use `Literal` for training service platform type hints.

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


