### PR TITLE
Refactor integration test (step 3) - Azure blob mount robustness

### DIFF
--- a/ts/nni_manager/training_service/reusable/shared_storages/azureblobStorageService.ts
+++ b/ts/nni_manager/training_service/reusable/shared_storages/azureblobStorageService.ts
@@ -35,9 +35,7 @@ version=$(lsb_release -r | cut -c9- | sed s/[[:space:]]//g)
 if [ "$id" = "Ubuntu" ]
 then
     wget https://packages.microsoft.com/config/ubuntu/$version/packages-microsoft-prod.deb
-    export DEBIAN_FRONTEND=noninteractive
-    sudo -E dpkg -i packages-microsoft-prod.deb
-    echo "dpkg success!"
+    sudo DEBIAN_FRONTEND=noninteractive dpkg -i packages-microsoft-prod.deb
     sudo apt-get update
     sudo apt-get install -y blobfuse fuse
 elif [ "$id" = "CentOS" ] || [ "$id" = "RHEL" ]


### PR DESCRIPTION
The mount fails when there is stderr. This is definitely incorrect, because dpkg itself can produce some stderr but it doesn't mean that it has failed.

I don't know the correct fix for this issue, but the changes are necessary to make pipelines work.