### PR TITLE
fix exp update_max_experiment_duration bug && nnictl update duration bug

### DIFF
--- a/nni/experiment/experiment.py
+++ b/nni/experiment/experiment.py
@@ -403,7 +403,7 @@ class Experiment:
     def _get_query_type(self, key: str):
         if key == 'trialConcurrency':
             return '?update_type=TRIAL_CONCURRENCY'
-        if key == 'maxExecDuration':
+        if key == 'maxExperimentDuration':
             return '?update_type=MAX_EXEC_DURATION'
         if key == 'searchSpace':
             return '?update_type=SEARCH_SPACE'
@@ -448,7 +448,7 @@ class Experiment:
             Strings like '1m' for one minute or '2h' for two hours.
             SUFFIX may be 's' for seconds, 'm' for minutes, 'h' for hours or 'd' for days.
         """
-        self._update_experiment_profile('maxExecDuration', value)
+        self._update_experiment_profile('maxExperimentDuration', value)
 
     def update_search_space(self, value: dict):
         """

--- a/nni/tools/nnictl/updater.py
+++ b/nni/tools/nnictl/updater.py
@@ -50,7 +50,7 @@ def get_query_type(key):
     '''get update query type'''
     if key == 'trialConcurrency':
         return '?update_type=TRIAL_CONCURRENCY'
-    if key == 'maxExecDuration':
+    if key == 'maxExperimentDuration':
         return '?update_type=MAX_EXEC_DURATION'
     if key == 'searchSpace':
         return '?update_type=SEARCH_SPACE'
@@ -100,7 +100,7 @@ def update_duration(args):
     args.value = parse_time(args.value)
     args.port = get_experiment_port(args)
     if args.port is not None:
-        if update_experiment_profile(args, 'maxExecDuration', int(args.value)):
+        if update_experiment_profile(args, 'maxExperimentDuration', int(args.value)):
             print_normal('Update %s success!' % 'duration')
         else:
             print_error('Update %s failed!' % 'duration')


### PR DESCRIPTION
Description
fix exp update_max_experiment_duration bug && nnictl update duration bug

Test Options
nnictl update duration --value 300000m
exp.update_max_experiment_duration('200000m')

