### PR TITLE
Add condition control when passing parameters bounds to scipy.minimize.

### DIFF
--- a/nni/algorithms/hpo/gp_tuner/util.py
+++ b/nni/algorithms/hpo/gp_tuner/util.py
@@ -89,7 +89,8 @@ def acq_max(f_acq, gp, y_max, bounds, space, num_warmup, num_starting_points):
     x_seeds = [space.random_sample() for _ in range(int(num_starting_points))]
 
     bounds_minmax = np.array(
-        [[bound['_value'][0], bound['_value'][-1]] for bound in bounds])
+        [[bound['_value'][0], bound['_value'][1 if bound['_type'] == 'quniform' 
+            or bound['_type'] == 'qloguniform' else -1]] for bound in bounds])
 
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function

--- a/nni/algorithms/hpo/gp_tuner/util.py
+++ b/nni/algorithms/hpo/gp_tuner/util.py
@@ -89,7 +89,7 @@ def acq_max(f_acq, gp, y_max, bounds, space, num_warmup, num_starting_points):
     x_seeds = [space.random_sample() for _ in range(int(num_starting_points))]
 
     bounds_minmax = np.array(
-        [[bound['_value'][0], bound['_value'][1 if bound['_type'] == 'quniform' 
+        [[bound['_value'][0], bound['_value'][1 if bound['_type'] == 'quniform'
             or bound['_type'] == 'qloguniform' else -1]] for bound in bounds])
 
     for x_try in x_seeds:


### PR DESCRIPTION
### Description ###
See [Issue](https://github.com/microsoft/nni/issues/4974). When using GP tuner, it will pass wrong search space bound to scipy, which will fail bound check. Previous code is:
```
    bounds_minmax = np.array(
        [[bound['_value'][0], bound['_value'][-1]] for bound in bounds])
```
But GP tuner should support both quniform and qloguniform, which is [low, high, q]. `bound['_value'][-1]` will visit q instead of higher bound.