### PR TITLE
fix the bug that can only create two stage

### DIFF
--- a/nni/algorithms/nas/pytorch/fbnet/mutator.py
+++ b/nni/algorithms/nas/pytorch/fbnet/mutator.py
@@ -148,7 +148,7 @@ class FBNetMutator(BaseMutator):
 
             for i in range(left, left + right):
                 ops_names_mutable[i] = ops_names
-            left = right
+            left += right
 
         # Create the mixed op
         for i, mutable in enumerate(self.undedup_mutables):


### PR DESCRIPTION
### Description ###
find error when define stages more than two in example/nas/oneshot/pfld/lib/builder.py
#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


