### PR TITLE
Replace `logging.info` with `logger.info`

### DIFF
--- a/nni/common/version.py
+++ b/nni/common/version.py
@@ -25,21 +25,21 @@ try:
     import torch
     TORCH_VERSION = _minor_version_tuple(torch.__version__)
 except ImportError:
-    logging.info("PyTorch is not installed.")
+    logging.getLogger(__name__).info("PyTorch is not installed.")
     TORCH_VERSION = None
 
 try:
     import pytorch_lightning
     PYTORCH_LIGHTNING_VERSION = _minor_version_tuple(pytorch_lightning.__version__)
 except ImportError:
-    logging.info("PyTorch Lightning is not installed.")
+    logging.getLogger(__name__).info("PyTorch Lightning is not installed.")
     PYTORCH_LIGHTNING_VERSION = None
 
 try:
     import tensorflow
     TENSORFLOW_VERSION = _minor_version_tuple(tensorflow.__version__)
 except ImportError:
-    logging.info("Tensorflow is not installed.")
+    logging.getLogger(__name__).info("Tensorflow is not installed.")
     TENSORFLOW_VERSION = None
 
 # Serialization version check are needed because they are prone to be inconsistent between versions

--- a/nni/experiment/experiment.py
+++ b/nni/experiment/experiment.py
@@ -425,7 +425,7 @@ class Experiment:
         experiment_profile = self.get_experiment_profile()
         experiment_profile['params'][key] = value
         rest.put(self.port, api, experiment_profile, self.url_prefix)
-        logging.info('Successfully update %s.', key)
+        _logger.info('Successfully update %s.', key)
 
     def update_trial_concurrency(self, value: int):
         """


### PR DESCRIPTION
All logs appear twice after this:

```python
import nni
import logging
logging.info('hello')

_logger = logging.getLogger('nni.logger')
_logger.info('hello')
```

`logging.info` will automatically register a root handler in case there is none. NNI's log will propagate to the root logger and processed by this default handler. The easiest solution here is avoid using `logging.info` at all.