### PR TITLE
Add Group Norm support for Pruning model

### DIFF
--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/base.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/base.py
@@ -6,7 +6,8 @@ from datetime import datetime
 import logging
 from pathlib import Path
 import types
-from typing import List, Dict, Literal, Tuple, Optional, Callable, Union
+from typing import List, Dict, Tuple, Optional, Callable, Union
+from typing_extensions import Literal
 
 import json_tricks
 import torch

--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/base.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/base.py
@@ -6,8 +6,7 @@ from datetime import datetime
 import logging
 from pathlib import Path
 import types
-from typing import List, Dict, Tuple, Optional, Callable, Union
-from typing_extensions import Literal
+from typing import List, Dict, Literal, Tuple, Optional, Callable, Union
 
 import json_tricks
 import torch

--- a/nni/common/graph_utils.py
+++ b/nni/common/graph_utils.py
@@ -8,6 +8,7 @@ import re
 from collections import defaultdict
 import torch
 from torch.utils.tensorboard._pytorch_graph import NodePy, NodePyIO, NodePyOP, GraphPy
+from typing import List, Dict
 CLASSTYPE_KIND = 'ClassType'
 GETATTR_KIND = 'prim::GetAttr'
 CAT_KIND = 'aten::cat'
@@ -250,6 +251,7 @@ class TorchModuleGraph(TorchGraph):
 
     def __init__(self, model=None, dummy_input=None, traced_model=None):
         super().__init__(model, dummy_input, traced_model)
+        self.name_to_node: Dict[str, NodePyOP]
         self.global_count = 0
         self.reused_module = set()
         self.name_to_node, self.input_to_node, self.output_to_node = self._build_graph()
@@ -790,7 +792,7 @@ class TorchModuleGraph(TorchGraph):
                 node_group.auxiliary = self._extract_cat_info(
                     node_group, cpp_node)
 
-    def find_predecessors(self, unique_name):
+    def find_predecessors(self, unique_name) -> List[str]:
         """
         Find predecessor node of the given node
 
@@ -813,7 +815,7 @@ class TorchModuleGraph(TorchGraph):
                 predecessors.append(node_py.unique_name)
         return predecessors
 
-    def find_successors(self, unique_name):
+    def find_successors(self, unique_name) -> List[str]:
         """
         Find successor nodes of the given node
 

--- a/nni/common/graph_utils.py
+++ b/nni/common/graph_utils.py
@@ -6,9 +6,9 @@ import logging
 import queue
 import re
 from collections import defaultdict
+from typing import List, Dict
 import torch
 from torch.utils.tensorboard._pytorch_graph import NodePy, NodePyIO, NodePyOP, GraphPy
-from typing import List, Dict
 CLASSTYPE_KIND = 'ClassType'
 GETATTR_KIND = 'prim::GetAttr'
 CAT_KIND = 'aten::cat'

--- a/nni/compression/pytorch/speedup/compress_modules.py
+++ b/nni/compression/pytorch/speedup/compress_modules.py
@@ -48,7 +48,7 @@ replace_module = {
     'Embedding': lambda module, masks: replace_embedding(module, masks),
     'PixelShuffle': lambda module, masks: replace_pixelshuffle(module, masks),
     'Flatten': lambda module, masks: no_replace(module, masks),
-    "GroupNorm": lambda module, masks: replace_groupnorm(module, masks),
+    'GroupNorm': lambda module, masks: replace_groupnorm(module, masks),
 }
 
 
@@ -362,15 +362,15 @@ def replace_groupnorm(norm: nn.GroupNorm, masks):
     for groupid in range(norm.num_groups):
         in_start = groupid * ori_channel_step
         in_end = in_start + ori_channel_step
-        masks = torch.logical_and(in_start <= remained_in, remained_in < in_end)
-        current_input_index = remained_in[masks]
-        if len(current_input_index) == 0:
+        num_item = torch.logical_and(
+            in_start <= remained_in,
+            remained_in < in_end,
+        ).sum().item()
+        if num_item == 0:
             continue
 
-        # remap the global index to the group index
-        current_input_index = current_input_index - in_start
         # check if the number of remained channel of each group are the same
-        if len(current_input_index) != new_channel_step:
+        if num_item != new_channel_step:
             raise UnBalancedGroupError()
 
         new_groups += 1

--- a/nni/compression/pytorch/speedup/infer_mask.py
+++ b/nni/compression/pytorch/speedup/infer_mask.py
@@ -82,6 +82,8 @@ class AutoMaskInference:
         if output_mask is not None:
             # assume the given output mask is right
             self.output_mask = output_mask
+        elif isinstance(module, nn.GroupNorm):
+            self.output_mask = self.in_masks[0]
         else:
             if isinstance(self.output, torch.Tensor):
                 self.output_mask = torch.ones_like(self.output)

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -359,20 +359,10 @@ class GroupDependency(Dependency):
     traced_model : torch._C.Graph
         if we alreay has the traced graph of the target model, we donnot
         need to trace the model again.
-    group_norm_target: Literal["instancenorm", "layernorm"]
-        Target layer type to prune GroupNorm into.
     """
 
-    def __init__(
-            self,
-            model,
-            dummy_input,
-            traced_model=None,
-            group_norm_target: str="instancenorm",
-        ):
+    def __init__(self, model, dummy_input, traced_model=None):
         self.min_groups = {}
-        assert group_norm_target in ["instancenorm", "layernorm"]
-        self.group_norm_target = group_norm_target
         super(GroupDependency, self).__init__(model, dummy_input, traced_model)
 
     def _get_parent_convs(self, node):
@@ -451,12 +441,7 @@ class GroupDependency(Dependency):
             leaf_module = leaf_module.module
         assert isinstance(leaf_module, (torch.nn.GroupNorm))
 
-        if self.group_norm_target == "instancenorm":
-            condition = leaf_module.num_groups
-        else:
-            condition = leaf_module.num_channels // leaf_module.num_groups
-
-        return condition
+        return leaf_module.num_groups
 
 
     def build_dependency(self):

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -365,8 +365,8 @@ class GroupDependency(Dependency):
 
     def __init__(
             self,
-            model: torch.nn.Module,
-            dummy_input: torch.Tensor,
+            model,
+            dummy_input,
             traced_model=None,
             group_norm_target: str="instancenorm",
         ):

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -354,15 +354,25 @@ class GroupDependency(Dependency):
     ----------
     model : torch.nn.Module
         The model to be analyzed.
-    data : torch.Tensor
+    dummy_input : torch.Tensor
         The example input data to trace the network architecture.
     traced_model : torch._C.Graph
         if we alreay has the traced graph of the target model, we donnot
         need to trace the model again.
+    group_norm_target: Literal["instancenorm", "layernorm"]
+        Target layer type to prune GroupNorm into.
     """
 
-    def __init__(self, model, dummy_input, traced_model=None):
+    def __init__(
+            self,
+            model: torch.nn.Module,
+            dummy_input: torch.Tensor,
+            traced_model=None,
+            group_norm_target: str="instancenorm",
+        ):
         self.min_groups = {}
+        assert group_norm_target in ["instancenorm", "layernorm"]
+        self.group_norm_target = group_norm_target
         super(GroupDependency, self).__init__(model, dummy_input, traced_model)
 
     def _get_parent_convs(self, node):
@@ -421,26 +431,32 @@ class GroupDependency(Dependency):
             return 1
         return group
 
-    def _get_group_norm_group(self, node_group) -> int:
+    def _get_group_norm_condition(self, node_group) -> int:
         """
         Get the number of groups for a group norm layer.
+
         Parameters
         ----------
         node_group : NodePyGroup
             target node.
         Returns
         -------
-        group : int
-            the number of the groups of the target group norm layer.
+        condition: int
+            the number that layer's num channel
+            require to be divisible to
         """
         node_name = node_group.name
         _, leaf_module = get_module_by_name(self.model, node_name)
         if isinstance(leaf_module, (PrunerModuleWrapper, PrunerModuleWrapper_v2)):
             leaf_module = leaf_module.module
         assert isinstance(leaf_module, (torch.nn.GroupNorm))
-        group = leaf_module.num_groups
 
-        return group
+        if self.group_norm_target == "instancenorm":
+            condition = leaf_module.num_groups
+        else:
+            condition = leaf_module.num_channels // leaf_module.num_groups
+
+        return condition
 
 
     def build_dependency(self):
@@ -470,7 +486,7 @@ class GroupDependency(Dependency):
                 if node.op_type in ['Conv2d', 'ConvTranspose2d']:
                     group = self._get_conv_groups(node)
                 elif node.op_type == "GroupNorm":
-                    group = self._get_group_norm_group(node)
+                    group = self._get_group_norm_condition(node)
                 if node.name in self.groups:
                     # the conv layer whose group is larger than 1 will require that
                     # it's number of output channel to be divisible by the number of group.

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -49,7 +49,7 @@ class Dependency:
             # user should provide model & dummy_input to trace
             # the model or a already traced model
             assert model is not None and dummy_input is not None
-        self.graph = TorchModuleGraph(model, dummy_input, traced_model)
+        self.graph: TorchModuleGraph = TorchModuleGraph(model, dummy_input, traced_model)
         self.model = model
         self.dependency = dict()
         self.build_dependency()
@@ -122,6 +122,9 @@ class ChannelDependency(Dependency):
             self.target_types.extend(['Conv2d', 'Linear', 'ConvTranspose2d'])
         elif self.prune_type == 'Batchnorm':
             self.target_types.append('BatchNorm2d')
+
+        from typing import Dict, Set
+        self.dependency: Dict[str, Set[str]]
 
         super(ChannelDependency, self).__init__(
             model, dummy_input, traced_model)
@@ -418,6 +421,28 @@ class GroupDependency(Dependency):
             return 1
         return group
 
+    def _get_group_norm_group(self, node_group) -> int:
+        """
+        Get the number of groups for a convolutional layer.
+        Parameters
+        ----------
+        node_group : NodePyGroup
+            target node.
+        Returns
+        -------
+        group : int
+            the number of the groups of the target conv layer.
+        """
+        node_name = node_group.name
+        _, leaf_module = get_module_by_name(self.model, node_name)
+        if isinstance(leaf_module, (PrunerModuleWrapper, PrunerModuleWrapper_v2)):
+            leaf_module = leaf_module.module
+        assert isinstance(leaf_module, (torch.nn.GroupNorm))
+        group = leaf_module.num_groups
+
+        return group
+
+
     def build_dependency(self):
         """
         Build the channel dependency for the conv layers
@@ -441,8 +466,12 @@ class GroupDependency(Dependency):
         """
         self.groups = {}
         for node in self.graph.nodes_py.nodes_op:
-            if node.op_type == 'Conv2d' or node.op_type == 'ConvTranspose2d':
-                group = self._get_conv_groups(node)
+            if node.op_type in ['Conv2d', 'ConvTranspose2d', "GroupNorm"]:
+
+                if node.op_type in ['Conv2d', 'ConvTranspose2d']:
+                    group = self._get_conv_groups(node)
+                elif node.op_type == "GroupNorm":
+                    group = self._get_group_norm_group(node)
                 if node.name in self.groups:
                     # the conv layer whose group is larger than 1 will require that
                     # it's number of output channel to be divisible by the number of group.

--- a/nni/compression/pytorch/utils/shape_dependency.py
+++ b/nni/compression/pytorch/utils/shape_dependency.py
@@ -423,7 +423,7 @@ class GroupDependency(Dependency):
 
     def _get_group_norm_group(self, node_group) -> int:
         """
-        Get the number of groups for a convolutional layer.
+        Get the number of groups for a group norm layer.
         Parameters
         ----------
         node_group : NodePyGroup
@@ -431,7 +431,7 @@ class GroupDependency(Dependency):
         Returns
         -------
         group : int
-            the number of the groups of the target conv layer.
+            the number of the groups of the target group norm layer.
         """
         node_name = node_group.name
         _, leaf_module = get_module_by_name(self.model, node_name)
@@ -467,7 +467,6 @@ class GroupDependency(Dependency):
         self.groups = {}
         for node in self.graph.nodes_py.nodes_op:
             if node.op_type in ['Conv2d', 'ConvTranspose2d', "GroupNorm"]:
-
                 if node.op_type in ['Conv2d', 'ConvTranspose2d']:
                     group = self._get_conv_groups(node)
                 elif node.op_type == "GroupNorm":


### PR DESCRIPTION
### Description ###

Add Group Norm support for model pruning.

I am not sure if this algorithm works for GroupNorm 
--> Need to do experiments to recheck the algorithm.

There are two main ways to prune GroupNorm (one is pruning group (reduce the number of groups, keep the number of channels per group the same, finally the module will become `LayerNorm`), the other is pruning the channel per group (finally the module will become `InstanceNorm`).

This implementation is the second approach as I saw that for `Conv2d`, we keep the number of groups the same.

But personally, I prefer the first approach as LayerNorm is more widely accepted and outperforms `InstanceNorm` according to `GroupNorm` original paper.

p.s: Lacking the infrastructure to do these test :(

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
```python
from nni.compression.pytorch.pruning import FPGMPruner
from nni.compression.pytorch import ModelSpeedup
import torch
from torch import nn

class GroupNormModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(3, 128, 3)
        self.norm = nn.GroupNorm(32, 128)
        # self.norm = nn.BatchNorm2d(128)
        self.conv2 = nn.Conv2d(128, 128, 3, groups=32)

    def forward(self, x):
        x = self.conv1(x)
        x = self.norm(x)
        x = self.conv2(x)
        return x

config_list = [
    {
        'sparsity': 0.3,
        'op_types': ['Conv2d'],
    }
]

input_shape = (1, 3, 224, 224)
speed_up_config = dict(
    mode="dependency_aware",
    dummy_input=torch.rand(input_shape, device="cuda")
)
model = GroupNormModel().cuda().eval()
print("Before speed up")
print(model(speed_up_config["dummy_input"]).shape)
print(model)
print("---")

pruner = FPGMPruner(
    model,
    config_list,
    **speed_up_config,
)

masked_model, masks = pruner.compress()
pruner.show_pruned_weights()
pruner._unwrap_model()
ModelSpeedup(model, dummy_input=torch.rand(input_shape, device="cuda"), masks_file=masks).speedup_model()

print("After speed up")
print(model)
print(model(speed_up_config["dummy_input"]).shape)
```