### PR TITLE
fix the bug that weights are not initialized correctly in adaptive_parzen…

### DIFF
--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -411,7 +411,7 @@ def adaptive_parzen_normal(args, history_mus, prior_mu, prior_sigma):
     n = min(100, len(mus) + 1)
     sigmas = np.clip(sigmas, prior_sigma / n, prior_sigma)
 
-    weights = np.append(linear_forgetting_weights(args, len(mus)-1), args.prior_weight)
+    weights = np.append(linear_forgetting_weights(args, len(mus) - 1), args.prior_weight)
     weights = weights[order]
 
     return weights / np.sum(weights), mus, sigmas

--- a/nni/algorithms/hpo/tpe_tuner.py
+++ b/nni/algorithms/hpo/tpe_tuner.py
@@ -411,7 +411,7 @@ def adaptive_parzen_normal(args, history_mus, prior_mu, prior_sigma):
     n = min(100, len(mus) + 1)
     sigmas = np.clip(sigmas, prior_sigma / n, prior_sigma)
 
-    weights = np.append(linear_forgetting_weights(args, len(mus)), args.prior_weight)
+    weights = np.append(linear_forgetting_weights(args, len(mus)-1), args.prior_weight)
     weights = weights[order]
 
     return weights / np.sum(weights), mus, sigmas


### PR DESCRIPTION
### Description ###
When initializing the `weights` variable, the prior was considered repeatedly, so it was removed.


#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


