### PR TITLE
Fix logo for documentation

### DIFF
--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -6,8 +6,8 @@
             class="md-header-nav__button md-logo">
           {% if theme_logo_icon|e %}
             <i class="md-icon">{{ theme_logo_icon }}</i>
-          {% elif logo %}
-              <img src="{{ pathto('_static/' ~ logo, 1) }}" height="26"
+          {% elif logo_url %}
+              <img src="{{ pathto(logo_url, 1) }}" height="26"
                     alt="{{ shorttitle|striptags|e }} logo">
           {% else %}
             &nbsp;


### PR DESCRIPTION
Fix `logo_url`.

![image](https://user-images.githubusercontent.com/8463288/217193709-d328f238-deaa-4bfd-ac45-93409438c062.png)

https://www.sphinx-doc.org/en/master/extdev/deprecated.html#dev-deprecated-apis
