### PR TITLE
Make anneal tuner optional

### DIFF
--- a/dependencies/required.txt
+++ b/dependencies/required.txt
@@ -2,7 +2,6 @@ astor
 cloudpickle
 colorama
 filelock
-hyperopt == 0.1.2
 json_tricks >= 3.15.5
 numpy < 1.22 ; python_version < "3.8"
 numpy ; python_version >= "3.8"

--- a/dependencies/required_extra.txt
+++ b/dependencies/required_extra.txt
@@ -1,6 +1,9 @@
 # the following content will be read by setup.py.
 # please follow the logic in setup.py.
 
+# Anneal
+hyperopt == 0.1.2
+
 # SMAC
 ConfigSpaceNNI>=0.4.7.3
 smac4nni

--- a/docs/source/hpo/tuners.rst
+++ b/docs/source/hpo/tuners.rst
@@ -77,6 +77,8 @@ Built-in Tuners
       - Heuristic
       - This simple annealing algorithm begins by sampling from the prior, but tends over time to sample from points closer and closer to the best ones observed. This algorithm is a simple variation on the random search that leverages smoothness in the response surface. The annealing rate is not adaptive.
 
+        Notice, Anneal needs to be installed by ``pip install nni[Anneal]`` command.
+
     * - :class:`Evolution <nni.algorithms.hpo.evolution_tuner.EvolutionTuner>`
       - Heuristic
       - Naive Evolution comes from Large-Scale Evolution of Image Classifiers. It randomly initializes a population-based on search space. For each generation, it chooses better ones and does some mutation (e.g., change a hyperparameter, add/remove one layer) on them to get the next generation. Naïve Evolution requires many trials to work, but it's very simple and easy to expand new features. `Reference paper <https://arxiv.org/pdf/1703.01041.pdf>`__

--- a/nni/algorithms/hpo/hyperopt_tuner.py
+++ b/nni/algorithms/hpo/hyperopt_tuner.py
@@ -198,6 +198,12 @@ class HyperoptTuner(Tuner):
     This algorithm is a simple variation of random search that leverages smoothness in the response surface.
     The annealing rate is not adaptive.
 
+    Note that it needs additional installation using the following command:
+
+    .. code-block:: bash
+
+        pip install nni[Anneal]
+
     Examples
     --------
 

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ def _setup():
         python_requires = '>=3.7',
         install_requires = _read_requirements_txt('dependencies/required.txt'),
         extras_require = {
+            'Anneal': _read_requirements_txt('dependencies/required_extra.txt', 'Anneal'),
             'SMAC': _read_requirements_txt('dependencies/required_extra.txt', 'SMAC'),
             'BOHB': _read_requirements_txt('dependencies/required_extra.txt', 'BOHB'),
             'PPOTuner': _read_requirements_txt('dependencies/required_extra.txt', 'PPOTuner'),


### PR DESCRIPTION
### Description ###

It does not affect users who upgrade from 2.9-

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - ~~test case~~
  - [x] doc

### How to test ###

Use a new environment, run `pip install nni[Anneal]` and create HPO experiment with Anneal tuner.