### PR TITLE
Fix error message for incorrect tuner config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,7 @@ linkcheck_ignore = [
     r'https://www\.msra\.cn/',                              # MSRA
     r'https://1drv\.ms/',                                   # OneDrive (shortcut)
     r'https://onedrive\.live\.com/',                        # OneDrive
+    r'https://www\.openml\.org/',
 ]
 
 # Ignore all links located in release.rst

--- a/nni/experiment/config/experiment_config.py
+++ b/nni/experiment/config/experiment_config.py
@@ -118,7 +118,7 @@ class ExperimentConfig(ConfigBase):
                 # we do the convertion again to show user the error message
                 _AlgorithmConfig(**algo)  # pylint: disable=not-a-mapping
 
-            if algo is not None and algo.name == '_none_':
+            if algo is not None and algo.name == '_none_':  # type: ignore
                 setattr(self, algo_type, None)
 
         if self.advisor is not None:

--- a/nni/experiment/config/experiment_config.py
+++ b/nni/experiment/config/experiment_config.py
@@ -116,7 +116,7 @@ class ExperimentConfig(ConfigBase):
                 # the base class should have converted it to `_AlgorithmConfig` if feasible
                 # it is a `dict` here means an exception was raised during the convertion attempt
                 # we do the convertion again to show user the error message
-                _AlgorithmConfig(**algo)
+                _AlgorithmConfig(**algo)  # pylint: disable=not-a-mapping
 
             if algo is not None and algo.name == '_none_':
                 setattr(self, algo_type, None)

--- a/nni/experiment/config/experiment_config.py
+++ b/nni/experiment/config/experiment_config.py
@@ -110,6 +110,14 @@ class ExperimentConfig(ConfigBase):
 
         for algo_type in ['tuner', 'assessor', 'advisor']:
             algo = getattr(self, algo_type)
+
+            # TODO: need a more universal solution for similar problems
+            if isinstance(algo, dict):
+                # the base class should have converted it to `_AlgorithmConfig` if feasible
+                # it is a `dict` here means an exception was raised during the convertion attempt
+                # we do the convertion again to show user the error message
+                _AlgorithmConfig(**algo)
+
             if algo is not None and algo.name == '_none_':
                 setattr(self, algo_type, None)
 


### PR DESCRIPTION
### Description ###

If the experiment config contains a bad field in tuner section, the error message will not be correctly shown.

Example:
```yaml
tuner:
  name: tpe
  kwargs:  # it should be "class_args"
    optimize_mode: maximize
......
```

The error message should be something like "AlgorithmConfig does not have field kwargs".

