### PR TITLE
Fix jquery dependency in docs and add sphinx-comment

### DIFF
--- a/dependencies/develop.txt
+++ b/dependencies/develop.txt
@@ -14,6 +14,7 @@ pytest-rerunfailures
 rstcheck >= 6.0
 sphinx >= 4.5
 sphinx-argparse-nni >= 0.4.0
+sphinx-comments
 sphinx-copybutton
 sphinx-gallery
 sphinx-intl

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,6 +59,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_tabs.tabs',
     'sphinx_copybutton',
+    'sphinx_comments',
 
     # Custom extensions in extension/ folder.
     'tutorial_links',  # this has to be after sphinx-gallery

--- a/docs/templates/layout.html
+++ b/docs/templates/layout.html
@@ -8,6 +8,8 @@
 
 {#- TO INJECT INFORMATION FROM READTHEDOCS HERE #}
 {% block scripts %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js" integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
   {{ super() }}
 
   {#- CUSTOM THEME #}
@@ -33,6 +35,7 @@
       github: "{{ pathto('_static/img/gallery-github.svg', 1) }}"
     }
   </script>
+
 {% endblock %}
 
 {#- REPLACE ATTRIBUTES INSTANTLY TO DISABLE SOME HOOKS #}


### PR DESCRIPTION
### Description ###

Jquery is no longer an auto-injected dependency as of the latest version of sphinx.

Added sphinx-comment for easier documentation annotation and review.
