### PR TITLE
Add official pretrained weights for Autoformer

### DIFF
--- a/nni/common/blob_utils.py
+++ b/nni/common/blob_utils.py
@@ -73,6 +73,7 @@ def load_or_download_file(local_path: str, download_url: str, download: bool = F
                     sha256.update(chunk)
                     pbar.update(len(chunk))
                     f.flush()
+            f.close()
         else:
             raise FileNotFoundError(
                 'Download is not enabled, and file does not exist: {}. Please set download=True.'.format(local_path)

--- a/nni/nas/hub/pytorch/autoformer.py
+++ b/nni/nas/hub/pytorch/autoformer.py
@@ -12,7 +12,6 @@ from nni.nas.nn.pytorch.choice import ValueChoiceX
 from nni.nas.oneshot.pytorch.supermodule.operation import MixedOperation
 from nni.nas.oneshot.pytorch.supermodule._valuechoice_utils import traverse_all_options
 from nni.nas.oneshot.pytorch.supermodule._operation_utils import Slicable as _S, MaybeWeighted as _W
-from nni.nas.strategy import RandomOneShot
 
 from .utils.fixed import FixedFactory
 from .utils.pretrained import load_pretrained_weight
@@ -432,9 +431,14 @@ class AutoformerSpace(nn.Module):
 
     @classmethod
     def load_strategy_checkpoint(cls, name: str, download: bool = True, progress: bool = True):
-        strategy = RandomOneShot(mutation_hooks=cls.get_extra_mutation_hooks())
+        legal = ['random-one-shot-tiny', 'random-one-shot-small', 'random-one-shot-base']
+        if name not in legal:
+            raise ValueError(f'Unsupported name: {name}. It should be one of {legal}.')
+        name = name[16:]
+        from nni.nas.strategy import RandomOneShot
         init_kwargs = cls.preset(name)
         model_sapce = cls(**init_kwargs)
+        strategy = RandomOneShot(mutation_hooks=cls.get_extra_mutation_hooks())
         strategy.attach_model(model_sapce)
         weight_file = load_pretrained_weight(f"autoformer-{name}-supernet", download=download, progress=progress)
         pretrained_weights = torch.load(weight_file)
@@ -446,6 +450,10 @@ class AutoformerSpace(nn.Module):
         cls, name: str,
         pretrained: bool = False, download: bool = False, progress: bool = True
     ) -> nn.Module:
+        legal = ['autoformer-tiny', 'autoformer-small', 'autoformer-base']
+        if name not in legal:
+            raise ValueError(f'Unsupported name: {name}. It should be one of {legal}.')
+        name = name[11:]
         init_kwargs = cls.preset(name)
         if name == 'tiny':
             mlp_ratio = [3.5, 3.5, 3.0, 3.5, 3.0, 3.0, 4.0, 4.0, 3.5, 4.0, 3.5, 4.0, 3.5] + [3.0]

--- a/nni/nas/hub/pytorch/autoformer.py
+++ b/nni/nas/hub/pytorch/autoformer.py
@@ -431,6 +431,23 @@ class AutoformerSpace(nn.Module):
 
     @classmethod
     def load_strategy_checkpoint(cls, name: str, download: bool = True, progress: bool = True):
+        """
+        Load the RandomOneShot strategy initialized with supernet weights.
+
+        Parameters
+        ----------
+        name : str
+            Search space size, must be one of {'random-one-shot-tiny', 'random-one-shot-small', 'random-one-shot-base'}.
+        download : bool
+            Whether to download supernet weights. Default is ``True``.
+        progress : bool
+            Whether to display the download progress. Default is ``True``.
+
+        Returns
+        -------
+        BaseStrategy
+            The RandomOneShot strategy initialized with supernet weights provided in the official repo.
+        """
         legal = ['random-one-shot-tiny', 'random-one-shot-small', 'random-one-shot-base']
         if name not in legal:
             raise ValueError(f'Unsupported name: {name}. It should be one of {legal}.')
@@ -449,8 +466,27 @@ class AutoformerSpace(nn.Module):
     @classmethod
     def load_searched_model(
         cls, name: str,
-        pretrained: bool = False, download: bool = False, progress: bool = True
+        pretrained: bool = False, download: bool = True, progress: bool = True
     ) -> nn.Module:
+        """
+        Load the searched subnet model.
+
+        Parameters
+        ----------
+        name : str
+            Search space size, must be one of {'autoformer-tiny', 'autoformer-small', 'autoformer-base'}.
+        pretrained : bool
+            Whether initialized with pre-trained weights. Default is ``False``.
+        download : bool
+            Whether to download supernet weights. Default is ``True``.
+        progress : bool
+            Whether to display the download progress. Default is ``True``.
+
+        Returns
+        -------
+        nn.Module
+            The subnet model.
+        """
         legal = ['autoformer-tiny', 'autoformer-small', 'autoformer-base']
         if name not in legal:
             raise ValueError(f'Unsupported name: {name}. It should be one of {legal}.')

--- a/nni/nas/hub/pytorch/autoformer.py
+++ b/nni/nas/hub/pytorch/autoformer.py
@@ -442,6 +442,7 @@ class AutoformerSpace(nn.Module):
         strategy.attach_model(model_sapce)
         weight_file = load_pretrained_weight(f"autoformer-{name}-supernet", download=download, progress=progress)
         pretrained_weights = torch.load(weight_file)
+        assert strategy.model is not None
         strategy.model.load_state_dict(pretrained_weights)
         return strategy
 

--- a/nni/nas/hub/pytorch/utils/pretrained.py
+++ b/nni/nas/hub/pytorch/utils/pretrained.py
@@ -41,7 +41,16 @@ PRETRAINED_WEIGHT_URLS = {
     # autoformer
     'autoformer-tiny': f'{NNI_BLOB}/nashub/autoformer-searched-tiny-1e90ebc1.pth',
     'autoformer-small': f'{NNI_BLOB}/nashub/autoformer-searched-small-4bc5d4e5.pth',
-    'autoformer-base': f'{NNI_BLOB}/nashub/autoformer-searched-base-c417590a.pth'
+    'autoformer-base': f'{NNI_BLOB}/nashub/autoformer-searched-base-c417590a.pth',
+
+    # autoformer subnet
+    'autoformer-tiny-subnet': f'{NNI_BLOB}/nashub/autoformer-tiny-subnet-12ed42ff.pth',
+    'autoformer-small-subnet': f'{NNI_BLOB}/nashub/autoformer-small-subnet-b4e25a1b.pth',
+    'autoformer-base-subnet': f'{NNI_BLOB}/nashub/autoformer-base-subnet-85105f76.pth',
+    # autoformer supernet
+    'autoformer-tiny-supernet': f'{NNI_BLOB}/nashub/autoformer-tiny-supernet-6f107004.pth',
+    'autoformer-small-supernet': f'{NNI_BLOB}/nashub/autoformer-small-supernet-8ed79e18.pth',
+    'autoformer-base-supernet': f'{NNI_BLOB}/nashub/autoformer-base-supernet-0c6d6612.pth',
 }
 
 

--- a/nni/nas/hub/pytorch/utils/pretrained.py
+++ b/nni/nas/hub/pytorch/utils/pretrained.py
@@ -38,11 +38,6 @@ PRETRAINED_WEIGHT_URLS = {
     # spos
     'spos': f'{NNI_BLOB}/nashub/spos-0b17f6fc.pth',
 
-    # autoformer
-    'autoformer-tiny': f'{NNI_BLOB}/nashub/autoformer-searched-tiny-1e90ebc1.pth',
-    'autoformer-small': f'{NNI_BLOB}/nashub/autoformer-searched-small-4bc5d4e5.pth',
-    'autoformer-base': f'{NNI_BLOB}/nashub/autoformer-searched-base-c417590a.pth',
-
     # autoformer subnet
     'autoformer-tiny-subnet': f'{NNI_BLOB}/nashub/autoformer-tiny-subnet-12ed42ff.pth',
     'autoformer-small-subnet': f'{NNI_BLOB}/nashub/autoformer-small-subnet-b4e25a1b.pth',

--- a/test/algo/nas/test_space_hub.py
+++ b/test/algo/nas/test_space_hub.py
@@ -196,3 +196,17 @@ def test_shufflenet():
 def test_autoformer():
     ss = searchspace.AutoformerSpace()
     _test_searchspace_on_dataset(ss, dataset='imagenet')
+
+    from nni.nas.strategy import RandomOneShot
+
+    Autoformer = searchspace.AutoformerSpace
+    for name in ['tiny', 'small', 'base']:
+        # check subnet weights load
+        Autoformer.load_searched_model(name, pretrained = True, download = True)
+        init_kwargs = Autoformer.official_config(name)
+        model_sapce = Autoformer(**init_kwargs)
+        # check model space weights load
+        strategy = RandomOneShot(mutation_hooks=Autoformer.get_extra_mutation_hooks())
+        strategy.attach_model(model_sapce)
+        pretrained_weights = Autoformer.official_weights(name, 'supernet')
+        strategy.model.load_state_dict(pretrained_weights)

--- a/test/algo/nas/test_space_hub.py
+++ b/test/algo/nas/test_space_hub.py
@@ -197,16 +197,7 @@ def test_autoformer():
     ss = searchspace.AutoformerSpace()
     _test_searchspace_on_dataset(ss, dataset='imagenet')
 
-    from nni.nas.strategy import RandomOneShot
-
-    Autoformer = searchspace.AutoformerSpace
     for name in ['tiny', 'small', 'base']:
-        # check subnet weights load
-        Autoformer.load_searched_model(name, pretrained = True, download = True)
-        init_kwargs = Autoformer.official_config(name)
-        model_sapce = Autoformer(**init_kwargs)
-        # check model space weights load
-        strategy = RandomOneShot(mutation_hooks=Autoformer.get_extra_mutation_hooks())
-        strategy.attach_model(model_sapce)
-        pretrained_weights = Autoformer.official_weights(name, 'supernet')
-        strategy.model.load_state_dict(pretrained_weights)
+        # check subnet & supernet weights load
+        searchspace.AutoformerSpace.load_searched_model(name, pretrained = True, download = True)
+        searchspace.AutoformerSpace.load_strategy_checkpoint(name)

--- a/test/algo/nas/test_space_hub.py
+++ b/test/algo/nas/test_space_hub.py
@@ -197,7 +197,11 @@ def test_autoformer():
     ss = searchspace.AutoformerSpace()
     _test_searchspace_on_dataset(ss, dataset='imagenet')
 
+    import torch
     for name in ['tiny', 'small', 'base']:
         # check subnet & supernet weights load
-        searchspace.AutoformerSpace.load_searched_model(name, pretrained = True, download = True)
-        searchspace.AutoformerSpace.load_strategy_checkpoint(name)
+        model = searchspace.AutoformerSpace.load_searched_model(f'autoformer-{name}', pretrained = True, download = True)
+        model(torch.rand(1, 3, 224, 224))
+        strategy = searchspace.AutoformerSpace.load_strategy_checkpoint(f'random-one-shot-{name}')
+        strategy.model.resample()
+        strategy.model(torch.rand(1, 3, 224, 224))


### PR DESCRIPTION
### Description ###
Add subnet and supernet weights from offical repo for autoformer. Add interface for official model space config.

#### Test Options ####
  - [x] fast test
  - [x] full test - NAS

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
```
from nni.retiarii.hub.pytorch import AutoformerSpace
for name in ['tiny', 'small', 'base']:
    # check subnet weights load
    AutoformerSpace.load_searched_model(name, pretrained = True, download = True)
    AutoformerSpace.load_strategy_checkpoint(name)
```


