### PR TITLE
[Common] fix dce and add Scope

### DIFF
--- a/nni/common/concrete_trace_utils/concrete_tracer.py
+++ b/nni/common/concrete_trace_utils/concrete_tracer.py
@@ -47,8 +47,6 @@ try:
     # comes with Scope
     from torch.fx.proxy import ScopeContextManager
 except ImportError:
-    import copy
-
     # copy from pytorch 2.0
     @compatibility(is_backward_compatible=False)
     class ScopeContextManager:

--- a/nni/common/concrete_trace_utils/utils.py
+++ b/nni/common/concrete_trace_utils/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Type
 import functools
 
 import torch
+from torch.fx import Node
 
 # These need to run in global scope to handle nested calls correctly
 _orig_module_call: Callable = torch.nn.Module.__call__
@@ -48,6 +49,8 @@ _orig_index: Callable = operator.index
 _orig_all: Callable = builtins.all
 _orig_min: Callable = builtins.min
 _orig_max: Callable = builtins.max
+
+_orig_node_is_impure: Callable = Node.is_impure
 
 
 def run_onlyif_instance(cond_type: Type[Any], return_orig: bool = True, return_const: Any = None):

--- a/test/algo/compression/pruning/test_concrete_trace_dce.py
+++ b/test/algo/compression/pruning/test_concrete_trace_dce.py
@@ -6,8 +6,6 @@ import pytest
 import torch
 import torchvision.models as models
 
-import sys
-sys.path.append("/home/v-junliang/DNNGen/nni")
 from nni.common.concrete_trace_utils import concrete_trace
 
 model_list = [

--- a/test/algo/compression/pruning/test_concrete_trace_dce.py
+++ b/test/algo/compression/pruning/test_concrete_trace_dce.py
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import pytest
+
+import torch
+import torchvision.models as models
+
+import sys
+sys.path.append("/home/v-junliang/DNNGen/nni")
+from nni.common.concrete_trace_utils import concrete_trace
+
+model_list = [
+    models.alexnet,
+    models.convnext_base,
+    models.densenet121,
+    models.efficientnet_b0,
+    models.mobilenet_v2,
+    models.resnet18,
+    models.resnext50_32x4d,
+    models.vit_b_16,
+    models.inception_v3,
+]
+
+
+def check_equal(a, b):
+    if type(a) != type(b):
+        # add this because there are some models whose output type is a UserMapping
+        # but the traced graphmodule output type is a dict
+        if isinstance(a, dict) and isinstance(b, dict):
+            for key in a:
+                if key not in b:
+                    continue
+                return check_equal(a.get(key), b.get(key))
+        else:
+            return False
+    if isinstance(a, (list, tuple, set)):
+        if len(a) != len(b):
+            return False
+        for sub_a, sub_b in zip(a, b):
+            if not check_equal(sub_a, sub_b):
+                return False
+        return True
+    elif isinstance(a, dict):
+        keys_a, kes_b = set(a.keys()), set(b.keys())
+        if keys_a != kes_b:
+            return False
+        for key in keys_a:
+            if not check_equal(a[key], b[key]):
+                return False
+        return True
+    elif isinstance(a, torch.Tensor):
+        # may not euqal on gpu
+        return torch.std(a - b).item() < 1e-6
+    else:
+        return a == b
+
+@pytest.mark.parametrize('model_fn', model_list)
+def test_torchvision_models(model_fn):
+    model = model_fn()
+    model.eval()
+    dummy_inputs = (torch.rand(2, 3, 224, 224), )
+    traced = concrete_trace(model, dummy_inputs, dce=False)
+    traced_dce = concrete_trace(model, dummy_inputs, dce=True)
+    out_orig = model.forward(*dummy_inputs)
+    out_traced = traced.forward(*dummy_inputs)
+    out_traced_dce = traced_dce.forward(*dummy_inputs)
+    assert check_equal(out_orig, out_traced), f'{traced.code}'
+    assert check_equal(out_orig, out_traced_dce), f'{traced_dce.code}'
+    del out_orig, out_traced, out_traced_dce


### PR DESCRIPTION
### Description ###
This PR mainly contains:
- fix dce: the new concrete_trace_utils makes use of pytorch official `Graph.eliminate_dead_code()` but adds more checks to avoid  already known mistakes by official dce. This is done by adding a `node_is_impure_wrapper`.
- add Scope: `Scope` is a new feature introduced since Pytorch2.0. The new concrete_trace_utils makes use of official `Scope` to record nodes' module path information(hierarchy) and makes it backward compatible with older version of Pytorch.
- add `trace_twice` api: make it default to trace once.
- fix other bugs.

#### Test Options ####
  - [ ] fast test
  - [ ] full test - HPO
  - [ ] full test - NAS
  - [ ] full test - compression

### Checklist ###
  - [ ] test case
  - [ ] doc

### How to test ###
added a test file nni/test/algo/compression/pruning/test_concrete_trace_dce.py

