### PR TITLE
[Common] add warnings and retain the module after inappropriate weight assignment

### DIFF
--- a/nni/common/concrete_trace_utils/concrete_proxy.py
+++ b/nni/common/concrete_trace_utils/concrete_proxy.py
@@ -73,11 +73,7 @@ class ConcreteProxy(Proxy):
         self.node = node
 
     def __repr__(self) -> str:
-        # to detect if in debugging or in code
-        calling_frame_name = inspect.stack()[1][1]
-        if calling_frame_name.endswith('pydevd_exe2.py') or calling_frame_name.endswith('pydevd_safe_repr.py'):
-            return f'ConcreteProxy({self.node.name})'
-        return repr(self.value)
+        return f'ConcreteProxy({self.node.name}, {self.value})'
 
     def __getattr__(self, k) -> ConcreteProxy:
         return ConcreteAttrProxy(self, k)

--- a/nni/common/concrete_trace_utils/concrete_tracer.py
+++ b/nni/common/concrete_trace_utils/concrete_tracer.py
@@ -270,7 +270,7 @@ class ConcreteTracer(TracerBase):
 
     @compatibility(is_backward_compatible=True)
     def create_proxy(self, kind: str, target: Target, args: Tuple[Any, ...], kwargs: Dict[str, Any],
-                     name: Optional[str] = None, type_expr: Optional[Any] = None, 
+                     name: Optional[str] = None, type_expr: Optional[Any] = None,
                      proxy_factory_fn: Optional[Callable[[Node], Any]] = None):
         """
         similar to _symbolic_trace.Tracer.create_proxy.
@@ -282,7 +282,7 @@ class ConcreteTracer(TracerBase):
         assert isinstance(kwargs_, dict)
 
         node = self.create_node(kind, target, args_, kwargs_, name, type_expr)
-        
+
         def upwrapper(obj: Any):
             while _orig_isinstance(obj, ep.ConcreteProxy):
                 obj = obj.value
@@ -1303,12 +1303,14 @@ def _retain_weight_consistency(root: torch.nn.Module):
     for module in root.modules():
         for name, param in module.named_parameters():
             if _orig_isinstance(param, ep.ConcreteProxy):
-                _logger.warning(f'Parameter {name} of {module} is a ConcreteProxy. Some weight may be modified inplace within forward().')    
+                param: ep.ConcreteProxy     # pyright: reportGeneralTypeIssues=false
+                _logger.warning(f'Parameter {name} of {module} is a ConcreteProxy. Some weight may be modified inplace within forward().')
                 setattr(module, name, param.value)
                 _flag |= 1
         for name, buffer in module.named_buffers():
             if _orig_isinstance(buffer, ep.ConcreteProxy):
-                _logger.warning(f'Buffer {name} of {module} is a ConcreteProxy. Some buffer may be modified inplace within forward().')    
+                buffer: ep.ConcreteProxy    # pyright: reportGeneralTypeIssues=false
+                _logger.warning(f'Buffer {name} of {module} is a ConcreteProxy. Some buffer may be modified inplace within forward().')
                 setattr(module, name, buffer.value)
                 _flag |= 1
     if _flag:


### PR DESCRIPTION
### Description ###
Consider the following code with the inappropriate assignment of parameters and buffers during forward().
```python
class A(torch.nn.Module):
    def __init__(self):
        super().__init__()
        x = torch.tensor([1.0])
        buf = torch.tensor([1])
        self.register_parameter('x', torch.nn.Parameter(x))
        self.register_buffer('buf', buf)

    def forward(self):
        self.x = self.x.to(torch.float32)
        self.buf = self.buf + 1
        return self.x, self.buf
```
Here we raise a warning and recover the module.
```bash
[2023-03-14 04:40:14] WARNING: Parameter x of A() is a ConcreteProxy. Some weight may be modified inplace within forward().
[2023-03-14 04:40:14] WARNING: Buffer buf of A() is a ConcreteProxy. Some buffer may be modified inplace within forward().
[2023-03-14 04:40:14] WARNING: Some weight or buffer is modified inplace within forward(). This may cause unexpected behavior. ``concrete_trace`` may not guarantee the consistency of the traced graph.



def forward(self):
    x = self.x
    to = x.to(torch.float32);  x = None
    x_1 = self.x
    buf = self.buf
    add = buf + 1;  buf = None
    return (to, add)
```
This is not correct in the sense that we do need to modify a certain field of a module during forward(). But at least we can detect the error and raise a warning.
#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


