### PR TITLE
Fix unintended modification of trace symbol after dump

### DIFF
--- a/nni/common/serializer.py
+++ b/nni/common/serializer.py
@@ -538,6 +538,7 @@ def _trace_cls(base, kw_only, call_super=True, inheritable=False):
 
             # Pickle can't handle type objects.
             if '_nni_symbol' in obj_:
+                obj_ = dict(obj_)  # copy the object to keep the original symbol unchanged
                 obj_['_nni_symbol'] = cloudpickle.dumps(obj_['_nni_symbol'])
 
             return _pickling_object, (type_, kw_only, obj_)

--- a/test/ut/sdk/test_serializer.py
+++ b/test/ut/sdk/test_serializer.py
@@ -371,6 +371,23 @@ def test_subclass():
     assert isinstance(obj, Super)
 
 
+class ConsistencyTest1:
+    pass
+
+
+class ConsistencyTest2:
+    def __init__(self):
+        self.test = nni.trace(ConsistencyTest1)()
+
+
+def test_dump_consistency():
+    test2 = ConsistencyTest2()
+    symbol1 = test2.test.trace_symbol
+    pickle.dumps(test2)
+    symbol2 = test2.test.trace_symbol
+    assert symbol1 == symbol2
+
+
 def test_get():
     @nni.trace
     class Foo:


### PR DESCRIPTION
### Description ###

`_nni_symbol` gets unexpectedly modified after calling nni.dump / pickle.dump / torch.save. cc @J-shang

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [x] test case
  - [ ] doc

### How to test ###


