### PR TITLE
[FEAT]: resume waiting/running, dedup on tuner side (TPE-only)

### DIFF
--- a/nni/common/hpo_utils/dedup.py
+++ b/nni/common/hpo_utils/dedup.py
@@ -79,6 +79,12 @@ class Deduplicator:
             self._history.add(params_str)
             return True
 
+    def add_history(self, formatted_parameters: FormattedParameters) -> None:
+        params = deformat_parameters(formatted_parameters, self._space)
+        params_str = typing.cast(str, nni.dump(params, sort_keys=True))
+        if params_str not in self._history:
+            self._history.add(params_str)
+
 def _spec_never_dup(spec: ParameterSpec) -> bool:
     if spec.is_nested():
         return False  # "not chosen" duplicates with "not chosen"

--- a/nni/runtime/msg_dispatcher.py
+++ b/nni/runtime/msg_dispatcher.py
@@ -121,8 +121,14 @@ class MsgDispatcher(MsgDispatcherBase):
 
     def handle_add_customized_trial(self, data):
         # data: parameters
-        id_ = _create_parameter_id()
-        _customized_parameter_ids.add(id_)
+        if not isinstance(data, list):
+            data = [data]
+
+        for _ in data:
+            id_ = _create_parameter_id()
+            _customized_parameter_ids.add(id_)
+
+        self.tuner.import_customized_data(data)
 
     def handle_report_metric_data(self, data):
         """
@@ -187,7 +193,8 @@ class MsgDispatcher(MsgDispatcherBase):
             self.tuner.receive_trial_result(id_, _trial_params[id_], value, customized=customized,
                                             trial_job_id=data.get('trial_job_id'))
         else:
-            _logger.warning('Find unknown job parameter id %s, maybe something goes wrong.', _trial_params[id_])
+            _logger.warning('Find unknown job parameter id %s, maybe something goes wrong.', id_)
+            _logger.warning('_trial_params %s', _trial_params)
 
     def _handle_intermediate_metric_data(self, data):
         """Call assessor to process intermediate results

--- a/nni/tuner.py
+++ b/nni/tuner.py
@@ -219,6 +219,14 @@ class Tuner(Recoverable):
         # data: a list of dictionarys, each of which has at least two keys, 'parameter' and 'value'
         pass
 
+    def import_customized_data(self, data: list[TrialRecord]) -> None:
+        """
+        Internal API under revising, not recommended for end users.
+        """
+        # Import resume data for avoiding duplications
+        # data: a list of dictionarys, each of which has at least two keys, 'parameter_id' and 'parameters'
+        pass
+
     def _on_exit(self) -> None:
         pass
 

--- a/test/ut/sdk/test_builtin_tuners.py
+++ b/test/ut/sdk/test_builtin_tuners.py
@@ -272,7 +272,7 @@ class BuiltinTunersTestCase(TestCase):
             search_space = {
                 "choice_str": {
                     "_type": "choice",
-                    "_value": ["cat", "dog", "elephant", "cow", "sheep", "panda"]
+                    "_value": ["cat", "dog", "elephant", "cow", "sheep", "panda", "tiger"]
                 }
             }
         elif stype == "choice_num":

--- a/ts/nni_manager/common/datastore.ts
+++ b/ts/nni_manager/common/datastore.ts
@@ -4,7 +4,7 @@
 import { ExperimentProfile, TrialJobStatistics } from './manager';
 import { TrialJobDetail, TrialJobStatus } from './trainingService';
 
-type TrialJobEvent = TrialJobStatus | 'USER_TO_CANCEL' | 'ADD_CUSTOMIZED' | 'ADD_HYPERPARAMETER' | 'IMPORT_DATA';
+type TrialJobEvent = TrialJobStatus | 'USER_TO_CANCEL' | 'ADD_CUSTOMIZED' | 'ADD_HYPERPARAMETER' | 'IMPORT_DATA' |'ADD_RESUMED';
 type MetricType = 'PERIODICAL' | 'FINAL' | 'CUSTOM' | 'REQUEST_PARAMETER';
 
 interface ExperimentProfileRecord {

--- a/ts/nni_manager/common/trainingService.ts
+++ b/ts/nni_manager/common/trainingService.ts
@@ -34,6 +34,7 @@ interface TrialJobApplicationForm {
     readonly sequenceId: number;
     readonly hyperParameters: HyperParameters;
     readonly placementConstraint?: PlacementConstraint;
+    id?: string;
 }
 
 interface TrialCommandContent {

--- a/ts/nni_manager/test/mock/datastore.ts
+++ b/ts/nni_manager/test/mock/datastore.ts
@@ -229,6 +229,8 @@ class MockedDataStore implements DataStore {
                 return 'USER_CANCELED';
             case 'ADD_CUSTOMIZED':
                 return 'WAITING';
+            case 'ADD_RESUMED':
+                return 'WAITING';
         }
         return <TrialJobStatus>event;
     }

--- a/ts/nni_manager/training_service/kubernetes/adl/adlTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/adl/adlTrainingService.ts
@@ -116,7 +116,7 @@ class AdlTrainingService extends KubernetesTrainingService implements Kubernetes
             this.kubernetesRestServerPort = restServer.clusterRestServerPort;
         }
 
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
         const adlJobName: string = `nni-exp-${this.experimentId}-trial-${trialJobId}`.toLowerCase();
         const initStatus: TrialJobStatus = 'WAITING';
         const codeDir = this.adlTrialConfig.codeDir;

--- a/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/frameworkcontroller/frameworkcontrollerTrainingService.ts
@@ -131,7 +131,7 @@ class FrameworkControllerTrainingService extends KubernetesTrainingService imple
             await this.copyExpCodeDirPromise;
         }
 
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
         // Set trial's NFS working folder
         const trialWorkingFolder: string = path.join(this.CONTAINER_MOUNT_PATH, 'nni', getExperimentId(), trialJobId);
         const trialLocalTempFolder: string = path.join(getExperimentRootDir(), 'trials', trialJobId);

--- a/ts/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
+++ b/ts/nni_manager/training_service/kubernetes/kubeflow/kubeflowTrainingService.ts
@@ -78,7 +78,7 @@ class KubeflowTrainingService extends KubernetesTrainingService implements Kuber
             await this.copyExpCodeDirPromise;
         }
 
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
         const trialWorkingFolder: string = path.join(this.CONTAINER_MOUNT_PATH, 'nni', getExperimentId(), trialJobId);
         const kubeflowJobName: string = `nni-exp-${this.experimentId}-trial-${trialJobId}`.toLowerCase();
         const trialLocalTempFolder: string = path.join(getExperimentRootDir(), 'trials', trialJobId);

--- a/ts/nni_manager/training_service/local/localTrainingService.ts
+++ b/ts/nni_manager/training_service/local/localTrainingService.ts
@@ -193,7 +193,7 @@ class LocalTrainingService implements TrainingService {
     }
 
     public submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
         const trialJobDetail: LocalTrialJobDetail = new LocalTrialJobDetail(
             trialJobId,
             'WAITING',

--- a/ts/nni_manager/training_service/pai/paiTrainingService.ts
+++ b/ts/nni_manager/training_service/pai/paiTrainingService.ts
@@ -248,7 +248,7 @@ class PAITrainingService implements TrainingService {
     public async submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
         this.log.info('submitTrialJob: form:',  form);
 
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
         //TODO: use HDFS working folder instead
         const trialWorkingFolder: string = path.join(this.expRootDir, 'trials', trialJobId);
         const paiJobName: string = `nni_exp_${this.experimentId}_trial_${trialJobId}`;

--- a/ts/nni_manager/training_service/remote_machine/remoteMachineTrainingService.ts
+++ b/ts/nni_manager/training_service/remote_machine/remoteMachineTrainingService.ts
@@ -226,7 +226,7 @@ class RemoteMachineTrainingService implements TrainingService {
      */
     public async submitTrialJob(form: TrialJobApplicationForm): Promise<TrialJobDetail> {
         // Generate trial job id(random)
-        const trialJobId: string = uniqueString(5);
+        const trialJobId: string = form.id === undefined ? uniqueString(5) : form.id;
 
         const trialJobDetail: RemoteMachineTrialJobDetail = new RemoteMachineTrialJobDetail(
             trialJobId,

--- a/ts/nni_manager/training_service/reusable/trialDispatcher.ts
+++ b/ts/nni_manager/training_service/reusable/trialDispatcher.ts
@@ -160,7 +160,7 @@ class TrialDispatcher implements TrainingService {
     }
 
     public async submitTrialJob(form: TrialJobApplicationForm): Promise<TrialDetail> {
-        const trialId: string = uniqueString(5);
+        const trialId: string = form.id === undefined ? uniqueString(5) : form.id;
 
         const trialJobDetail: TrialDetail = new TrialDetail(trialId, "WAITING", Date.now(), "", form);
 


### PR DESCRIPTION
### Description ###
update resume logic, change RUNNING/WAITING to WAITING (was FAILED).
send resume parameters to the tuner side, to allow deduplication logic work.

NOTE: currently only TPE tuner implemented the import_customized_data function.

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
1. run the case: nnictl create --config examples/trials/mnist-pytorch/config.yml 
2. nnictl stop
3. nnictl resume xxx
4. check the status(waiting for the not finished trials), check the "Trial No."(keep original sequenceId/parameter_index)
5. after all trials done, no duplicate params.

