### PR TITLE
Fix Autoformer to compatible with RandomOneShot strategy

### DIFF
--- a/nni/retiarii/hub/pytorch/autoformer.py
+++ b/nni/retiarii/hub/pytorch/autoformer.py
@@ -371,6 +371,10 @@ class AutoformerSpace(nn.Module):
         self.head = nn.Linear(cast(int, embed_dim), num_classes) if num_classes > 0 else nn.Identity()
 
     @classmethod
+    def get_extra_mutation_hooks(cls):
+        return [MixedAbsPosEmbed.mutate, MixedClsToken.mutate]
+
+    @classmethod
     def load_searched_model(
         cls, name: str,
         pretrained: bool = False, download: bool = False, progress: bool = True

--- a/nni/retiarii/hub/pytorch/autoformer.py
+++ b/nni/retiarii/hub/pytorch/autoformer.py
@@ -8,7 +8,10 @@ import torch
 import torch.nn.functional as F
 from timm.models.layers import trunc_normal_, DropPath
 import nni.retiarii.nn.pytorch as nn
+
+
 from nni.retiarii import model_wrapper
+from nni.retiarii.hub.pytorch.utils.fixed import FixedFactory
 
 
 class RelativePosition2D(nn.Module):
@@ -16,10 +19,8 @@ class RelativePosition2D(nn.Module):
         super().__init__()
         self.head_embed_dim = head_embed_dim
         self.legnth = length
-        self.embeddings_table_v = nn.Parameter(
-            torch.randn(length * 2 + 2, head_embed_dim))
-        self.embeddings_table_h = nn.Parameter(
-            torch.randn(length * 2 + 2, head_embed_dim))
+        self.embeddings_table_v = nn.Parameter(torch.randn(length * 2 + 2, head_embed_dim))
+        self.embeddings_table_h = nn.Parameter(torch.randn(length * 2 + 2, head_embed_dim))
 
         trunc_normal_(self.embeddings_table_v, std=.02)
         trunc_normal_(self.embeddings_table_h, std=.02)
@@ -28,44 +29,26 @@ class RelativePosition2D(nn.Module):
         # remove the first cls token distance computation
         length_q = length_q - 1
         length_k = length_k - 1
-        range_vec_q = torch.arange(length_q)
-        range_vec_k = torch.arange(length_k)
+        range_vec_q = torch.arange(length_q, device=self.embeddings_table_v.device)
+        range_vec_k = torch.arange(length_k, device=self.embeddings_table_v.device)
         # compute the row and column distance
-        distance_mat_v = (range_vec_k[None, :] //
-                          int(length_q ** 0.5) -
-                          range_vec_q[:, None] //
-                          int(length_q ** 0.5))
-        distance_mat_h = (range_vec_k[None, :] %
-                          int(length_q ** 0.5) -
-                          range_vec_q[:, None] %
-                          int(length_q ** 0.5))
+        distance_mat_v = (range_vec_k[None, :] // int(length_q ** 0.5) - range_vec_q[:, None] // int(length_q ** 0.5))
+        distance_mat_h = (range_vec_k[None, :] % int(length_q ** 0.5) - range_vec_q[:, None] % int(length_q ** 0.5))
         # clip the distance to the range of [-legnth, legnth]
-        distance_mat_clipped_v = torch.clamp(
-            distance_mat_v, -self.legnth, self.legnth)
-        distance_mat_clipped_h = torch.clamp(
-            distance_mat_h, -self.legnth, self.legnth)
+        distance_mat_clipped_v = torch.clamp(distance_mat_v, -self.legnth, self.legnth)
+        distance_mat_clipped_h = torch.clamp(distance_mat_h, -self.legnth, self.legnth)
 
-        # translate the distance from [1, 2 * legnth + 1], 0 is for the cls
-        # token
+        # translate the distance from [1, 2 * legnth + 1], 0 is for the cls token
         final_mat_v = distance_mat_clipped_v + self.legnth + 1
         final_mat_h = distance_mat_clipped_h + self.legnth + 1
         # pad the 0 which represent the cls token
-        final_mat_v = F.pad(
-            final_mat_v, (1, 0, 1, 0), "constant", 0)
-        final_mat_h = F.pad(
-            final_mat_h, (1, 0, 1, 0), "constant", 0)
+        final_mat_v = F.pad(final_mat_v, (1, 0, 1, 0), "constant", 0)
+        final_mat_h = F.pad(final_mat_h, (1, 0, 1, 0), "constant", 0)
 
-        final_mat_v = torch.tensor(
-            final_mat_v,
-            dtype=torch.long,
-            device=self.embeddings_table_v.device)
-        final_mat_h = torch.tensor(
-            final_mat_h,
-            dtype=torch.long,
-            device=self.embeddings_table_v.device)
+        final_mat_v = final_mat_v.long()
+        final_mat_h = final_mat_h.long()
         # get the embeddings with the corresponding distance
-        embeddings = self.embeddings_table_v[final_mat_v] + \
-            self.embeddings_table_h[final_mat_h]
+        embeddings = self.embeddings_table_v[final_mat_v] + self.embeddings_table_h[final_mat_h]
 
         return embeddings
 
@@ -80,61 +63,66 @@ class RelativePositionAttention(nn.Module):
     and keys in self-attention modules.
     """
     def __init__(
-            self,
-            embed_dim,
-            fixed_embed_dim,
-            num_heads,
-            attn_drop=0.,
-            proj_drop=0,
-            rpe=False,
-            qkv_bias=False,
-            qk_scale=None,
-            rpe_length=14) -> None:
+            self, embed_dim, num_heads,
+            attn_drop=0., proj_drop=0.,
+            qkv_bias = False, qk_scale = None,
+            rpe_length = 14, rpe = False,
+            head_dim = 64):
         super().__init__()
+        head_dim = head_dim or (embed_dim // num_heads)
         self.num_heads = num_heads
-        head_dim = embed_dim // num_heads
+        self.head_dim = head_dim
         self.scale = qk_scale or head_dim ** -0.5
-        self.qkv = nn.Linear(embed_dim, embed_dim * 3, bias=qkv_bias)
+        """
+        When head nums increase from 2 to 3. 
+        For nn.Linear(embed_dim, (head_dim * num_heads) * 3), 
+        the activate(o) weight distribute: ■■■■■■□□□□□□ -> ■■■■■■■■■□□□. not suitable.
+        when use three split nn.Linear(embed_dim, (head_dim * num_heads)).
+        the activate(o) weight distribute: ■■□□■■□□■■□□ -> ■■■□■■■□■■■□
+        """
+        self.q = nn.Linear(embed_dim, head_dim * num_heads, bias=qkv_bias)
+        self.k = nn.Linear(embed_dim, head_dim * num_heads, bias=qkv_bias)
+        self.v = nn.Linear(embed_dim, head_dim * num_heads, bias=qkv_bias)
+
         self.attn_drop = nn.Dropout(attn_drop)
-        self.proj = nn.Linear(embed_dim, embed_dim)
+        self.proj = nn.Linear(head_dim * num_heads, embed_dim)
         self.proj_drop = nn.Dropout(proj_drop)
         self.rpe = rpe
         if rpe:
-            self.rel_pos_embed_k = RelativePosition2D(
-                fixed_embed_dim // num_heads, rpe_length)
-            self.rel_pos_embed_v = RelativePosition2D(
-                fixed_embed_dim // num_heads, rpe_length)
+            self.rel_pos_embed_k = RelativePosition2D(head_dim, rpe_length)
+            self.rel_pos_embed_v = RelativePosition2D(head_dim, rpe_length)
 
     def forward(self, x):
         B, N, C = x.shape
-        qkv = self.qkv(x).reshape(B,N,3,self.num_heads,C//self.num_heads).permute(
-            2,0,3,1,4)
-        # make torchscript happy (cannot use tensor as tuple)
-        q, k, v = qkv[0], qkv[1], qkv[2]
+        head_dim = self.head_dim
+        num_heads = -1
+        # [B, N, C] -> [B, N, heads, head_dim] -> [B, heads, N, head_dim]
+        q = self.q(x).reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
+        k = self.k(x).reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
+        v = self.v(x).reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
+        num_heads = q.size(1)
 
         attn = (q @ k.transpose(-2, -1)) * self.scale
+
         if self.rpe:
             r_p_k = self.rel_pos_embed_k(N, N)
             attn = attn + (
-                q.permute(2, 0, 1, 3).reshape(
-                    N, self.num_heads * B, -1) @ r_p_k.transpose(
-                    2, 1)) .transpose(1, 0).reshape(
-                        B, self.num_heads, N, N) * self.scale
+                q.permute(2, 0, 1, 3).reshape(N, num_heads * B, head_dim) @ r_p_k.transpose(2, 1)
+            ).transpose(1, 0).reshape(B, num_heads, N, N) * self.scale
 
         attn = attn.softmax(dim=-1)
         attn = self.attn_drop(attn)
 
-        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, num_heads * head_dim)
+        
         if self.rpe:
+            attn_1 = attn.permute(2, 0, 1, 3).reshape(N, B * num_heads, N)
             r_p_v = self.rel_pos_embed_v(N, N)
-            attn_1 = attn.permute(
-                2, 0, 1, 3).reshape(
-                N, B * self.num_heads, -1)
             # The size of attention is (B, num_heads, N, N), reshape it to (N, B*num_heads, N) and do batch matmul with
             # the relative position embedding of V (N, N, head_dim) get shape like (N, B*num_heads, head_dim). We reshape it to the
             # same size as x (B, num_heads, N, hidden_dim)
-            x = x + (attn_1 @ r_p_v).transpose(1, 0).reshape(B,
-                                                             self.num_heads, N, -1).transpose(2, 1).reshape(B, N, -1)
+            x = x + (attn_1 @ r_p_v).transpose(1, 0).reshape(B, num_heads, N, head_dim).transpose(2, 1).reshape(B, N, num_heads * head_dim)
+        
         x = self.proj(x)
         x = self.proj_drop(x)
         return x
@@ -148,7 +136,6 @@ class TransformerEncoderLayer(nn.Module):
     def __init__(
         self,
         embed_dim,
-        fixed_embed_dim,
         num_heads,
         mlp_ratio=4.,
         qkv_bias=False,
@@ -160,62 +147,38 @@ class TransformerEncoderLayer(nn.Module):
         drop_path=0.,
         pre_norm=True,
         rpe_length=14,
+        head_dim=64
     ):
         super().__init__()
 
         self.normalize_before = pre_norm
-        self.drop_path = DropPath(
-            drop_path) if drop_path > 0. else nn.Identity()
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
         self.dropout = drop_rate
         self.attn = RelativePositionAttention(
-            embed_dim=embed_dim,
-            fixed_embed_dim=fixed_embed_dim,
-            num_heads=num_heads,
-            attn_drop=attn_drop,
+            embed_dim = embed_dim,
+            num_heads = num_heads,
+            attn_drop = attn_drop,
             proj_drop=proj_drop,
             rpe=rpe,
             qkv_bias=qkv_bias,
             qk_scale=qk_scale,
-            rpe_length=rpe_length)
+            rpe_length=rpe_length,
+            head_dim = head_dim
+        )
 
         self.attn_layer_norm = nn.LayerNorm(embed_dim)
         self.ffn_layer_norm = nn.LayerNorm(embed_dim)
+
         self.activation_fn = nn.GELU()
+
         self.fc1 = nn.Linear(
-            cast(int, embed_dim), cast(int, nn.ValueChoice.to_int(
-                embed_dim * mlp_ratio)))
+            cast(int, embed_dim), 
+            cast(int, nn.ValueChoice.to_int(embed_dim * mlp_ratio))
+        )
         self.fc2 = nn.Linear(
-            cast(int, nn.ValueChoice.to_int(
-                embed_dim * mlp_ratio)),
-            cast(int, embed_dim))
-
-    def forward(self, x):
-        """
-        Args:
-            x (Tensor): input to the layer of shape `(batch, patch_num , sample_embed_dim)`
-
-        Returns:
-            encoded output of shape `(batch, patch_num, sample_embed_dim)`
-        """
-        residual = x
-        x = self.maybe_layer_norm(self.attn_layer_norm, x, before=True)
-        x = self.attn(x)
-        x = nn.functional.dropout(x, p=self.dropout, training=self.training)
-        x = self.drop_path(x)
-        x = residual + x
-        x = self.maybe_layer_norm(self.attn_layer_norm, x, after=True)
-
-        residual = x
-        x = self.maybe_layer_norm(self.ffn_layer_norm, x, before=True)
-        x = self.fc1(x)
-        x = self.activation_fn(x)
-        x = nn.functional.dropout(x, p=self.dropout, training=self.training)
-        x = self.fc2(x)
-        x = nn.functional.dropout(x, p=self.dropout, training=self.training)
-        x = self.drop_path(x)
-        x = residual + x
-        x = self.maybe_layer_norm(self.ffn_layer_norm, x, after=True)
-        return x
+            cast(int, nn.ValueChoice.to_int(embed_dim * mlp_ratio)),
+            cast(int, embed_dim)
+        )
 
     def maybe_layer_norm(self, layer_norm, x, before=False, after=False):
         assert before ^ after
@@ -224,13 +187,69 @@ class TransformerEncoderLayer(nn.Module):
         else:
             return x
 
+    def forward(self, x):
+        """
+        Args:
+            x (Tensor): input to the layer of shape `(batch, patch_num , sample_embed_dim)`
+        Returns:
+            encoded output of shape `(batch, patch_num, sample_embed_dim)`
+        """
+        residual = x
+        x = self.maybe_layer_norm(self.attn_layer_norm, x, before=True)
+        x = self.attn(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = self.drop_path(x)
+        x = residual + x
+        x = self.maybe_layer_norm(self.attn_layer_norm, x, after=True)
+        
+        residual = x
+        x = self.maybe_layer_norm(self.ffn_layer_norm, x, before=True)
+        x = self.fc1(x)
+        x = self.activation_fn(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = self.fc2(x)
+        x = F.dropout(x, p=self.dropout, training=self.training)
+        x = self.drop_path(x)
+        x = residual + x
+        x = self.maybe_layer_norm(self.ffn_layer_norm, x, after=True)
+
+        return x
+
+
+class ClsToken(nn.Module):
+    """ Concat class token before patch embedding.
+    """
+    def __init__(self, embed_dim):
+        super(ClsToken, self).__init__()
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        trunc_normal_(self.cls_token, std=.02)
+    
+    def forward(self, x):
+        B, N, C = x.shape
+        cls_token = self.cls_token[..., :C].expand(B, -1, -1)
+        x = torch.cat((cls_token, x), dim=1)
+        return x
+
+class AbsPosEmbed(nn.Module):
+    """ Add absolute position for patch embedding.
+    """
+    def __init__(self, length, embed_dim, enable = False):
+        super(AbsPosEmbed, self).__init__()
+        self.enable = enable
+        self.pos_embed = nn.Parameter(torch.zeros(1, length, embed_dim))
+        trunc_normal_(self.pos_embed, std=.02)
+
+    def forward(self, x):
+        if not self.enable:
+            return x
+        B, N, C = x.shape
+        return x + self.pos_embed[..., :C]
 
 @model_wrapper
 class AutoformerSpace(nn.Module):
     """
     The search space that is proposed in `Autoformer <https://arxiv.org/abs/2107.00651>`__.
     There are four searchable variables: depth, embedding dimension, heads number and MLP ratio.
-
     Parameters
     ----------
     search_embed_dim : list of int
@@ -267,13 +286,12 @@ class AutoformerSpace(nn.Module):
         The scaler on score map in self-attention.
     rpe : bool
         Whether to use relative position encoding.
-
     """
 
     def __init__(
             self,
             search_embed_dim: Tuple[int, ...] = (192, 216, 240),
-            search_mlp_ratio: Tuple[float, ...] = (3.5, 4.0),
+            search_mlp_ratio: Tuple[float, ...] = (3.0, 3.5, 4.0),
             search_num_heads: Tuple[int, ...] = (3, 4),
             search_depth: Tuple[int, ...] = (12, 13, 14),
             img_size: int = 224,
@@ -293,61 +311,136 @@ class AutoformerSpace(nn.Module):
         super().__init__()
 
         embed_dim = nn.ValueChoice(list(search_embed_dim), label="embed_dim")
-        fixed_embed_dim = nn.ModelParameterChoice(
-            list(search_embed_dim), label="embed_dim")
         depth = nn.ValueChoice(list(search_depth), label="depth")
+        mlp_ratios = [nn.ValueChoice(list(search_mlp_ratio), label=f"mlp_ratio_{i}") for i in range(max(search_depth))]
+        num_heads = [nn.ValueChoice(list(search_num_heads), label=f"num_head_{i}") for i in range(max(search_depth))]
+
         self.patch_embed = nn.Conv2d(
-            in_chans,
-            cast(int, embed_dim),
-            kernel_size=patch_size,
-            stride=patch_size)
+            in_chans, cast(int, embed_dim),
+            kernel_size = patch_size,
+            stride = patch_size
+        )
         self.patches_num = int((img_size // patch_size) ** 2)
         self.global_pool = global_pool
-        self.cls_token = nn.Parameter(torch.zeros(1, 1, cast(int, fixed_embed_dim)))
-        trunc_normal_(self.cls_token, std=.02)
 
-        dpr = [
-            x.item() for x in torch.linspace(
-                0,
-                drop_path_rate,
-                max(search_depth))]  # stochastic depth decay rule
+        self.cls_token = ClsToken(max(search_embed_dim))
+        self.pos_embed = AbsPosEmbed(self.patches_num+1, max(search_embed_dim), abs_pos)
 
-        self.abs_pos = abs_pos
-        if self.abs_pos:
-            self.pos_embed = nn.Parameter(torch.zeros(
-                1, self.patches_num + 1, cast(int, fixed_embed_dim)))
-            trunc_normal_(self.pos_embed, std=.02)
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, max(search_depth))]  # stochastic depth decay rule
 
-        self.blocks = nn.Repeat(lambda index: nn.LayerChoice([
-            TransformerEncoderLayer(embed_dim=embed_dim,
-                                    fixed_embed_dim=fixed_embed_dim,
-                                    num_heads=num_heads, mlp_ratio=mlp_ratio,
-                                    qkv_bias=qkv_bias, drop_rate=drop_rate,
-                                    attn_drop=attn_drop_rate,
-                                    drop_path=dpr[index],
-                                    rpe_length=img_size // patch_size,
-                                    qk_scale=qk_scale, rpe=rpe,
-                                    pre_norm=pre_norm,)
-            for mlp_ratio, num_heads in itertools.product(search_mlp_ratio, search_num_heads)
-        ], label=f'layer{index}'), depth)
-        self.pre_norm = pre_norm
-        if self.pre_norm:
-            self.norm = nn.LayerNorm(cast(int, embed_dim))
-        self.head = nn.Linear(
-            cast(int, embed_dim),
-            num_classes) if num_classes > 0 else nn.Identity()
+        self.blocks = nn.Repeat(
+            lambda index: TransformerEncoderLayer(
+                embed_dim = embed_dim, num_heads = num_heads[index], mlp_ratio=mlp_ratios[index],
+                qkv_bias = qkv_bias, drop_rate = drop_rate, attn_drop = attn_drop_rate, drop_path=dpr[index],
+                rpe_length=img_size // patch_size, qk_scale=qk_scale, rpe=rpe, pre_norm=pre_norm, head_dim = 64
+            ), depth
+        )
+
+        self.norm = nn.LayerNorm(cast(int, embed_dim)) if pre_norm else nn.Identity()
+        self.head = nn.Linear(cast(int, embed_dim), num_classes) if num_classes > 0 else nn.Identity()
+
+    @classmethod
+    def fixed_model(cls, name: str = "small") -> nn.Module:
+        init_kwargs = {"qkv_bias": True, "drop_rate": 0.0, "drop_path_rate": 0.1, "global_pool": True, "num_classes": 3}
+        if name == "small":
+            arch = {
+                'embed_dim': 64, 
+                'depth': 2, 
+                "mlp_ratio_0": 1.0,
+                "mlp_ratio_1": 1.0,
+                "num_head_0": 2,
+                "num_head_1": 2
+            }
+            init_kwargs.update({
+                "search_embed_dim": (64, 128),
+                "search_mlp_ratio": (1.0, 1.5),
+                "search_num_heads": (2, 3),
+                "search_depth": (1, 2)
+            })
+        elif name == "large":
+            arch = {
+                'embed_dim': 128, 
+                'depth': 2, 
+                "mlp_ratio_0": 1.5,
+                "mlp_ratio_1": 1.5,
+                "num_head_0": 3,
+                "num_head_1": 3
+            }
+            init_kwargs.update({
+                "search_embed_dim": (64, 128),
+                "search_mlp_ratio": (1.0, 1.5),
+                "search_num_heads": (2, 3),
+                "search_depth": (1, 2)
+            })
+        else:
+            raise ValueError(f'Unsupported architecture with name: {name}')
+
+        model_factory = FixedFactory(cls, arch)
+        model = model_factory(**init_kwargs)
+
+        return model
+
+    def load_supernet(
+        cls, name: str,
+        pretrained: bool = False, download: bool = False, progress: bool = True
+    ) -> nn.Module:
+
+        if pretrained:
+            pass
+            # weight_file = load_pretrained_weight(name, download=download, progress=progress)
+            # pretrained_weights = torch.load(weight_file)
+            # model.load_state_dict(pretrained_weights)
+
+        return 
+
+    @classmethod
+    def load_searched_model(
+        cls, name: str,
+        pretrained: bool = False, download: bool = False, progress: bool = True
+    ) -> nn.Module:
+
+        init_kwargs = {"qkv_bias": True, "drop_rate": 0.0, "drop_path_rate": 0.1, "global_pool": True, "num_classes": 3}
+        if name == "autoformer-tiny":
+            mlp_ratio = [3.5, 3.5, 3.0, 3.5, 3.0, 3.0, 4.0, 4.0, 3.5, 4.0, 3.5, 4.0, 3.5] + [3.0]
+            num_head = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3] + [3]
+            arch = {
+                'embed_dim': 192, 
+                'depth': 13
+            }
+            for i in range(14):
+                arch[f"mlp_ratio_{i}"] = mlp_ratio[i]
+                arch[f"num_head_{i}"] = num_head[i]
+
+            init_kwargs.update({
+                "search_embed_dim": (240, 216, 192),
+                "search_mlp_ratio": (4.0, 3.5, 3.0),
+                "search_num_heads": (4, 3),
+                "search_depth": (14, 13, 12),
+            })
+
+        else:
+            raise ValueError(f'Unsupported architecture with name: {name}')
+
+        model_factory = FixedFactory(cls, arch)
+        model = model_factory(**init_kwargs)
+
+        if pretrained:
+            pass
+            # weight_file = load_pretrained_weight(name, download=download, progress=progress)
+            # pretrained_weights = torch.load(weight_file)
+            # model.load_state_dict(pretrained_weights)
+
+        return model
 
     def forward(self, x):
         B = x.shape[0]
         x = self.patch_embed(x)
         x = x.permute(0, 2, 3, 1).view(B, self.patches_num, -1)
-        cls_tokens = self.cls_token.expand(B, -1, -1)
-        x = torch.cat((cls_tokens, x), dim=1)
-        if self.abs_pos:
-            x = x + self.pos_embed
+        x = self.cls_token(x)
+        x = self.pos_embed(x)
         x = self.blocks(x)
-        if self.pre_norm:
-            x = self.norm(x)
+        x = self.norm(x)
+        
         if self.global_pool:
             x = torch.mean(x[:, 1:], dim=1)
         else:

--- a/nni/retiarii/hub/pytorch/autoformer.py
+++ b/nni/retiarii/hub/pytorch/autoformer.py
@@ -382,15 +382,23 @@ class AutoformerSpace(nn.Module):
 
         init_kwargs = {'qkv_bias': True, 'drop_rate': 0.0, 'drop_path_rate': 0.1, 'global_pool': True, 'num_classes': 1000}
         if name == 'autoformer-tiny':
-            mlp_ratio = [3.5, 3.5, 3.0, 3.5, 3.0, 3.0, 4.0, 4.0, 3.5, 4.0, 3.5, 4.0, 3.5] + [3.0]
-            num_head = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3] + [3]
             arch = {
-                'embed_dim': 192,
-                'depth': 13
+                'embed_dim': 192, 'depth': 13,
+                'mlp_ratio_0': 3.5, 'num_head_0': 3,
+                'mlp_ratio_1': 3.5, 'num_head_1': 3,
+                'mlp_ratio_2': 3.0, 'num_head_2': 3,
+                'mlp_ratio_3': 3.5, 'num_head_3': 3,
+                'mlp_ratio_4': 3.0, 'num_head_4': 3,
+                'mlp_ratio_5': 3.0, 'num_head_5': 3,
+                'mlp_ratio_6': 4.0, 'num_head_6': 3,
+                'mlp_ratio_7': 4.0, 'num_head_7': 3,
+                'mlp_ratio_8': 3.5, 'num_head_8': 3,
+                'mlp_ratio_9': 4.0, 'num_head_9': 3,
+                'mlp_ratio_10': 3.5, 'num_head_10': 4,
+                'mlp_ratio_11': 4.0, 'num_head_11': 3,
+                'mlp_ratio_12': 3.5, 'num_head_12': 3,
+                'mlp_ratio_13': 3.0, 'num_head_13': 3
             }
-            for i in range(14):
-                arch[f'mlp_ratio_{i}'] = mlp_ratio[i]
-                arch[f'num_head_{i}'] = num_head[i]
 
             init_kwargs.update({
                 'search_embed_dim': (240, 216, 192),
@@ -399,15 +407,23 @@ class AutoformerSpace(nn.Module):
                 'search_depth': (14, 13, 12),
             })
         elif name == 'autoformer-small':
-            mlp_ratio = [3.0, 3.5, 3.0, 3.5, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 3.5, 4.0] + [3.0]
-            num_head = [6, 6, 5, 7, 5, 5, 5, 6, 6, 7, 7, 6, 7] + [5]
             arch = {
-                'embed_dim': 384,
-                'depth': 13
+                'embed_dim': 384, 'depth': 13,
+                'mlp_ratio_0': 3.0, 'num_head_0': 6,
+                'mlp_ratio_1': 3.5, 'num_head_1': 6,
+                'mlp_ratio_2': 3.0, 'num_head_2': 5,
+                'mlp_ratio_3': 3.5, 'num_head_3': 7,
+                'mlp_ratio_4': 4.0, 'num_head_4': 5,
+                'mlp_ratio_5': 4.0, 'num_head_5': 5,
+                'mlp_ratio_6': 4.0, 'num_head_6': 5,
+                'mlp_ratio_7': 4.0, 'num_head_7': 6,
+                'mlp_ratio_8': 4.0, 'num_head_8': 6,
+                'mlp_ratio_9': 4.0, 'num_head_9': 7,
+                'mlp_ratio_10': 4.0, 'num_head_10': 7,
+                'mlp_ratio_11': 3.5, 'num_head_11': 6,
+                'mlp_ratio_12': 4.0, 'num_head_12': 7,
+                'mlp_ratio_13': 3.0, 'num_head_13': 5
             }
-            for i in range(14):
-                arch[f'mlp_ratio_{i}'] = mlp_ratio[i]
-                arch[f'num_head_{i}'] = num_head[i]
 
             init_kwargs.update({
                 'search_embed_dim': (448, 384, 320),
@@ -417,15 +433,25 @@ class AutoformerSpace(nn.Module):
             })
 
         elif name == 'autoformer-base':
-            mlp_ratio = [3.5, 3.5, 4.0, 3.5, 4.0, 3.5, 3.5, 3.0, 4.0, 4.0, 3.0, 4.0, 3.0, 3.5] + [3.0, 3.0]
-            num_head = [9, 9, 9, 9, 9, 10, 9, 9, 10, 9, 10, 9, 9, 10] + [8, 8]
             arch = {
-                'embed_dim': 576,
-                'depth': 14
+                'embed_dim': 576, 'depth': 14,
+                'mlp_ratio_0': 3.5, 'num_head_0': 9,
+                'mlp_ratio_1': 3.5, 'num_head_1': 9,
+                'mlp_ratio_2': 4.0, 'num_head_2': 9,
+                'mlp_ratio_3': 3.5, 'num_head_3': 9,
+                'mlp_ratio_4': 4.0, 'num_head_4': 9,
+                'mlp_ratio_5': 3.5, 'num_head_5': 10,
+                'mlp_ratio_6': 3.5, 'num_head_6': 9,
+                'mlp_ratio_7': 3.0, 'num_head_7': 9,
+                'mlp_ratio_8': 4.0, 'num_head_8': 10,
+                'mlp_ratio_9': 4.0, 'num_head_9': 9,
+                'mlp_ratio_10': 3.0, 'num_head_10': 10,
+                'mlp_ratio_11': 4.0, 'num_head_11': 9,
+                'mlp_ratio_12': 3.0, 'num_head_12': 9,
+                'mlp_ratio_13': 3.5, 'num_head_13': 10,
+                'mlp_ratio_14': 3.0, 'num_head_14': 8,
+                'mlp_ratio_15': 3.0, 'num_head_15': 8
             }
-            for i in range(16):
-                arch[f'mlp_ratio_{i}'] = mlp_ratio[i]
-                arch[f'num_head_{i}'] = num_head[i]
 
             init_kwargs.update({
                 'search_embed_dim': (624, 576, 528),

--- a/nni/retiarii/hub/pytorch/utils/pretrained.py
+++ b/nni/retiarii/hub/pytorch/utils/pretrained.py
@@ -37,6 +37,11 @@ PRETRAINED_WEIGHT_URLS = {
 
     # spos
     'spos': f'{NNI_BLOB}/nashub/spos-0b17f6fc.pth',
+
+    # autoformer
+    'autoformer-tiny': f'{NNI_BLOB}/nashub/autoformer-searched-tiny-1e90ebc1.pth',
+    'autoformer-small': f'{NNI_BLOB}/nashub/autoformer-searched-small-4bc5d4e5.pth',
+    'autoformer-base': f'{NNI_BLOB}/nashub/autoformer-searched-base-c417590a.pth'
 }
 
 

--- a/nni/retiarii/oneshot/pytorch/supermodule/_operation_utils.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/_operation_utils.py
@@ -140,7 +140,7 @@ class Slicable(Generic[T]):
             raise TypeError(f'Unsuppoted weight type: {type(weight)}')
         self.weight = weight
 
-    def __getitem__(self, index: slice_type | multidim_slice) -> T:
+    def __getitem__(self, index: slice_type | multidim_slice | Any) -> T:
         if not isinstance(index, tuple):
             index = (index, )
         index = cast(multidim_slice, index)
@@ -267,7 +267,7 @@ def _iterate_over_slice_type(s: slice_type):
 def _iterate_over_multidim_slice(ms: multidim_slice):
     """Get :class:`MaybeWeighted` instances in ``ms``."""
     for s in ms:
-        if s is not None:
+        if s is not None and s is not Ellipsis:
             yield from _iterate_over_slice_type(s)
 
 
@@ -286,8 +286,8 @@ def _evaluate_multidim_slice(ms: multidim_slice, value_fn: _value_fn_type = None
     """Wraps :meth:`MaybeWeighted.evaluate` to evaluate the whole ``multidim_slice``."""
     res = []
     for s in ms:
-        if s is not None:
+        if s is not None and s is not Ellipsis:
             res.append(_evaluate_slice_type(s, value_fn))
         else:
-            res.append(None)
+            res.append(s)
     return tuple(res)

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -474,14 +474,15 @@ class MixedBatchNorm2d(MixedOperation, nn.BatchNorm2d):
         )
 
 class MixedLayerNorm(MixedOperation, nn.LayerNorm):
-    """ Mixed LayerNorm operation.
+    """
+    Mixed LayerNorm operation.
 
     Supported arguments are:
-    
-    - ``normalized_shape ``
+
+    - ``normalized_shape``
     - ``eps`` (only supported in path sampling)
-    
-    For path-sampling, prefix of ``weight`` and ``bias`` are sliced. 
+
+    For path-sampling, prefix of ``weight`` and ``bias`` are sliced.
     For weighted cases, the maximum ``normalized_shape`` is used directly.
 
     eps is required to be float.
@@ -509,7 +510,7 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
             return max(all_sizes)
 
     def forward_with_args(self,
-                          normalized_shape,
+                          normalized_shape: int_or_int_dict,
                           eps: float,
                           inputs: torch.Tensor) -> torch.Tensor:
 
@@ -524,7 +525,7 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
             normalized_shape = (normalized_shape, )
         if isinstance(self.normalized_shape, int):
             normalized_shape = (self.normalized_shape, )
-        
+
         # slice all the normalized shape
         indices = [slice(0, min(i, j)) for i, j in zip(normalized_shape, self.normalized_shape)]
 

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -529,8 +529,8 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
         # slice all the normalized shape
         indices = [slice(0, min(i, j)) for i, j in zip(normalized_shape, self.normalized_shape)]
 
-        weight = self.weight[indices] if self.weight is not None else None
-        bias = self.bias[indices] if self.bias is not None else None
+        weight = _S(self.weight)[indices] if self.weight is not None else None
+        bias = _S(self.bias)[indices] if self.bias is not None else None
 
         return F.layer_norm(
             inputs,

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -474,34 +474,62 @@ class MixedBatchNorm2d(MixedOperation, nn.BatchNorm2d):
         )
 
 class MixedLayerNorm(MixedOperation, nn.LayerNorm):
-    """
-    Mixed LayerNorm operation.
+    """ Mixed LayerNorm operation.
+
     Supported arguments are:
+    
     - ``normalized_shape ``
     - ``eps`` (only supported in path sampling)
-    For path-sampling, prefix of ``weight`` and ``bias`` are sliced. For weighted cases, the maximum ``normalized_shape`` is used directly.
+    
+    For path-sampling, prefix of ``weight`` and ``bias`` are sliced. 
+    For weighted cases, the maximum ``normalized_shape`` is used directly.
+
+    eps is required to be float.
     """
 
     bound_type = retiarii_nn.LayerNorm
     argument_list = ['normalized_shape', 'eps']
 
+    @staticmethod
+    def _to_tuple(value: scalar_or_scalar_dict[Any]) -> tuple[Any, Any]:
+        if not isinstance(value, tuple):
+            return (value, value)
+        return value
+
     def super_init_argument(self, name: str, value_choice: ValueChoiceX):
-        return max(traverse_all_options(value_choice))
+        if name not in ['normalized_shape']:
+            raise NotImplementedError(f'Unsupported value choice on argument: {name}')
+        all_sizes = set(traverse_all_options(value_choice))
+        if any(isinstance(sz, (tuple, list)) for sz in all_sizes):
+            # transpose
+            all_sizes = list(zip(*all_sizes))
+            # maximum dim should be calculated on every dimension
+            return (max(self._to_tuple(sz)) for sz in all_sizes)
+        else:
+            return max(all_sizes)
 
     def forward_with_args(self,
                           normalized_shape,
                           eps: float,
                           inputs: torch.Tensor) -> torch.Tensor:
+
+        if any(isinstance(arg, dict) for arg in [eps]):
+            raise ValueError(_diff_not_compatible_error.format('eps', 'LayerNorm'))
+
+        if isinstance(normalized_shape, dict):
+            normalized_shape = self.normalized_shape
+
         # make it as tuple
         if isinstance(normalized_shape, int):
             normalized_shape = (normalized_shape, )
         if isinstance(self.normalized_shape, int):
             normalized_shape = (self.normalized_shape, )
         
+        # slice all the normalized shape
         indices = [slice(0, min(i, j)) for i, j in zip(normalized_shape, self.normalized_shape)]
 
-        weight = self.weight[indices]
-        bias = self.bias[indices]
+        weight = self.weight[indices] if self.weight is not None else None
+        bias = self.bias[indices] if self.bias is not None else None
 
         return F.layer_norm(
             inputs,

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -529,8 +529,8 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
         # slice all the normalized shape
         indices = [slice(0, min(i, j)) for i, j in zip(normalized_shape, self.normalized_shape)]
 
-        weight = _S(self.weight)[indices] if self.weight is not None else None
-        bias = _S(self.bias)[indices] if self.bias is not None else None
+        weight = self.weight[indices] if self.weight is not None else None
+        bias = self.bias[indices] if self.bias is not None else None
 
         return F.layer_norm(
             inputs,

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -510,7 +510,7 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
             return max(all_sizes)
 
     def forward_with_args(self,
-                          normalized_shape: int_or_int_dict,
+                          normalized_shape,
                           eps: float,
                           inputs: torch.Tensor) -> torch.Tensor:
 

--- a/nni/retiarii/oneshot/pytorch/supermodule/operation.py
+++ b/nni/retiarii/oneshot/pytorch/supermodule/operation.py
@@ -529,6 +529,7 @@ class MixedLayerNorm(MixedOperation, nn.LayerNorm):
         # slice all the normalized shape
         indices = [slice(0, min(i, j)) for i, j in zip(normalized_shape, self.normalized_shape)]
 
+        # remove _S(*)
         weight = self.weight[indices] if self.weight is not None else None
         bias = self.bias[indices] if self.bias is not None else None
 

--- a/test/algo/nas/test_oneshot_supermodules.py
+++ b/test/algo/nas/test_oneshot_supermodules.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import torch
 import torch.nn as nn
-from nni.retiarii.nn.pytorch import ValueChoice, Conv2d, BatchNorm2d, Linear, MultiheadAttention
+from nni.retiarii.nn.pytorch import ValueChoice, Conv2d, BatchNorm2d, LayerNorm, Linear, MultiheadAttention
 from nni.retiarii.oneshot.pytorch.base_lightning import traverse_and_mutate_submodules
 from nni.retiarii.oneshot.pytorch.supermodule.differentiable import (
     MixedOpDifferentiablePolicy, DifferentiableMixedLayer, DifferentiableMixedInput, GumbelSoftmax,
@@ -225,6 +225,23 @@ def test_mixed_batchnorm2d():
     assert _mixed_operation_sampling_sanity_check(bn, {'dim': 64}, torch.randn(2, 64, 3, 3)).size(1) == 64
 
     _mixed_operation_differentiable_sanity_check(bn, torch.randn(2, 64, 3, 3))
+
+
+def test_mixed_layernorm():
+    ln = LayerNorm(ValueChoice([32, 64], label='normalized_shape'), elementwise_affine=True)
+
+    assert _mixed_operation_sampling_sanity_check(ln, {'normalized_shape': 32}, torch.randn(2, 16, 32)).size(-1) == 32
+    assert _mixed_operation_sampling_sanity_check(ln, {'normalized_shape': 64}, torch.randn(2, 16, 64)).size(-1) == 64
+
+    _mixed_operation_differentiable_sanity_check(ln, torch.randn(2, 16, 64))
+    
+    import itertools
+    ln = LayerNorm(ValueChoice(list(itertools.product([16, 32, 64], [8, 16])), label='normalized_shape'))
+
+    assert list(_mixed_operation_sampling_sanity_check(ln, {'normalized_shape': (16, 8)}, torch.randn(2, 16, 8)).shape[-2:]) == [16, 8]
+    assert list(_mixed_operation_sampling_sanity_check(ln, {'normalized_shape': (64, 16)}, torch.randn(2, 64, 16)).shape[-2:]) == [64, 16]
+
+    _mixed_operation_differentiable_sanity_check(ln, torch.randn(2, 64, 16))
 
 
 def test_mixed_mhattn():

--- a/test/algo/nas/test_oneshot_supermodules.py
+++ b/test/algo/nas/test_oneshot_supermodules.py
@@ -28,6 +28,12 @@ def test_slice():
     assert S(weight)[:, 1:W(3)*2+1, :, 9:13].shape == (3, 6, 24, 4)
     assert S(weight)[:, 1:W(3)*2+1].shape == (3, 6, 24, 23)
 
+    # Ellipsis
+    assert S(weight)[..., 9:13].shape == (3, 7, 24, 4)
+    assert S(weight)[:2, ..., 1:W(3)+1].shape == (2, 7, 24, 3)
+    assert S(weight)[..., 1:W(3)*2+1].shape == (3, 7, 24, 6)
+    assert S(weight)[..., :10, 1:W(3)*2+1].shape == (3, 7, 10, 6)
+
     # no effect
     assert S(weight)[:] is weight
 

--- a/test/algo/nas/test_space_hub_oneshot.py
+++ b/test/algo/nas/test_space_hub_oneshot.py
@@ -191,13 +191,10 @@ def test_hub_oneshot(space_type, strategy_type):
     NDS_SPACES = ['amoeba', 'darts', 'pnas', 'enas', 'nasnet']
     if strategy_type == 'proxyless':
         if 'width' in space_type or 'depth' in space_type or \
-                any(space_type.startswith(prefix) for prefix in NDS_SPACES + ['proxylessnas', 'mobilenetv3']):
+                any(space_type.startswith(prefix) for prefix in NDS_SPACES + ['proxylessnas', 'mobilenetv3', 'autoformer']):
             pytest.skip('The space has used unsupported APIs.')
     if strategy_type in ['darts', 'gumbel'] and space_type == 'mobilenetv3':
         pytest.skip('Skip as it consumes too much memory.')
-    
-    if space_type == "autoformer" and strategy_type != "random":
-        pytest.skip('The AutoFormer sapce only support randomoneshot currently.')
 
     model_space = _hub_factory(space_type)
 

--- a/test/algo/nas/test_space_hub_oneshot.py
+++ b/test/algo/nas/test_space_hub_oneshot.py
@@ -70,6 +70,10 @@ def _hub_factory(alias):
 
 
 def _strategy_factory(alias, space_type):
+    # Autoformer search space require specific hooks
+    if alias == 'random' and space_type == 'autoformer':
+        from nni.retiarii.hub.pytorch.autoformer import MixedAbsPosEmbed, MixedClsToken
+        return stg.RandomOneShot(mutation_hooks=[MixedAbsPosEmbed.mutate, MixedClsToken.mutate])
     # Some search space needs extra hooks
     extra_mutation_hooks = []
     nds_need_shape_alignment = '_smalldepth' in space_type
@@ -149,7 +153,7 @@ def _dataset_factory(dataset_type, subset=20):
     'mobilenetv3_small',
     'proxylessnas',
     'shufflenet',
-    # 'autoformer',
+    'autoformer',
     'nasnet',
     'enas',
     'amoeba',
@@ -190,6 +194,9 @@ def test_hub_oneshot(space_type, strategy_type):
             pytest.skip('The space has used unsupported APIs.')
     if strategy_type in ['darts', 'gumbel'] and space_type == 'mobilenetv3':
         pytest.skip('Skip as it consumes too much memory.')
+    
+    if space_type == "autoformer" and strategy_type != "random":
+        pytest.skip('The AutoFormer sapce only support randomoneshot currently.')
 
     model_space = _hub_factory(space_type)
 

--- a/test/algo/nas/test_space_hub_oneshot.py
+++ b/test/algo/nas/test_space_hub_oneshot.py
@@ -70,10 +70,6 @@ def _hub_factory(alias):
 
 
 def _strategy_factory(alias, space_type):
-    # Autoformer search space require specific hooks
-    if alias == 'random' and space_type == 'autoformer':
-        from nni.retiarii.hub.pytorch.autoformer import MixedAbsPosEmbed, MixedClsToken
-        return stg.RandomOneShot(mutation_hooks=[MixedAbsPosEmbed.mutate, MixedClsToken.mutate])
     # Some search space needs extra hooks
     extra_mutation_hooks = []
     nds_need_shape_alignment = '_smalldepth' in space_type
@@ -82,6 +78,11 @@ def _strategy_factory(alias, space_type):
             extra_mutation_hooks.append(NDSStagePathSampling.mutate)
         else:
             extra_mutation_hooks.append(NDSStageDifferentiable.mutate)
+    
+    # Autoformer search space require specific extra hooks
+    if space_type == 'autoformer':
+        from nni.retiarii.hub.pytorch.autoformer import MixedAbsPosEmbed, MixedClsToken
+        extra_mutation_hooks.extend([MixedAbsPosEmbed.mutate, MixedClsToken.mutate])
 
     if alias == 'darts':
         return stg.DARTS(mutation_hooks=extra_mutation_hooks)


### PR DESCRIPTION
### Description  [Update 2022-07-08]
A new code of [pull#4965](https://github.com/microsoft/nni/pull/4965). Refactoring autoformer's search space to make it compatible with enas, darts, randomoneshot strategy.

Major changes:

- Add `MixedLayerNorm` in `nni/nni/retiarii/oneshot/pytorch/supermodule/operation.py` and unit test.
- Support fixed head_dim(64) in `RelativePositionAttention` of `nni/nni/retiarii/hub/pytorch/autoformer.py`.
- Use split QKV linear layer rather than one  linear layer.
- Add `ClsToken` and `AbsPosEmbed` to replace `ModelParameterChoice`, which is not compatible with RandomOneShot strategy. Use mixed operation.
- Add `load_searched_model` to load searched model and weights from official code. The result is align.


### How to test ###
evaluate on imagenet val set
```
import os
from tqdm import tqdm

import torch
import torch.nn as nn

from torch.utils.data import DataLoader
from torchvision.datasets import ImageFolder
import torchvision.transforms as T

import nni.retiarii.hub.pytorch as hub


device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

IMAGENET_DEFAULT_MEAN = (0.485, 0.456, 0.406)
IMAGENET_DEFAULT_STD = (0.229, 0.224, 0.225)

@torch.no_grad()
def validate(model, loader):
    total = 0
    top1 = 0
    top5 = 0
    model.eval()
    with tqdm(loader) as t:
        for data, target in t:
            data, target = data.to(device), target.to(device)
            topk = torch.topk(model(data), dim=-1, k=5, largest=True, sorted=True).indices
            correct = topk.eq(target.view(-1, 1).expand_as(topk))
            top1 += correct[:, 0].sum().item()
            top5 += correct[:, :5].sum().item()
            total += target.size(0)
            t.set_postfix({"Top1": f"{top1/total:.2%}", "Top5": f"{top5/total:.2%}"})
    return top1/total, top5/total

model_space = hub.AutoformerSpace(
    search_embed_dim = (240, 216, 192),
    search_mlp_ratio = (4.0, 3.5, 3.0),
    search_num_heads = (4, 3),
    search_depth = (14, 13, 12),
)

model = model_space.load_searched_model("autoformer-tiny", pretrained=True, download=True)
model.eval()
model.to(device)
transform = T.Compose([
    T.Resize(256, interpolation=T.InterpolationMode.BICUBIC),
    T.CenterCrop(224),
    T.ToTensor(),
    T.Normalize(IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD)
])

root = "path/to/imagenet"
dataset = ImageFolder(os.path.join(root, "val"), transform=transform)
dataloader = DataLoader(dataset, batch_size=128, shuffle=False, num_workers=4)

validate(model, dataloader)
```

train supernet with RandomOneShot strategy
```
import os
from pathlib import Path

import torch
import torch.nn as nn
import torch.optim as optim
from torchvision.datasets import ImageFolder
import torchvision.transforms as T

IMAGENET_DEFAULT_MEAN = (0.485, 0.456, 0.406)
IMAGENET_DEFAULT_STD = (0.229, 0.224, 0.225)

transform = T.Compose([
    T.Resize(256, interpolation=T.InterpolationMode.BICUBIC),
    T.CenterCrop(224),
    T.ToTensor(),
    T.Normalize(IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD)
])
root = "path/to/imagenet"
train_set = ImageFolder(os.path.join(root, "train"), transform=transform)
valid_set = ImageFolder(os.path.join(root, "val"), transform=transform)

import nni.retiarii.strategy as strategy
from nni.retiarii.experiment.pytorch import RetiariiExperiment, RetiariiExeConfig
import nni.retiarii.evaluator.pytorch.lightning as pl

import nni.retiarii.hub.pytorch as hub
from nni.retiarii.hub.pytorch.autoformer import MixedAbsPosEmbed, MixedClsToken

evaluator = pl.Classification(
    criterion = nn.CrossEntropyLoss,
    optimizer = optim.Adam,
    learning_rate = 0.001,
    weight_decay = 1e-4,
    # Need to use `pl.DataLoader` instead of `torch.utils.data.DataLoader` here,
    # or use `nni.trace` to wrap `torch.utils.data.DataLoader`.
    train_dataloaders = pl.DataLoader(train_set, batch_size=128, shuffle=True, num_workers=4),
    val_dataloaders = pl.DataLoader(valid_set, batch_size=128, shuffle=False, num_workers=4),
    # Other keyword arguments passed to pytorch_lightning.Trainer.
    max_epochs = 2,
    gpus = 4,
    accelerator = "gpu",
    auto_select_gpus = True,
    strategy = "ddp"
)

model_space = hub.AutoformerSpace(
    search_embed_dim = (240, 216, 192),
    search_mlp_ratio = (4.0, 3.5, 3.0),
    search_num_heads = (4, 3),
    search_depth = (14, 13, 12),
    num_classes = 1000
)


search_strategy = strategy.RandomOneShot(mutation_hooks=[MixedAbsPosEmbed.mutate, MixedClsToken.mutate])

exp = RetiariiExperiment(model_space, evaluator, [], search_strategy)
exp_config = RetiariiExeConfig('local')
exp_config.experiment_name = 'ImageNet'
exp_config.execution_engine = 'oneshot'

exp.run(exp_config, 6002)
```


