### PR TITLE
Fix `html_logo` for sphinx docs

### DIFF
--- a/dependencies/develop.txt
+++ b/dependencies/develop.txt
@@ -12,7 +12,7 @@ pytest
 pytest-cov
 pytest-rerunfailures
 rstcheck >= 6.0
-sphinx >= 4.5, < 7.0
+sphinx >= 4.5
 sphinx-argparse-nni >= 0.4.0
 sphinx-comments
 sphinx-copybutton

--- a/dependencies/develop.txt
+++ b/dependencies/develop.txt
@@ -12,7 +12,7 @@ pytest
 pytest-cov
 pytest-rerunfailures
 rstcheck >= 6.0
-sphinx >= 4.5
+sphinx >= 4.5, < 7.0
 sphinx-argparse-nni >= 0.4.0
 sphinx-comments
 sphinx-copybutton

--- a/docs/static/img/nni-icon.svg
+++ b/docs/static/img/nni-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 162 84">
+  <polygon fill="#ffffff" points="0,84 12,84 34,18 56,84 68,84 87,27 75,27 62,66 40,0 28,0 0,84"/>
+  <polygon fill="#ffffff" points="94,84 106,84 125,27 113,27 100,66 90,36 84,54 94,84"/>
+  <polygon fill="#ffffff" points="122,0 128,18 140,18 134,0 122,0"/>
+  <polygon fill="#ffffff" points="131,27 150,84 162,84 143,27 131,27"/>
+</svg>

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -4,14 +4,8 @@
       <div class="md-flex__cell md-flex__cell--shrink">
         <a href="{{ pathto(master_doc)|e }}" title="{{ docstitle|e }}"
             class="md-header-nav__button md-logo">
-          {% if theme_logo_icon|e %}
-            <i class="md-icon">{{ theme_logo_icon }}</i>
-          {% elif logo_url %}
-              <img src="{{ pathto(logo_url, 1) }}" height="26"
-                    alt="{{ shorttitle|striptags|e }} logo">
-          {% else %}
-            &nbsp;
-          {% endif %}
+          <img src="{{ pathto('_static/img/nni-icon.svg', 1) }}" height="26"
+                alt="{{ shorttitle|striptags|e }} logo">
         </a>
       </div>
       <div class="md-flex__cell md-flex__cell--shrink">


### PR DESCRIPTION
~Temporarily pin sphinx < 7.0 to resolve the icon issue and avoid blocking release.~

Turns out `html_logo` setting is broken a long time ago.