### PR TITLE
add url prefix as logs/ api path

### DIFF
--- a/ts/webui/src/static/const.ts
+++ b/ts/webui/src/static/const.ts
@@ -14,7 +14,7 @@ const METRIC_GROUP_UPDATE_SIZE = 20;
 const prefix = getPrefix();
 const RESTAPI = '/api/v1/nni';
 const MANAGER_IP = prefix === undefined ? RESTAPI : `${prefix}${RESTAPI}`;
-const DOWNLOAD_IP = `/logs`;
+const DOWNLOAD_IP = `${prefix}/logs`;
 
 const WEBUIDOC = 'https://nni.readthedocs.io/en/latest/experiment/webui.html';
 


### PR DESCRIPTION
### Description ###
background: support url prefix in v2.3. in v2.7 when you click `nnimanager log`,it always show `waiting`...
actually `logs/` api also need the url prefix

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
start an experiment: nnictl create --config xxx --url_prefix xx
use `logs file` btn to see experiment logs

![image](https://user-images.githubusercontent.com/61399850/175246201-fde426e0-5a59-4657-b1ca-41fa6eaabbaa.png)


