### PR TITLE
Add pretrained weight for autoformer

### DIFF
--- a/nni/retiarii/hub/pytorch/utils/pretrained.py
+++ b/nni/retiarii/hub/pytorch/utils/pretrained.py
@@ -37,6 +37,11 @@ PRETRAINED_WEIGHT_URLS = {
 
     # spos
     'spos': f'{NNI_BLOB}/nashub/spos-0b17f6fc.pth',
+
+    # Autoformer
+    "autoformer-tiny": f'{NNI_BLOB}/nashub/autoformer_tiny-7bd6a6f4.pth',
+    "autoformer-small": f'{NNI_BLOB}/nashub/autoformer_small-26d42568.pth',
+    "autoformer-base": f'{NNI_BLOB}/nashub/autoformer_base-a797015d.pth',
 }
 
 


### PR DESCRIPTION
### Description ###
The AutoFormer in `hub` is
Implemented the pre-trained weights load function(`load_searched_model`)  of Autoformer in `hub`. This `load_searched_model` method will load the searched model converted from [ official  Autoformer repo](https://github.com/microsoft/Cream/tree/83a154beb6f85dd6141853b4b7c0738eeec628ba/AutoFormer). The results were consistent.
![reproduce](https://user-images.githubusercontent.com/28671582/175529703-bfa631c0-9f23-49c9-85c9-32eacea79b1f.png)

#### key modification

- add pretrained url in  
https://github.com/microsoft/nni/blob/d5921a7312da8c12199e1acb0faf090bebce2b7c/nni/retiarii/hub/pytorch/utils/pretrained.py#L14
- use the fixed head dim rather than 
https://github.com/microsoft/nni/blob/d5921a7312da8c12199e1acb0faf090bebce2b7c/nni/retiarii/hub/pytorch/autoformer.py#L94-L106  

#### Test Options ####
  - [x] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [x] test case
  - [ ] doc

### How to test ###

```
import nni.retiarii.hub.pytorch as hub

# support name: 'autoformer-tiny', 'autoformer-small', 'autoformer-base' 
name = "autoformer-tiny"
model = hub.AutoformerSpace.load_searched_model(name, pretrained=True, download=True)
model.eval()

evaluate(model, dataloader)
```


