### PR TITLE
Fix to #5338 in generate_scenario function for SMAC tunner

### DIFF
--- a/nni/algorithms/hpo/smac_tuner/convert_ss_to_scenario.py
+++ b/nni/algorithms/hpo/smac_tuner/convert_ss_to_scenario.py
@@ -189,7 +189,7 @@ def generate_scenario(ss_content):
         The scenario-object (smac.scenario.scenario.Scenario) is used to configure SMAC and can be constructed
         either by providing an actual scenario-object, or by specifing the options in a scenario file
     """
-    with open('scenario.txt', 'w') as sce_fd:
+    with open('/tmp/scenario.txt', 'w') as sce_fd:
         sce_fd.write('deterministic = 0\n')
         # sce_fd.write('output_dir = \n')
         sce_fd.write('paramfile = param_config_space.pcs\n')

--- a/test/ut/sdk/test_builtin_tuners.py
+++ b/test/ut/sdk/test_builtin_tuners.py
@@ -407,7 +407,7 @@ class BuiltinTunersTestCase(TestCase):
         self.nas_search_space_test_all(tuner_fn)
 
     def tearDown(self):
-        file_list = glob.glob("smac3*") + ["param_config_space.pcs", "scenario.txt", "model_path"]
+        file_list = glob.glob("smac3*") + ["param_config_space.pcs", "/tmp/scenario.txt", "model_path"]
         for file in file_list:
             if os.path.exists(file):
                 if os.path.isdir(file):


### PR DESCRIPTION
### Description ###
This is a simple fix for #5338


#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


