### PR TITLE
Let tuner auto reconnect to NNI manager

### DIFF
--- a/nni/__main__.py
+++ b/nni/__main__.py
@@ -1,11 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import os
 import argparse
-import logging
-import json
 import base64
+import json
+import logging
+import os
+import traceback
 
 from .runtime.msg_dispatcher import MsgDispatcher
 from .runtime.msg_dispatcher_base import MsgDispatcherBase
@@ -65,6 +66,7 @@ def main():
         tuner._on_error()
         if assessor is not None:
             assessor._on_error()
+        dispatcher.report_error(traceback.format_exc())
         raise
 
 

--- a/nni/runtime/msg_dispatcher_base.py
+++ b/nni/runtime/msg_dispatcher_base.py
@@ -84,6 +84,16 @@ class MsgDispatcherBase(Recoverable):
 
         _logger.info('Dispatcher terminiated')
 
+    def report_error(self, error: str) -> None:
+        '''
+        Report dispatcher error to NNI manager.
+        '''
+        _logger.info(f'Report error to NNI manager: {error}')
+        try:
+            self.send(CommandType.Error, error)
+        except Exception:
+            _logger.error('Connection to NNI manager is broken. Failed to report error.')
+
     def send(self, command, data):
         self._channel._send(command, data)
 

--- a/nni/runtime/tuner_command_channel/channel.py
+++ b/nni/runtime/tuner_command_channel/channel.py
@@ -65,7 +65,8 @@ class TunerCommandChannel:
 
     def _retry_send(self, command: str) -> None:
         _logger.warning('Connection lost. Trying to reconnect...')
-        for interval in self._retry_intervals:
+        for i, interval in enumerate(self._retry_intervals):
+            _logger.info(f'Attempt #{i}, wait {interval} seconds...')
             time.sleep(interval)
             self._channel = WebSocket(self._url)
             try:
@@ -91,7 +92,8 @@ class TunerCommandChannel:
 
     def _retry_receive(self) -> str:
         _logger.warning('Connection lost. Trying to reconnect...')
-        for interval in self._retry_intervals:
+        for i, interval in enumerate(self._retry_intervals):
+            _logger.info(f'Attempt #{i}, wait {interval} seconds...')
             time.sleep(interval)
             self._channel = WebSocket(self._url)
             try:

--- a/nni/runtime/tuner_command_channel/channel.py
+++ b/nni/runtime/tuner_command_channel/channel.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 
 __all__ = ['TunerCommandChannel']
 
+import logging
+import time
+
 from .command_type import CommandType
 from .websocket import WebSocket
+
+_logger = logging.getLogger(__name__)
 
 class TunerCommandChannel:
     """
@@ -37,6 +42,7 @@ class TunerCommandChannel:
     def __init__(self, url: str):
         self._url = url
         self._channel = WebSocket(url)
+        self._retry_intervals = [0, 1, 10]
 
     def connect(self) -> None:
         self._channel.connect()
@@ -55,17 +61,45 @@ class TunerCommandChannel:
         try:
             self._channel.send(command)
         except WebSocket.ConnectionClosed:
+            self._retry_send(command)
+
+    def _retry_send(self, command: str) -> None:
+        _logger.warning('Connection lost. Trying to reconnect...')
+        for interval in self._retry_intervals:
+            time.sleep(interval)
             self._channel = WebSocket(self._url)
-            self._channel.send(command)
+            try:
+                self._channel.send(command)
+                _logger.info('Reconnected.')
+                return
+            except Exception as e:
+                _logger.exception(e)
+        _logger.error('Failed to reconnect.')
+        raise RuntimeError('Connection lost')
 
     def _receive(self) -> tuple[CommandType, str] | tuple[None, None]:
         try:
             command = self._channel.receive()
         except WebSocket.ConnectionClosed:
-            self._channel = WebSocket(self._url)
-            command = self._channel.receive()
-
+            # this is for robustness and should never happen
+            _logger.warning('ConnectionClosed exception on receiving.')
+            command = None
         if command is None:
-            raise RuntimeError('NNI manager closed connection')
+            command = self._retry_receive()
         command_type = CommandType(command[:2].encode())
         return command_type, command[2:]
+
+    def _retry_receive(self) -> str:
+        _logger.warning('Connection lost. Trying to reconnect...')
+        for interval in self._retry_intervals:
+            time.sleep(interval)
+            self._channel = WebSocket(self._url)
+            try:
+                command = self._channel.receive()
+            except WebSocket.ConnectionClosed:
+                command = None  # for robustness
+            if command is not None:
+                _logger.info('Reconnected')
+                return command
+        _logger.error('Failed to reconnect.')
+        raise RuntimeError('Connection lost')

--- a/nni/runtime/tuner_command_channel/command_type.py
+++ b/nni/runtime/tuner_command_channel/command_type.py
@@ -21,3 +21,4 @@ class CommandType(Enum):
     SendTrialJobParameter = b'SP'
     NoMoreTrialJobs = b'NO'
     KillTrialJob = b'KI'
+    Error = b'ER'

--- a/ts/nni_manager/common/deferred.ts
+++ b/ts/nni_manager/common/deferred.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ *  TODO: Back ported from 3.0 draft.
+ *
+ *  An augmented version of ts-deferred.
+ *
+ *  You can `await deferred.promise` more than once and they will be resolved together.
+ *
+ *  You can resolve a deferred multiple times with identical value and it will be ignored.
+ *
+ *  If a deferred is resolved and/or rejected with conflict values,
+ *  it will throw error and log both values or reasons.
+ **/
+
+import util from 'util';
+
+import { Logger, getLogger } from 'common/log';
+
+const logger = getLogger('common.deferred');
+
+export class Deferred<T> {
+    private resolveCallbacks: any[] = [];
+    private rejectCallbacks: any[] = [];
+    private isResolved: boolean = false;
+    private isRejected: boolean = false;
+    private resolvedValue?: T;
+    private rejectedReason?: Error;
+
+    public get promise(): Promise<T> {
+        // use getter to compat ts-deferred
+        if (this.isResolved) {
+            return Promise.resolve(this.resolvedValue) as Promise<T>;
+        }
+        if (this.isRejected) {
+            return Promise.reject(this.rejectedReason) as Promise<T>;
+        }
+        return new Promise<T>((resolutionFunc, rejectionFunc) => {
+            this.resolveCallbacks.push(resolutionFunc);
+            this.rejectCallbacks.push(rejectionFunc);
+        });
+    }
+
+    public get settled(): boolean {
+        // use getter for consistent api style
+        return this.isResolved || this.isRejected;
+    }
+
+    public resolve = (value: T): void => {
+        if (!this.isResolved && ! this.isRejected) {
+            this.isResolved = true;
+            this.resolvedValue = value;
+            for (const callback of this.resolveCallbacks) {
+                callback(value);
+            }
+
+        } else if (this.isResolved && this.resolvedValue == value) {
+            logger.debug('Double resolve:', value);
+
+        } else {
+            const msg = this.errorMessage('trying to resolve with value: ' + util.inspect(value));
+            logger.error(msg);
+            throw new Error('Conflict Deferred result. ' + msg);
+        }
+    }
+
+    public reject = (reason: Error): void => {
+        if (!this.isResolved && !this.isRejected) {
+            this.isRejected = true;
+            this.rejectedReason = reason;
+            for (const callback of this.rejectCallbacks) {
+                callback(reason);
+            }
+
+        } else if (this.isRejected) {
+            logger.warning('Double reject:', this.rejectedReason, reason);
+
+        } else {
+            const msg = this.errorMessage('trying to reject with reason: ' + util.inspect(reason));
+            logger.error(msg);
+            throw new Error('Conflict Deferred result. ' + msg);
+        }
+    }
+
+    private errorMessage(curStat: string): string {
+        let prevStat = '';
+        if (this.isResolved) {
+            prevStat = 'Already resolved with value: ' + util.inspect(this.resolvedValue);
+        }
+        if (this.isRejected) {
+            prevStat = 'Already rejected with reason: ' + util.inspect(this.rejectedReason);
+        }
+        return prevStat + ' ; ' + curStat;
+    }
+}

--- a/ts/nni_manager/core/tuner_command_channel/shim.ts
+++ b/ts/nni_manager/core/tuner_command_channel/shim.ts
@@ -10,6 +10,24 @@ export async function createDispatcherInterface(): Promise<IpcInterface> {
 
 class WsIpcInterface implements IpcInterface {
     private channel: WebSocketChannel = getWebSocketChannel();
+    private commandListener?: (commandType: string, content: string) => void;
+    private errorListener?: (error: Error) => void;
+
+    constructor() {
+        this.channel.onCommand((command: string) => {
+            const commandType = command.slice(0, 2);
+            const content = command.slice(2);
+            if (commandType === 'ER') {
+                if (this.errorListener !== undefined) {
+                    this.errorListener(new Error(content));
+                }
+            } else {
+                if (this.commandListener !== undefined) {
+                    this.commandListener(commandType, content);
+                }
+            }
+        });
+    }
 
     public async init(): Promise<void> {
         await this.channel.init();
@@ -25,12 +43,10 @@ class WsIpcInterface implements IpcInterface {
     }
 
     public onCommand(listener: (commandType: string, content: string) => void): void {
-        this.channel.onCommand((command: string) => {
-            listener(command.slice(0, 2), command.slice(2));
-        });
+        this.commandListener = listener;
     }
 
     public onError(listener: (error: Error) => void): void {
-        this.channel.onError(listener);
+        this.errorListener = listener;
     }
 }

--- a/ts/nni_manager/test/core/tuner_command_channel.test.ts
+++ b/ts/nni_manager/test/core/tuner_command_channel.test.ts
@@ -81,7 +81,11 @@ async function testShutdown(): Promise<void> {
     const channel = getWebSocketChannel();
     await channel.shutdown();
 
-    client.close();
+    try {
+        client.close();
+    } catch (error) {
+        console.log('Error on clean up:', error);
+    }
     server.close();
 }
 

--- a/ts/nni_manager/test/core/tuner_command_channel.test.ts
+++ b/ts/nni_manager/test/core/tuner_command_channel.test.ts
@@ -68,6 +68,14 @@ async function testError(): Promise<void> {
     client.resume();
 }
 
+// WebSocket might get broken in long experiments. Simulate reconnect.
+async function testReconnect(): Promise<void> {
+    client.close();
+    startClient();
+    testInit();
+    testSend();
+}
+
 // Clean up.
 async function testShutdown(): Promise<void> {
     const channel = getWebSocketChannel();
@@ -83,6 +91,7 @@ describe('## tuner_command_channel ##', () => {
     it('send', testSend);
     it('receive', testReceive);
     it('catch error', testError);
+    it('reconnect', testReconnect);
     it('shutdown', testShutdown);
 });
 


### PR DESCRIPTION
### Description ###

Dispatcher now tries to reconnect when it loses connection to NNI manager.
For one command it only retries once. If it fails twice for the same message then dispatcher crashes.
Because the reconnect is raised by client (dispatcher) side, dispatcher to manager messages will be resent on connection loss, but manager to dispatcher messages during the reconnect (~5s) will loss. I think it's okay because it only hurts tuner's accuracy.

Because connection error is now "expected", we add a new tuner command `ER` (error) to report real tuner error.
When the outermost function of dispatcher catches an exception, it tries to send the content with error command.
In NNI manager side, the shim layer of IPC channel is modified to report `ER` content to NNI manager and hide connection errors.

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [x] test case
  - ~~doc~~

### How to test ###

I don't know...
