### PR TITLE
Fix wrong examples in assessor docs

### DIFF
--- a/docs/source/hpo/assessors.rst
+++ b/docs/source/hpo/assessors.rst
@@ -26,7 +26,7 @@ To use a built-in assessor you need to specify its name and arguments:
 .. code-block:: python
 
     config.assessor.name = 'Medianstop'
-    config.tuner.class_args = {'optimize_mode': 'maximize'}
+    config.assessor.class_args = {'optimize_mode': 'maximize'}
 
 Built-in Assessors
 ------------------

--- a/nni/algorithms/hpo/curvefitting_assessor/curvefitting_assessor.py
+++ b/nni/algorithms/hpo/curvefitting_assessor/curvefitting_assessor.py
@@ -40,7 +40,7 @@ class CurvefittingAssessor(Assessor):
     .. code-block::
 
         config.assessor.name = 'Curvefitting'
-        config.tuner.class_args = {
+        config.assessor.class_args = {
             'epoch_num': 20,
             'start_step': 6,
             'threshold': 9,

--- a/nni/algorithms/hpo/medianstop_assessor.py
+++ b/nni/algorithms/hpo/medianstop_assessor.py
@@ -36,7 +36,7 @@ class MedianstopAssessor(Assessor):
     .. code-block::
 
         config.assessor.name = 'Medianstop'
-        config.tuner.class_args = {
+        config.assessor.class_args = {
             'optimize_mode': 'maximize',
             'start_step': 5
         }


### PR DESCRIPTION
From examples in assessor,
```python
config.assessor.name = 'Medianstop'
config.tuner.class_args = {
    'optimize_mode': 'maximize',
    'start_step': 5
}
```
these code cause error like this:
```
Traceback (most recent call last):
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/site-packages/nni/__main__.py", line 85, in <module>
    main()
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/site-packages/nni/__main__.py", line 42, in main
    tuner = _create_algo(exp_params['tuner'], 'tuner')
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/site-packages/nni/__main__.py", line 75, in _create_algo
    algo = create_builtin_class_instance(algo_config['name'], algo_config.get('classArgs'), algo_type + 's')
  File "/home/dof/anaconda3/envs/optune/lib/python3.9/site-packages/nni/tools/package_utils/tuner_factory.py", line 154, in create_builtin_class_instance
```

`config.tuner` should be changed to `config.assessor`
