### PR TITLE
Training service util: HTTP command channel

### DIFF
--- a/nni/runtime/command_channel/__init__.py
+++ b/nni/runtime/command_channel/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/nni/runtime/command_channel/base.py
+++ b/nni/runtime/command_channel/base.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any
+
+Command = Any  # TODO
+
+class CommandChannel:
+    def send(self, command: Command) -> None:
+        raise NotImplementedError()
+
+    def receive(self) -> Command:
+        raise NotImplementedError()

--- a/nni/runtime/command_channel/base.py
+++ b/nni/runtime/command_channel/base.py
@@ -9,5 +9,5 @@ class CommandChannel:
     def send(self, command: Command) -> None:
         raise NotImplementedError()
 
-    def receive(self) -> Command:
+    def receive(self) -> Command | None:
         raise NotImplementedError()

--- a/nni/runtime/command_channel/http.py
+++ b/nni/runtime/command_channel/http.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import requests
+
+from .base import Command, CommandChannel
+
+class HttpChannel(CommandChannel):
+    """
+    A simple command channel based on HTTP.
+
+    Check the server for details. (``ts/nni_manager/common/command_channel/http.ts``)
+    """
+
+    def __init__(self, url: str):
+        self._url: str = url
+
+    def send(self, command: Command) -> None:
+        requests.put(self._url, json=command)
+
+    def receive(self) -> Command:
+        while True:
+            r = requests.get(self._url)
+            if r.status_code == 200:
+                return r.json()
+            if r.status_code == 408:
+                continue
+            raise IOError(f'HTTP command channel received unexpected status code {r.status_code}')

--- a/nni/runtime/command_channel/http.py
+++ b/nni/runtime/command_channel/http.py
@@ -1,9 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import logging
+
 import requests
 
 from .base import Command, CommandChannel
+
+_logger = logging.getLogger(__name__)
 
 class HttpChannel(CommandChannel):
     """
@@ -18,11 +22,14 @@ class HttpChannel(CommandChannel):
     def send(self, command: Command) -> None:
         requests.put(self._url, json=command)
 
-    def receive(self) -> Command:
+    def receive(self) -> Command | None:
         while True:
             r = requests.get(self._url)
             if r.status_code == 200:
                 return r.json()
             if r.status_code == 408:
                 continue
+            if r.status_code == 410:
+                return None
+            _logger.error('Bad status %s %s', r.status_code, r.text)
             raise IOError(f'HTTP command channel received unexpected status code {r.status_code}')

--- a/ts/nni_manager/common/command_channel/http.ts
+++ b/ts/nni_manager/common/command_channel/http.ts
@@ -39,14 +39,14 @@ export class HttpChannelServer implements CommandChannelServer {
         this.path = urlPath;
     }
 
-    public start(): void {
+    public async start(): Promise<void> {
         this.serving = true;
         const channelPath = globals.rest.urlJoin(this.path, ':channel');
         globals.rest.registerSyncHandler('GET', channelPath, this.handleGet.bind(this));
         globals.rest.registerSyncHandler('PUT', channelPath, this.handlePut.bind(this));
     }
 
-    public shutdown(): void {
+    public async shutdown(): Promise<void> {
         this.serving = false;
         this.outgoingQueues.forEach(queue => { queue.clear(); });
     }

--- a/ts/nni_manager/common/command_channel/http.ts
+++ b/ts/nni_manager/common/command_channel/http.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ *  HTTP based command channel. Inefficient but simple.
+ *
+ *  Client to server command is implemented by naive PUT request.
+ *
+ *  Server to client command is implemented by polling with GET requests.
+ *  The client should repeat GET requests without intervals when it is receiving commands.
+ *  If the server has an outgoing command, it will be sent as response.
+ *  If there is no command, the server will wait for 1 second and response 408 "Request Timeout" status code.
+ **/
+
+import { EventEmitter } from 'events';
+
+import { Request, Response } from 'express';
+
+import { Deferred } from 'common/deferred';
+import globals from 'common/globals';
+import { Logger, getLogger } from 'common/log';
+import type { Command, CommandChannelServer } from './interface';
+
+let timeoutMilliseconds = 1000;
+
+export class HttpChannelServer implements CommandChannelServer {
+    private emitter: EventEmitter = new EventEmitter();
+    private log: Logger;
+    // the server can only send commands when the client requests, so it needs a queue
+    private outgoingQueues: Map<string, CommandQueue> = new Map();
+    private path: string;
+
+    constructor(name: string, urlPath: string) {
+        this.log = getLogger(`HttpChannelManager.${name}`);
+        this.path = urlPath;
+    }
+
+    public start(): void {
+        const channelPath = globals.rest.urlJoin(this.path, ':channel');
+        globals.rest.registerSyncHandler('GET', channelPath, this.handleGet.bind(this));
+        globals.rest.registerSyncHandler('PUT', channelPath, this.handlePut.bind(this));
+    }
+
+    public getChannelUrl(channelId: string): string {
+        return globals.rest.getFullUrl('http', this.path, channelId);
+    }
+
+    public send(channelId: string, command: Command): void {
+        this.getOutgoingQueue(channelId).push(command);
+    }
+
+    public onReceive(callback: (channelId: string, command: Command) => void): void {
+        this.emitter.on('receive', callback);
+    }
+
+    private handleGet(request: Request, response: Response): void {
+        const channelId = request.params['channel'];
+        const promise = this.getOutgoingQueue(channelId).asyncPop(timeoutMilliseconds);
+        promise.then(command => {
+            if (command === null) {
+                response.sendStatus(408);
+            } else {
+                response.send(command);
+            }
+        });
+    }
+
+    private handlePut(request: Request, response: Response): void {
+        const channelId = request.params['channel'];
+        const command = request.body;
+        this.emitter.emit('receive', channelId, command);
+        response.send();
+    }
+
+    private getOutgoingQueue(channelId: string): CommandQueue {
+        if (!this.outgoingQueues.has(channelId)) {
+            this.outgoingQueues.set(channelId, new CommandQueue());
+        }
+        return this.outgoingQueues.get(channelId)!;
+    }
+}
+
+class CommandQueue {
+    private commands: Command[] = [];
+    private consumers: Deferred<Command | null>[] = [];
+
+    public push(command: Command): void {
+        const consumer = this.consumers.shift();
+        if (consumer !== undefined) {
+            consumer.resolve(command);
+        } else {
+            this.commands.push(command);
+        }
+    }
+
+    public asyncPop(timeout: number): Promise<Command | null> {
+        // return null when timeout
+        const command = this.commands.shift();
+        if (command !== undefined) {
+            return Promise.resolve(command);
+        } else {
+            const deferred = new Deferred<Command | null>();
+            this.consumers.push(deferred);
+            setTimeout(() => {
+                if (!deferred.settled) {
+                    this.consumers = this.consumers.filter(item => (item !== deferred));
+                    deferred.resolve(null);
+                }
+            }, timeout);
+            return deferred.promise;
+        }
+    }
+}
+
+export namespace UnitTestHelpers {
+    export function setTimeoutMilliseconds(ms: number): void {
+        timeoutMilliseconds = ms;
+    }
+}

--- a/ts/nni_manager/common/command_channel/interface.ts
+++ b/ts/nni_manager/common/command_channel/interface.ts
@@ -16,7 +16,8 @@ export interface Command {
  **/
 export interface CommandChannelServer {
     // constructor(name: string, urlPath: string)
-    start(): void;
+    start(): Promise<void>;
+    shutdown(): Promise<void>;
     getChannelUrl(channelId: string): string;
     send(channelId: string, command: Command): void;
     onReceive(callback: (channelId: string, command: Command) => void): void;

--- a/ts/nni_manager/common/command_channel/interface.ts
+++ b/ts/nni_manager/common/command_channel/interface.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface Command {
+    type: string;
+}
+ 
+/**
+ *  A command channel server serves one or more command channels.
+ *  Each channel is connected to a client.
+ *
+ *  Normally each client has a unique channel URL,
+ *  which can be got with `server.getChannelUrl(id)`.
+ *
+ *  The APIs might be changed to return `Promise<void>` in future.
+ **/
+export interface CommandChannelServer {
+    // constructor(name: string, urlPath: string)
+    start(): void;
+    getChannelUrl(channelId: string): string;
+    send(channelId: string, command: Command): void;
+    onReceive(callback: (channelId: string, command: Command) => void): void;
+}

--- a/ts/nni_manager/common/globals/index.ts
+++ b/ts/nni_manager/common/globals/index.ts
@@ -19,6 +19,7 @@ import assert from 'assert/strict';
 import { NniManagerArgs, parseArgs } from './arguments';
 import { LogStream, initLogStream } from './log_stream';
 import { NniPaths, createPaths } from './paths';
+import { RestManager } from './rest';
 import { ShutdownManager } from './shutdown';
 
 export { NniManagerArgs, NniPaths };
@@ -32,6 +33,7 @@ export { NniManagerArgs, NniPaths };
 export interface NniGlobals {
     readonly args: NniManagerArgs;
     readonly paths: NniPaths;
+    readonly rest: RestManager;
     readonly shutdown: ShutdownManager;
 
     readonly logStream: LogStream;
@@ -59,8 +61,9 @@ export function initGlobals(): void {
     const args = parseArgs(process.argv.slice(2));
     const paths = createPaths(args);
     const logStream = initLogStream(args, paths);
+    const rest = new RestManager();
     const shutdown = new ShutdownManager();
 
-    const globals: NniGlobals = { args, paths, logStream, shutdown };
+    const globals: NniGlobals = { args, paths, logStream, rest, shutdown };
     Object.assign(global.nni, globals);
 }

--- a/ts/nni_manager/common/globals/rest.ts
+++ b/ts/nni_manager/common/globals/rest.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ *  WIP REST API manager.
+ *  Functions will be added when used.
+ **/
+
+import express, { Request, Response, Router } from 'express';
+
+type HttpMethod = 'GET' | 'PUT';
+
+type ExpressCallback = (req: Request, res: Response) => void;
+
+export class RestManager {
+    private router: Router;
+
+    constructor() {
+        this.router = Router();
+        this.router.use(express.json({ limit: '50mb' }));
+    }
+
+    public getExpressRouter(): Router {
+        return this.router;
+    }
+
+    public registerSyncHandler(method: HttpMethod, path: string, callback: ExpressCallback): void {
+        const p = '/' + trimSlash(path);
+        if (method === 'GET') {
+            this.router.get(p, callback);
+        } else if (method === 'PUT') {
+            this.router.put(p, callback);
+        } else {
+            throw new Error(`RestManager: Bad method ${method}`);
+        }
+    }
+
+    public registerExpressRouter(path: string, router: Router): void {
+        this.router.use(path, router);
+    }
+
+    public urlJoin(...parts: string[]): string {
+        return parts.map(trimSlash).filter(part => part).join('/');
+    }
+
+    public getFullUrl(protocol: string, ...parts: string[]): string {
+        const root = `${protocol}://localhost:${global.nni.args.port}/`;
+        return root + this.urlJoin(global.nni.args.urlPrefix, ...parts);
+    }
+}
+
+function trimSlash(s: string): string {
+    return s.replace(/^\/+|\/+$/g, '');
+}

--- a/ts/nni_manager/common/globals/unittest.ts
+++ b/ts/nni_manager/common/globals/unittest.ts
@@ -23,9 +23,11 @@ import os from 'os';
 import path from 'path';
 
 import type { NniManagerArgs } from './arguments';
-import { NniPaths, createPaths } from './paths';
 import type { LogStream } from './log_stream';
-// Enforce ts-node to import `shutdown.ts`.
+import { NniPaths, createPaths } from './paths';
+import { RestManager } from './rest';
+
+// Enforce ts-node to compile `shutdown.ts`.
 // Without this line it might complain "log_1.getRobustLogger is not a function".
 // "Magic. Do not touch."
 import './shutdown';
@@ -39,6 +41,7 @@ export interface MutableGlobals {
     args: Mutable<NniManagerArgs>;
     paths: Mutable<NniPaths>;
     logStream: LogStream;
+    rest: RestManager;
 
     reset(): void;
 }
@@ -62,12 +65,13 @@ export function resetGlobals(): void {
         writeLineSync: (_line: string): void => { /* dummy */ },
         close: async (): Promise<void> => { /* dummy */ }
     };
+    const rest = new RestManager();
     const shutdown = {
         register: (..._: any): void => { /* dummy */ },
     };
 
     const globalAsAny = global as any;
-    const utGlobals = { args, paths, logStream, shutdown, reset: resetGlobals };
+    const utGlobals = { args, paths, logStream, rest, shutdown, reset: resetGlobals };
     if (globalAsAny.nni === undefined) {
         globalAsAny.nni = utGlobals;
     } else {
@@ -76,6 +80,9 @@ export function resetGlobals(): void {
 }
 
 function isUnitTest(): boolean {
+    if ((global as any).nniUnitTest) {
+        return true;
+    }
     const event = process.env['npm_lifecycle_event'] ?? '';
     return event.startsWith('test') || event === 'mocha' || event === 'nyc';
 }

--- a/ts/nni_manager/main.ts
+++ b/ts/nni_manager/main.ts
@@ -37,13 +37,15 @@ import { SqlDB } from 'core/sqlDatabase';
 import { initExperimentsManager } from 'extensions/experiments_manager';
 import { NNITensorboardManager } from 'extensions/nniTensorboardManager';
 import { RestServer } from 'rest_server';
-
-import path from 'path';
+import { createRestHandler } from 'rest_server/restHandler';
 
 const logger: Logger = getLogger('main');
 
 async function start(): Promise<void> {
     logger.info('Start NNI manager');
+
+    const restServer = new RestServer(globals.args.port, globals.args.urlPrefix);
+    await restServer.start();
 
     Container.bind(Manager).to(NNIManager).scope(Scope.Singleton);
     Container.bind(Database).to(SqlDB).scope(Scope.Singleton);
@@ -53,8 +55,7 @@ async function start(): Promise<void> {
     const ds: DataStore = component.get(DataStore);
     await ds.init();
 
-    const restServer = new RestServer(globals.args.port, globals.args.urlPrefix);
-    await restServer.start();
+    globals.rest.registerExpressRouter('/api/v1/nni', createRestHandler());
 
     initExperimentsManager();
 

--- a/ts/nni_manager/rest_server/index.ts
+++ b/ts/nni_manager/rest_server/index.ts
@@ -33,7 +33,6 @@ import { Deferred } from 'ts-deferred';
 import globals from 'common/globals';
 import { Logger, getLogger } from 'common/log';
 import * as tunerCommandChannel from 'core/tuner_command_channel';
-import { createRestHandler } from './restHandler';
 
 const logger: Logger = getLogger('RestServer');
 
@@ -64,7 +63,8 @@ export class RestServer {
         const app = express();
         expressWs(app, undefined, { wsOptions: { maxPayload: 4 * 1024 * 1024 * 1024 }});
 
-        app.use('/' + this.urlPrefix, rootRouter());
+        app.use('/' + this.urlPrefix, mainRouter());
+        app.use('/' + this.urlPrefix, fallbackRouter());
         app.all('*', (_req: Request, res: Response) => { res.status(404).send(`Outside prefix "/${this.urlPrefix}"`); });
         this.server = app.listen(this.port);
 
@@ -103,12 +103,8 @@ export class RestServer {
  *  
  *  In fact experiments management should have a separate prefix and module.
  **/
-function rootRouter(): Router {
-    const router = Router() as expressWs.Router;
-    router.use(express.json({ limit: '50mb' }));
-
-    /* NNI manager APIs */
-    router.use('/api/v1/nni', restHandlerFactory());
+function mainRouter(): Router {
+    const router = globals.rest.getExpressRouter() as expressWs.Router;
 
     /* WebSocket APIs */
     router.ws('/tuner', (ws, _req, _next) => { tunerCommandChannel.serveWebSocket(ws); });
@@ -122,6 +118,15 @@ function rootRouter(): Router {
 
     /* NAS model visualization */
     router.use('/netron', netronProxy());
+    return router;
+}
+
+function fallbackRouter(): Router {
+    const router = Router();
+
+    // The main router will handle this request once initialized.
+    // So if it reaches here, the status is initializing.
+    router.get('/api/v1/nni/check-status', (_req, res) => { res.send('INITIALIZING'); });
 
     /* Web UI */
     router.get('*', express.static(webuiPath));
@@ -146,7 +151,6 @@ function netronProxy(): Router {
 
 let webuiPath: string = path.resolve('static');
 let netronUrl: string = 'https://netron.app';
-let restHandlerFactory = createRestHandler;
 
 export namespace UnitTestHelpers {
     export function getPort(server: RestServer): number {
@@ -161,13 +165,8 @@ export namespace UnitTestHelpers {
         netronUrl = mockUrl;
     }
 
-    export function disableNniManager(): void {
-        restHandlerFactory = (): Router => Router();
-    }
-
     export function reset(): void {
         webuiPath = path.resolve('static');
         netronUrl = 'https://netron.app';
-        restHandlerFactory = createRestHandler;
     }
 }

--- a/ts/nni_manager/test/common/command_channel/http.test.ts
+++ b/ts/nni_manager/test/common/command_channel/http.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import assert from 'assert/strict';
+import { setTimeout } from 'timers/promises';
+
+import globals from 'common/globals/unittest';
+import { HttpChannelServer, UnitTestHelpers } from 'common/command_channel/http';
+import { Command } from 'common/command_channel/interface';
+import { RestServer, UnitTestHelpers as RestServerHelpers } from 'rest_server';
+
+let server: HttpChannelServer;
+const serverReceivedCommands: Record<string, Command[]> = { '1': [], '2': [] };
+
+let restServer: RestServer;
+let port: number;
+
+const asciiCommand = { type: 'hello', message: 'world' };
+const unicodeCommand = { type: '你好', content: '世界' };
+
+describe('## http command channel ##', () => {
+    before(beforeHook);
+
+    it('init', () => testInit());
+    it('server <- client-1', () => testReceive('1'));
+    it('server -> client-2 (before polling)', () => testSendBefore('2'));
+    it('server <- client-2', () => testReceive('2'));
+    it('server -> client-1 (short after polling)', () => testSendAfter('1', 10));
+    it('server -> client-2 (long after polling)', () => testSendAfter('2', 30));
+
+    after(afterHook);
+});
+
+async function testInit(): Promise<void> {
+    UnitTestHelpers.setTimeoutMilliseconds(20);
+    server = new HttpChannelServer('ut', 'ut');
+    server.onReceive((channelId, command) => {
+        serverReceivedCommands[channelId].push(command);
+    });
+    server.start();
+    assert.equal(server.getChannelUrl('1'), `http://localhost:${port}/ut/1`);
+}
+
+async function testReceive(id: string): Promise<void> {
+    await clientSend(id, asciiCommand);
+    await clientSend(id, unicodeCommand);
+    await setTimeout(10);
+    assert.deepEqual(serverReceivedCommands[id], [ asciiCommand, unicodeCommand ]);
+}
+
+async function testSendBefore(id: string): Promise<void> {
+    server.send(id, asciiCommand);
+    const command = await clientReceive(id);
+    assert.deepEqual(command, asciiCommand);
+}
+
+async function testSendAfter(id: string, delay: number): Promise<void> {
+    const promise = clientReceive(id);
+    await setTimeout(delay);
+    server.send(id, unicodeCommand);
+    const command = await promise;
+    assert.deepEqual(command, unicodeCommand);
+}
+
+/* Helper and environment */
+
+async function clientSend(id: string, command: Command): Promise<void> {
+    const url = server.getChannelUrl(id);
+    await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(command),
+    });
+}
+
+async function clientReceive(id: string): Promise<Command> {
+    const url = server.getChannelUrl(id);
+    for (let i = 0; i < 10; i++) {
+        const r = await fetch(url);
+        if (r.status === 200) {
+            return r.json();
+        }
+        if (r.status === 408) {
+            continue;
+        }
+        throw new Error(`Unexpected status ${r.status}`);
+    }
+    throw new Error('No command in 10s');
+}
+
+async function beforeHook(): Promise<void> {
+    globals.reset();
+    restServer = new RestServer(0, '');
+    await restServer.start();
+    port = RestServerHelpers.getPort(restServer);
+}
+
+async function afterHook() {
+    if (restServer) {
+        await restServer.shutdown();
+    }
+    globals.reset();
+    RestServerHelpers.reset();
+}

--- a/ts/nni_manager/test/common/command_channel/http.test.ts
+++ b/ts/nni_manager/test/common/command_channel/http.test.ts
@@ -38,7 +38,7 @@ async function testStart(): Promise<void> {
     server.onReceive((channelId, command) => {
         serverReceivedCommands[channelId].push(command);
     });
-    server.start();
+    await server.start();
     assert.equal(server.getChannelUrl('1'), `http://localhost:${port}/ut/1`);
 }
 
@@ -66,7 +66,7 @@ async function testSendAfter(id: string, delay: number): Promise<void> {
 async function testStop(): Promise<void> {
     const promise = clientReceive('1');
     await setTimeout(10);
-    server.shutdown();
+    await server.shutdown();
     const response = await promise;
     assert.equal(response, null);
 }

--- a/ts/nni_manager/test/common/command_channel/http.test.ts
+++ b/ts/nni_manager/test/common/command_channel/http.test.ts
@@ -93,6 +93,7 @@ async function beforeHook(): Promise<void> {
     restServer = new RestServer(0, '');
     await restServer.start();
     port = RestServerHelpers.getPort(restServer);
+    globals.args.port = port;
 }
 
 async function afterHook() {

--- a/ts/nni_manager/test/register.js
+++ b/ts/nni_manager/test/register.js
@@ -1,3 +1,5 @@
+global.nniUnitTest = true;
+
 require('ts-node/register');
 require('app-module-path/cwd');
 

--- a/ts/nni_manager/test/rest_server/nni_manager_handlers.test.ts
+++ b/ts/nni_manager/test/rest_server/nni_manager_handlers.test.ts
@@ -20,6 +20,8 @@ import { MockedExperimentManager } from '../mock/experimentManager';
 import { TensorboardManager } from '../../common/tensorboardManager';
 import { MockTensorboardManager } from '../mock/mockTensorboardManager';
 import { UnitTestHelpers as ExpsMgrHelpers } from 'extensions/experiments_manager';
+import globals from 'common/globals/unittest';
+import { createRestHandler } from 'rest_server/restHandler';
 
 let restServer: RestServer;
 
@@ -38,6 +40,7 @@ describe('Unit test for rest handler', () => {
         await restServer.start();
         const port = UnitTestHelpers.getPort(restServer);
         ROOT_URL = `http://localhost:${port}/api/v1/nni`;
+        globals.rest.registerExpressRouter('/api/v1/nni', createRestHandler());
     });
 
     after(() => {

--- a/ts/nni_manager/test/rest_server/rest_server.test.ts
+++ b/ts/nni_manager/test/rest_server/rest_server.test.ts
@@ -5,8 +5,6 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 
-import fetch from 'node-fetch';
-
 import globals from 'common/globals/unittest';
 import { RestServer, UnitTestHelpers } from 'rest_server';
 import * as mock_netron_server from './mock_netron_server';
@@ -134,9 +132,9 @@ async function configRestServer(urlPrefix?: string): Promise<void> {
         await restServer.shutdown();
     }
 
+    globals.reset();
     globals.paths.logDirectory = path.join(__dirname, 'log');
     UnitTestHelpers.setWebuiPath(path.join(__dirname, 'static'));
-    UnitTestHelpers.disableNniManager();
 
     restServer = new RestServer(0, urlPrefix ?? '');
     await restServer.start();
@@ -146,15 +144,6 @@ async function configRestServer(urlPrefix?: string): Promise<void> {
     endPoint = urlJoin(endPointWithoutPrefix, urlPrefix ?? '');
 }
 
-function urlJoin(part1: string, part2: string): string {
-    if (part1.endsWith('/')) {
-        part1 = part1.slice(0, -1);
-    }
-    if (part2.startsWith('/')) {
-        part2 = part2.slice(1);
-    }
-    if (part2 === '') {
-        return part1;
-    }
-    return part1 + '/' + part2;
+function urlJoin(...parts: string[]): string {
+    return globals.rest.urlJoin(...parts);
 }


### PR DESCRIPTION
### Description ###

A simple command channel based on HTTP and polling.

It will be used by the new trial keeper to interact with trials.
The HTTP protocol is chosen because:
 1. The channel client is user's trial code. So it is good to keep the client as simple as possible.
 2. There are not many commands and only one of them is issued by the server. For each trial there is only 1 request parameter, 1 send parameter (from server), N send intermediate metrics, and 1 send final metric. Therefore the performance does not matter, especially the server to client performance.

Note: Trial logs (stdout and stderr) are not sent by command channel.

The RestServer is modified to support register REST API handlers on the fly.
Previously the RestServer is created after all other components and register all handlers during its initialization.
Now RestServer is the first initialized component so it can response to "check status" requests at the earliest stage. And then each other component will install their handlers on ready.

I'm using node 18 APIs in new codes so it might depend on #5206

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [x] test case
  - ~~doc~~

### How to test ###


