### PR TITLE
Reduce NNI manager's poll interval when using v3 training services

### DIFF
--- a/ts/nni_manager/core/nnimanager.ts
+++ b/ts/nni_manager/core/nnimanager.ts
@@ -495,6 +495,7 @@ class NNIManager implements Manager {
             const module_ = await import('../training_service/kubernetes/adl/adlTrainingService');
             return new module_.AdlTrainingService();
         } else {
+            this.pollInterval = 0.5;
             const module_ = await import('../training_service/v3/compat');
             return new module_.V3asV1(config.trainingService as TrainingServiceConfig);
         }


### PR DESCRIPTION
### Description ###

The polling APIs of v3 training services are trivial. So it's safe to reduce the interval.

#### Test Options ####
  - [ ] fast test
  - [x] full test - HPO
  - [x] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


