### PR TITLE
[Bugbash] fix some pruner bugs

### DIFF
--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -748,16 +748,16 @@ class ActivationPruner(EvaluatorBasedPruner):
         buffer.append(0)
 
         def collect_activation(_module: Module, _input: Tensor, output: Tensor):
-            if isinstance(_module, (torch.nn.Linear, torch.nn.Bilinear)):
+            if isinstance(_module.module, (torch.nn.Linear, torch.nn.Bilinear)):
                 batch_nums = math.prod(output.shape[:-1])
                 batch_dims = [_ for _ in range(len(output.shape[:-1]))]
-            elif isinstance(_module, (torch.nn.Conv1d, torch.nn.ConvTranspose1d)):
+            elif isinstance(_module.module, (torch.nn.Conv1d, torch.nn.ConvTranspose1d)):
                 batch_nums = math.prod(output.shape[:-2])
                 batch_dims = [_ for _ in range(len(output.shape[:-2]))]
-            elif isinstance(_module, (torch.nn.Conv2d, torch.nn.ConvTranspose2d)):
+            elif isinstance(_module.module, (torch.nn.Conv2d, torch.nn.ConvTranspose2d)):
                 batch_nums = math.prod(output.shape[:-3])
                 batch_dims = [_ for _ in range(len(output.shape[:-3]))]
-            elif isinstance(_module, (torch.nn.Conv3d, torch.nn.ConvTranspose3d)):
+            elif isinstance(_module.module, (torch.nn.Conv3d, torch.nn.ConvTranspose3d)):
                 batch_nums = math.prod(output.shape[:-4])
                 batch_dims = [_ for _ in range(len(output.shape[:-4]))]
             else:

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -751,7 +751,7 @@ class ActivationPruner(EvaluatorBasedPruner):
             if len(buffer) == 1:
                 buffer.append(torch.zeros_like(activation))
             if buffer[0] < self.training_steps:
-                buffer[1] += activation
+                buffer[1] += activation.to(buffer[1].device)
                 buffer[0] += 1
         return collect_activation
 

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -15,6 +15,8 @@ import torch.nn.functional as F
 from torch.nn import Module
 from torch.optim import Optimizer
 
+from nni.algorithms.compression.v2.pytorch.base.pruner import PrunerModuleWrapper
+
 from ..base import Pruner
 
 from .tools import (
@@ -748,7 +750,10 @@ class ActivationPruner(EvaluatorBasedPruner):
         buffer.append(0)
 
         def collect_activation(_module: Module, _input: Tensor, output: Tensor):
-            batch_dims, batch_num = get_output_batch_dims(output, _module.module)  # type: ignore
+            # TODO: remove `if` after deprecate the old API
+            if isinstance(_module, PrunerModuleWrapper):
+                _module = _module.module
+            batch_dims, batch_num = get_output_batch_dims(output, _module)  # type: ignore
             activation = self._activation_trans(output, batch_dims)
             if len(buffer) == 1:
                 buffer.append(torch.zeros_like(activation))

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_pruner.py
@@ -189,12 +189,12 @@ class EvaluatorBasedPruner(BasicPruner):
         for key, value in def_kwargs.items():
             if key not in merged_kwargs and key in arg_names:
                 merged_kwargs[key] = value
-        diff = set(arg_names).difference(merged_kwargs.keys())
-        if diff:
-            raise TypeError(f"{self.__class__.__name__}.__init__() missing {len(diff)} required positional argument: {diff}")
         diff = set(merged_kwargs.keys()).difference(arg_names)
         if diff:
             raise TypeError(f"{self.__class__.__name__}.__init__() got {len(diff)} unexpected keyword argument: {diff}")
+        diff = set(arg_names).difference(merged_kwargs.keys())
+        if diff:
+            raise TypeError(f"{self.__class__.__name__}.__init__() missing {len(diff)} required positional argument: {diff}")
         return merged_kwargs
 
     def compress(self) -> Tuple[Module, Dict]:

--- a/nni/algorithms/compression/v2/pytorch/pruning/basic_scheduler.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/basic_scheduler.py
@@ -62,12 +62,12 @@ class EvaluatorBasedPruningScheduler(BasePruningScheduler):
         for key, value in def_kwargs.items():
             if key not in merged_kwargs and key in arg_names:
                 merged_kwargs[key] = value
-        diff = set(arg_names).difference(merged_kwargs.keys())
-        if diff:
-            raise TypeError(f"{self.__class__.__name__}.__init__() missing {len(diff)} required positional argument: {diff}")
         diff = set(merged_kwargs.keys()).difference(arg_names)
         if diff:
             raise TypeError(f"{self.__class__.__name__}.__init__() got {len(diff)} unexpected keyword argument: {diff}")
+        diff = set(arg_names).difference(merged_kwargs.keys())
+        if diff:
+            raise TypeError(f"{self.__class__.__name__}.__init__() missing {len(diff)} required positional argument: {diff}")
         return merged_kwargs
 
 

--- a/nni/algorithms/compression/v2/pytorch/pruning/tools/task_generator.py
+++ b/nni/algorithms/compression/v2/pytorch/pruning/tools/task_generator.py
@@ -98,7 +98,7 @@ class FunctionBasedTaskGenerator(TaskGenerator):
 
         with Path(config_list_path).open('w') as f:
             json_tricks.dump(new_config_list, f, indent=4)
-        task = Task(task_id, model_path, masks_path, config_list_path)
+        task = Task(task_id, model_path, masks_path, config_list_path, speedup=True, finetune=True, evaluate=False)
 
         self._tasks[task_id] = task
 

--- a/nni/algorithms/compression/v2/pytorch/utils/__init__.py
+++ b/nni/algorithms/compression/v2/pytorch/utils/__init__.py
@@ -28,6 +28,7 @@ from .pruning import (
     compute_sparsity_mask2compact,
     compute_sparsity,
     get_model_weights_numel,
-    get_module_by_name
+    get_module_by_name,
+    get_output_batch_dims
 )
 from .scaling import Scaling

--- a/nni/algorithms/compression/v2/pytorch/utils/pruning.py
+++ b/nni/algorithms/compression/v2/pytorch/utils/pruning.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from copy import deepcopy
+import math
 from typing import Dict, List, Tuple
 
 import torch
@@ -279,3 +280,21 @@ def get_module_by_name(model, module_name):
         return model, leaf_module
     else:
         return None, None
+
+
+def get_output_batch_dims(t: Tensor, module: Module):
+    if isinstance(module, (torch.nn.Linear, torch.nn.Bilinear)):
+        batch_nums = math.prod(t.shape[:-1])
+        batch_dims = [_ for _ in range(len(t.shape[:-1]))]
+    elif isinstance(module, (torch.nn.Conv1d, torch.nn.ConvTranspose1d)):
+        batch_nums = math.prod(t.shape[:-2])
+        batch_dims = [_ for _ in range(len(t.shape[:-2]))]
+    elif isinstance(module, (torch.nn.Conv2d, torch.nn.ConvTranspose2d)):
+        batch_nums = math.prod(t.shape[:-3])
+        batch_dims = [_ for _ in range(len(t.shape[:-3]))]
+    elif isinstance(module, (torch.nn.Conv3d, torch.nn.ConvTranspose3d)):
+        batch_nums = math.prod(t.shape[:-4])
+        batch_dims = [_ for _ in range(len(t.shape[:-4]))]
+    else:
+        raise TypeError(f'Found unsupported module type in activation based pruner: {module.__class__.__name__}')
+    return batch_dims, batch_nums

--- a/nni/compression/pytorch/compressor.py
+++ b/nni/compression/pytorch/compressor.py
@@ -751,6 +751,8 @@ class Quantizer(Compressor):
             _setattr(self.bound_model, wrapper.module_name, wrapper.module)
         super()._unwrap_model()
 
+    # TODO: For most complex models, the information provided by input_shape is not enough to randomly initialize the complete input.
+    # And nni should not be responsible for exporting the onnx model, this feature should be deprecated in quantization refactor.
     def export_model_save(self, model, model_path, calibration_config=None, calibration_path=None, onnx_path=None,
                           input_shape=None, device=None):
         """


### PR DESCRIPTION
### Description ###
Fix some bugs found by @QuanluZhang
1. let pruner raise `unexpected keyword argument` error before raise `required positional argument` error.
2. disable evaluation in functional based scheduled pruners.
3. fix activation-based pruner collected module output on two devices in DP training.
4. fix activation-based pruner always reduce activation dim on 0 (now dynamically adapt reduce dims to different module types)

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


