### PR TITLE
Use Random to generate experiment id

### DIFF
--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -18,7 +18,6 @@ schema
 scikit-learn >= 0.24.1
 scipy < 1.8 ; python_version < "3.8"
 scipy ; python_version >= "3.8"
-shortuuid
 tqdm
 typeguard
 typing_extensions >= 4.0.0

--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -18,6 +18,7 @@ schema
 scikit-learn >= 0.24.1
 scipy < 1.8 ; python_version < "3.8"
 scipy ; python_version >= "3.8"
+shortuuid
 tqdm
 typeguard
 typing_extensions >= 4.0.0

--- a/nni/experiment/management.py
+++ b/nni/experiment/management.py
@@ -7,7 +7,14 @@ import string
 
 
 def generate_experiment_id() -> str:
-    return ''.join(random.sample(string.ascii_lowercase + string.digits, 8))
+    try:
+        # This try..catch is for backward-compatibility,
+        # in case shortuuid is not installed for some reason.
+        import shortuuid
+        return shortuuid.ShortUUID(alphabet=string.ascii_lowercase + string.digits).random(length=8)
+    except ImportError:
+        # shortuuid is not installed, use legacy random string instead
+        return ''.join(random.sample(string.ascii_lowercase + string.digits, 8))
 
 
 def create_experiment_directory(experiment_id: str) -> Path:

--- a/nni/experiment/management.py
+++ b/nni/experiment/management.py
@@ -2,8 +2,11 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
+import logging
 import random
 import string
+
+_logger = logging.getLogger(__name__)
 
 
 def generate_experiment_id() -> str:
@@ -13,7 +16,7 @@ def generate_experiment_id() -> str:
         import shortuuid
         return shortuuid.ShortUUID(alphabet=string.ascii_lowercase + string.digits).random(length=8)
     except ImportError:
-        # shortuuid is not installed, use legacy random string instead
+        _logger.warning('shortuuid is not installed, use legacy random string to generate experiment id instead.')
         return ''.join(random.sample(string.ascii_lowercase + string.digits, 8))
 
 

--- a/nni/experiment/management.py
+++ b/nni/experiment/management.py
@@ -2,22 +2,12 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
-import logging
-import random
+from random import Random
 import string
-
-_logger = logging.getLogger(__name__)
 
 
 def generate_experiment_id() -> str:
-    try:
-        # This try..catch is for backward-compatibility,
-        # in case shortuuid is not installed for some reason.
-        import shortuuid
-        return shortuuid.ShortUUID(alphabet=string.ascii_lowercase + string.digits).random(length=8)
-    except ImportError:
-        _logger.warning('shortuuid is not installed, use legacy random string to generate experiment id instead.')
-        return ''.join(random.sample(string.ascii_lowercase + string.digits, 8))
+    return ''.join(Random().sample(string.ascii_lowercase + string.digits, 8))
 
 
 def create_experiment_directory(experiment_id: str) -> Path:


### PR DESCRIPTION
### Description ###

Generate experiment id with ~shortuuid~ Random. This fixes the issue that when `random.seed` is called, experiment id is always the same.

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


