### PR TITLE
[Compression] fix issue 4875

### DIFF
--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -85,7 +85,7 @@ def reshape_break_channel_dependency(op_node):
     """
     in_shape = op_node.auxiliary['in_shape']
     out_shape = op_node.auxiliary['out_shape']
-    if in_shape or out_shape:
+    if not in_shape or not out_shape:
         return True
     in_channel = in_shape[1]
     out_channel = out_shape[1]

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -87,6 +87,8 @@ def reshape_break_channel_dependency(op_node):
     out_shape = op_node.auxiliary['out_shape']
     if not in_shape or not out_shape:
         return True
+    if len(in_shape) <= 1 or len(out_shape) <= 1:
+        return True
     in_channel = in_shape[1]
     out_channel = out_shape[1]
     return in_channel != out_channel


### PR DESCRIPTION
### Description ###
fix #4875
- [x] fix infinite loop in `ChannelDependency._get_parent_layers`
- [ ] fix buffer can not be traced? 
  - https://github.com/facebookresearch/detectron2/blob/45b3fcea6e76bf7a351e54e01c7d6e1a3a0100a5/detectron2/modeling/anchor_generator.py#L177
  - the following `view` in `base_anchors.view(1, -1, 4)`, don't have `input_shape` and don't have `dummy_input`

### Checklist ###
 ~- [ ] test case~
 ~- [ ] doc~

### How to test ###


