### PR TITLE
Fix compatibility with filelock 3.12.0

### DIFF
--- a/nni/tools/nnictl/common_utils.py
+++ b/nni/tools/nnictl/common_utils.py
@@ -95,6 +95,11 @@ class SimplePreemptiveLock(filelock.SoftFileLock):
     '''this is a lock support check lock expiration, if you do not need check expiration, you can use SoftFileLock'''
     def __init__(self, lock_file, stale=-1):
         super(__class__, self).__init__(lock_file, timeout=-1)
+
+        # FIXME: hack
+        if not hasattr(self, '_lock_file'):
+            self._lock_file = self.lock_file
+
         self._lock_file_name = '{}.{}'.format(self._lock_file, os.getpid())
         self._stale = stale
 

--- a/ts/webui/package-lock.json
+++ b/ts/webui/package-lock.json
@@ -65,6 +65,7 @@
         "html-webpack-plugin": ">=5.5.0",
         "jest": ">=29.5.0",
         "mini-css-extract-plugin": ">=2.7.3",
+        "minimatch": ">=7.4.2",
         "monaco-editor-webpack-plugin": ">=7.0.1",
         "npm": ">=9.6.1",
         "pnp-webpack-plugin": ">=1.7.0",


### PR DESCRIPTION
### Description ###

NNI is using an internal attribute of filelock, and it has changed in the latest version.

The webui lock file is updated because I forgot to commit it in last PR.

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###


