### PR TITLE
[BugFix] Using the builtin types like `int`, `bool` and `float`.

### DIFF
--- a/examples/nas/legacy/cdarts/datasets/data_utils.py
+++ b/examples/nas/legacy/cdarts/datasets/data_utils.py
@@ -303,7 +303,7 @@ class SubPolicy(object):
             "translateY": np.linspace(0, 150 / 331, 10),
             "rotate": np.linspace(0, 30, 10),
             "color": np.linspace(0.0, 0.9, 10),
-            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(np.int),
+            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(int),
             "solarize": np.linspace(256, 0, 10),
             "contrast": np.linspace(0.0, 0.9, 10),
             "sharpness": np.linspace(0.0, 0.9, 10),

--- a/examples/trials/README.md
+++ b/examples/trials/README.md
@@ -46,8 +46,8 @@ def create_mnist_model(hyper_params, input_shape=(H, W, 1), num_classes=NUM_CLAS
 def load_mnist_data(args):
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 
@@ -216,8 +216,8 @@ def load_mnist_data(args):
     '''
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 

--- a/examples/trials/README_zh_CN.md
+++ b/examples/trials/README_zh_CN.md
@@ -46,8 +46,8 @@ def create_mnist_model(hyper_params, input_shape=(H, W, 1), num_classes=NUM_CLAS
 def load_mnist_data(args):
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 
@@ -213,8 +213,8 @@ def load_mnist_data(args):
     '''
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 

--- a/examples/trials/mnist-batch-tune-keras/mnist-keras.py
+++ b/examples/trials/mnist-batch-tune-keras/mnist-keras.py
@@ -65,8 +65,8 @@ def load_mnist_data(args):
     '''
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 

--- a/examples/trials/mnist-keras/mnist-keras.py
+++ b/examples/trials/mnist-keras/mnist-keras.py
@@ -67,8 +67,8 @@ def load_mnist_data(args):
     (x_train, y_train), (x_test, y_test) = mnist.load_data(path=mnist_path)
     os.remove(mnist_path)
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 

--- a/examples/tuners/mnist_keras_customized_advisor/mnist_keras.py
+++ b/examples/tuners/mnist_keras_customized_advisor/mnist_keras.py
@@ -67,8 +67,8 @@ def load_mnist_data(args):
     """
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-    x_train = (np.expand_dims(x_train, -1).astype(np.float) / 255.)[:args.num_train]
-    x_test = (np.expand_dims(x_test, -1).astype(np.float) / 255.)[:args.num_test]
+    x_train = (np.expand_dims(x_train, -1).astype(float) / 255.)[:args.num_train]
+    x_test = (np.expand_dims(x_test, -1).astype(float) / 255.)[:args.num_test]
     y_train = keras.utils.to_categorical(y_train, NUM_CLASSES)[:args.num_train]
     y_test = keras.utils.to_categorical(y_test, NUM_CLASSES)[:args.num_test]
 

--- a/nni/algorithms/hpo/curvefitting_assessor/model_factory.py
+++ b/nni/algorithms/hpo/curvefitting_assessor/model_factory.py
@@ -287,7 +287,7 @@ class CurveModel:
         -------
         None
         """
-        init_weight = np.ones((self.effective_model_num), dtype=np.float) / self.effective_model_num
+        init_weight = np.ones((self.effective_model_num), dtype=float) / self.effective_model_num
         self.weight_samples = np.broadcast_to(init_weight, (NUM_OF_INSTANCE, self.effective_model_num))
         for _ in range(NUM_OF_SIMULATION_TIME):
             # sample new value from Q(i, j)
@@ -298,7 +298,7 @@ class CurveModel:
             # sample u
             u = np.random.rand(NUM_OF_INSTANCE)
             # new value
-            change_value_flag = (u < alpha).astype(np.int)
+            change_value_flag = (u < alpha).astype(int)
             for j in range(NUM_OF_INSTANCE):
                 new_values[j] = self.weight_samples[j] * (1 - change_value_flag[j]) + new_values[j] * change_value_flag[j]
             self.weight_samples = new_values

--- a/nni/algorithms/hpo/networkmorphism_tuner/bayesian.py
+++ b/nni/algorithms/hpo/networkmorphism_tuner/bayesian.py
@@ -219,7 +219,7 @@ class IncrementalGaussianProcess:
                 self._l_matrix.shape[0]))
         k_inv = l_inv.dot(l_inv.T)
         # Compute variance of predictive distribution
-        y_var = np.ones(len(train_x), dtype=np.float)
+        y_var = np.ones(len(train_x), dtype=float)
         y_var -= np.einsum("ij,ij->i", np.dot(k_trans, k_inv), k_trans)
 
         # Check if any of the variances is negative because of

--- a/nni/algorithms/hpo/ppo_tuner/ppo_tuner.py
+++ b/nni/algorithms/hpo/ppo_tuner/ppo_tuner.py
@@ -209,7 +209,7 @@ class PPOModel:
         mb_actions = np.asarray(mb_actions)
         mb_values = np.asarray(mb_values, dtype=np.float32)
         mb_neglogpacs = np.asarray(mb_neglogpacs, dtype=np.float32)
-        mb_dones = np.asarray(mb_dones, dtype=np.bool)
+        mb_dones = np.asarray(mb_dones, dtype=bool)
         last_values = self.model.value(np_obs, S=states, M=dones)
 
         return mb_obs, mb_actions, mb_values, mb_neglogpacs, mb_dones, last_values
@@ -231,7 +231,7 @@ class PPOModel:
         mb_returns = np.zeros_like(mb_rewards)
         mb_advs = np.zeros_like(mb_rewards)
         lastgaelam = 0
-        last_dones = np.asarray([True for _ in trials_result], dtype=np.bool) # ugly
+        last_dones = np.asarray([True for _ in trials_result], dtype=bool) # ugly
         for t in reversed(range(self.model_config.nsteps)):
             if t == self.model_config.nsteps - 1:
                 nextnonterminal = 1.0 - last_dones

--- a/nni/nas/benchmark/nasbench101/graph_util.py
+++ b/nni/nas/benchmark/nasbench101/graph_util.py
@@ -13,7 +13,7 @@ def _labeling_from_architecture(architecture, vertices):
 
 
 def _adjancency_matrix_from_architecture(architecture, vertices):
-    matrix = np.zeros((vertices, vertices), dtype=np.bool)  # type: ignore
+    matrix = np.zeros((vertices, vertices), dtype=bool)  # type: ignore
     for i in range(1, vertices):
         for k in architecture['input{}'.format(i)]:
             matrix[k, i] = 1

--- a/nni/nas/oneshot/pytorch/supermodule/_operation_utils.py
+++ b/nni/nas/oneshot/pytorch/supermodule/_operation_utils.py
@@ -70,7 +70,7 @@ def _eliminate_list_slice(shape: tuple, slice_: multidim_slice) -> multidim_slic
     for i in range(len(slice_)):
         if isinstance(slice_[i], list):
             # convert list of slices to mask
-            mask = np.zeros(shape[i], dtype=np.bool)  # type: ignore
+            mask = np.zeros(shape[i], dtype=bool)  # type: ignore
             for sl in cast(List[slice], slice_[i]):
                 mask[sl] = 1
             result.append(mask)

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -9,5 +9,4 @@ filterwarnings =
     ignore:Using key to access the identifier of:DeprecationWarning
     ignore:layer_choice.choices is deprecated.:DeprecationWarning
     ignore:The truth value of an empty array is ambiguous.:DeprecationWarning
-    ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning
     ignore:nni.retiarii.serialize is deprecated and will be removed in future release.:DeprecationWarning

--- a/test/ut/sdk/test_curvefitting_assessor.py
+++ b/test/ut/sdk/test_curvefitting_assessor.py
@@ -35,7 +35,7 @@ class TestCurveFittingAssessor(unittest.TestCase):
         test_model.point_num = 9
         test_model.target_pos = 20
         test_model.trial_history = ([1, 1, 1, 1, 1, 1, 1, 1, 1])
-        test_model.weight_samples = np.ones((test_model.effective_model_num), dtype=np.float) / test_model.effective_model_num
+        test_model.weight_samples = np.ones((test_model.effective_model_num), dtype=float) / test_model.effective_model_num
         self.assertAlmostEqual(test_model.predict_y('vap', 9), 0.5591906328335763)
         self.assertAlmostEqual(test_model.predict_y('logx_linear', 15), 1.0704360293379522)
         self.assertAlmostEqual(test_model.f_comb(9, test_model.weight_samples), 1.1543379521172443)


### PR DESCRIPTION
- In Numpy 1.20.0, the aliases of builtin types like np.int is deprecated.
- Fix #5604.
- No need to ignore the DeprecationWarning message in pytest.ini:
  - `np.bool` is a deprecated alias for the builtin `bool`.
- Update the document.

### Description ###

When the version of numpy is higher than 1.20.0, `numpy.bool`, `numpy.int`, and `numpy.float` are deprecated, which can lead to runtime errors and termination. I have modified all the deprecated aliases used in the project according to the official numpy documentation.

For `numpy.int` and `numpy.float` types, I followed the numpy documentation and changed them to `int` and `float`. If necessary, their precision can be specified.

For more details, please refer to the [Numpy release documentation](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).

Since there are many changes, an integration test may be needed.

#### Test Options ####
  - [x] fast test
  - [x] full test - HPO
  - [x] full test - NAS
  - [x] full test - compression

### Checklist ###
  - [x] test case
  - [x] doc
